### PR TITLE
enhance: project RESTful v2 errors to standard HTTP status codes (opt-in)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -506,6 +506,17 @@ proxy:
     # string wherever one appears, including inside either kind of array.
     legacyArrayResponse: false
     enablePprof: true # Whether to enable pprof middleware on the metrics port
+    # high-level restful api, project business errors to standard HTTP statuses instead of always returning
+    # 200 with the error only in the body (v2 endpoints only; the body keeps the same code/message envelope either way).
+    # Mapping: input 400, auth 401/403, rate/quota 429, proven client cancellation 499, retriable system 503, incomplete
+    # request upload timeout 408, and server-side timeout/other system errors 500. Explicitly retriable statuses (503 and
+    # 429 from RPC-borne limit codes) are advertised only for read operations, which mutate nothing and are safe to
+    # replay; mutations surface them as a generic 500 to avoid claiming that replay is safe. A 500 does not prevent a
+    # gateway configured to retry every 5xx, so clients and gateways must not automatically replay mutation routes
+    # without idempotency or proof that the request was not applied. Pre-execution limiter infrastructure 503 and HTTP
+    # pre-admission 429 can apply to both read and mutation routes because no business side effect has started.
+    # Off by default; enabling flips access-log method_status from Failed to HttpError<code>.
+    standardErrorStatus: false
     # high-level restful api, reject a search/query request with HTTP 429 while the proxy's DQL task
     # queue is full, before the request body is decoded. The scheduler rejects such a request with the same
     # TooManyRequests error anyway, but only after the body has been decoded; admission moves the same verdict before that

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -508,11 +508,11 @@ proxy:
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     # high-level restful api, project business errors to standard HTTP statuses instead of always returning
     # 200 with the error only in the body (v2 endpoints only; the body keeps the same code/message envelope either way).
-    # Mapping: explicit input 400, explicit authentication/authorization 401/403, HTTP-layer pre-execution rejection
-    # 429, proven client cancellation 499, incomplete request upload timeout 408, and every other error 500. The
-    # projection uses only facts proven at the HTTP boundary; downstream limit, retryable, timeout, and unknown errors
-    # all remain 500. A status does not prevent gateways from retrying, so mutation routes still require gateway retry
-    # exclusions or end-to-end idempotency when duplicate execution must be impossible.
+    # Mapping: explicit input 400, explicit authentication/authorization 401/403, HTTP-layer pre-execution rejection 429,
+    # proven client cancellation 499, incomplete request upload timeout 408, and every other error 500. The projection uses
+    # only facts proven at the HTTP boundary; downstream limit, retryable, timeout, and unknown errors all remain 500. A
+    # status does not prevent gateways from retrying, so mutation routes still require gateway retry exclusions or
+    # end-to-end idempotency when duplicate execution must be impossible.
     # Off by default; enabling flips access-log method_status from Failed to HttpError<code>.
     standardErrorStatus: false
     # high-level restful api, reject a search/query request with HTTP 429 while the proxy's DQL task

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -508,13 +508,11 @@ proxy:
     enablePprof: true # Whether to enable pprof middleware on the metrics port
     # high-level restful api, project business errors to standard HTTP statuses instead of always returning
     # 200 with the error only in the body (v2 endpoints only; the body keeps the same code/message envelope either way).
-    # Mapping: input 400, auth 401/403, rate/quota 429, proven client cancellation 499, retriable system 503, incomplete
-    # request upload timeout 408, and server-side timeout/other system errors 500. Explicitly retriable statuses (503 and
-    # 429 from RPC-borne limit codes) are advertised only for read operations, which mutate nothing and are safe to
-    # replay; mutations surface them as a generic 500 to avoid claiming that replay is safe. A 500 does not prevent a
-    # gateway configured to retry every 5xx, so clients and gateways must not automatically replay mutation routes
-    # without idempotency or proof that the request was not applied. Pre-execution limiter infrastructure 503 and HTTP
-    # pre-admission 429 can apply to both read and mutation routes because no business side effect has started.
+    # Mapping: explicit input 400, explicit authentication/authorization 401/403, HTTP-layer pre-execution rejection
+    # 429, proven client cancellation 499, incomplete request upload timeout 408, and every other error 500. The
+    # projection uses only facts proven at the HTTP boundary; downstream limit, retryable, timeout, and unknown errors
+    # all remain 500. A status does not prevent gateways from retrying, so mutation routes still require gateway retry
+    # exclusions or end-to-end idempotency when duplicate execution must be impossible.
     # Off by default; enabling flips access-log method_status from Failed to HttpError<code>.
     standardErrorStatus: false
     # high-level restful api, reject a search/query request with HTTP 429 while the proxy's DQL task

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -315,3 +315,68 @@ func TestFileResourceHandlerV2ChecksQuota(t *testing.T) {
 	assert.Equal(t, fileResourceLimiterCheck{rateType: internalpb.RateType_DDLCollection, n: 1}, limiter.checks[1])
 	assert.Zero(t, limiter.checks[2].n)
 }
+
+func TestFileResourceHandlerV2ProjectsLimiterOutcomes(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.StandardErrorStatus.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.StandardErrorStatus.Key)
+
+	t.Run("pre-execution rejection", func(t *testing.T) {
+		limiter := &rejectingFileResourceLimiter{t: t}
+		mockProxy := mocks.NewMockProxy(t)
+		mockProxy.EXPECT().GetRateLimiter().Return(limiter, nil).Once()
+		server := initHTTPServerV2(proxyComponentWithMetaCache{
+			ProxyComponent: mockProxy,
+			metaCache:      proxy.InitEmptyMetaCacheForTest(),
+		}, false)
+
+		req := httptest.NewRequest(http.MethodPost, versionalV2(FileResourceCategory, AddAction), bytes.NewBufferString(`{"name":"synonyms","path":"synonyms.txt"}`))
+		resp := httptest.NewRecorder()
+		server.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, resp.Code)
+		body := &ReturnErrMsg{}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), body))
+		assert.Equal(t, merr.Code(merr.ErrHTTPRateLimit), body.Code)
+	})
+
+	t.Run("infrastructure cancellation", func(t *testing.T) {
+		mockProxy := mocks.NewMockProxy(t)
+		mockProxy.EXPECT().GetRateLimiter().Return(nil, context.Canceled).Once()
+		server := initHTTPServerV2(proxyComponentWithMetaCache{
+			ProxyComponent: mockProxy,
+			metaCache:      proxy.InitEmptyMetaCacheForTest(),
+		}, false)
+
+		requestCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req := httptest.NewRequest(http.MethodPost, versionalV2(FileResourceCategory, AddAction), bytes.NewBufferString(`{"name":"synonyms","path":"synonyms.txt"}`)).WithContext(requestCtx)
+		resp := httptest.NewRecorder()
+		server.ServeHTTP(resp, req)
+
+		assert.Equal(t, statusClientClosedRequest, resp.Code)
+		body := &ReturnErrMsg{}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), body))
+		assert.Equal(t, merr.CanceledCode, body.Code)
+	})
+
+	t.Run("input-marked infrastructure error", func(t *testing.T) {
+		mockProxy := mocks.NewMockProxy(t)
+		mockProxy.EXPECT().GetRateLimiter().Return(nil, merr.WrapErrParameterInvalidMsg("nil rate limiter")).Once()
+		server := initHTTPServerV2(proxyComponentWithMetaCache{
+			ProxyComponent: mockProxy,
+			metaCache:      proxy.InitEmptyMetaCacheForTest(),
+		}, false)
+
+		req := httptest.NewRequest(http.MethodPost, versionalV2(FileResourceCategory, AddAction), bytes.NewBufferString(`{"name":"synonyms","path":"synonyms.txt"}`))
+		resp := httptest.NewRecorder()
+		server.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusInternalServerError, resp.Code)
+		body := &ReturnErrMsg{}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), body))
+		assert.Equal(t, merr.Code(merr.ErrParameterInvalid), body.Code)
+	})
+}

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -437,19 +437,6 @@ type (
 func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 	return func(gCtx *gin.Context) {
 		req := newReq()
-		// Receive phase: read the raw body first and cache it (ShouldBindBodyWith
-		// below reuses gin.BodyBytesKey), then mark the body as received BEFORE
-		// decoding. A timeout during the CPU-heavy JSON decode of an already
-		// received body is then attributed to server-side processing (500),
-		// not a slow-client 408 that a gateway would auto-retry into the same decode.
-		if body, readErr := io.ReadAll(gCtx.Request.Body); readErr == nil {
-			gCtx.Set(gin.BodyBytesKey, body)
-			// mark received only on a successful read: a read failure is itself a
-			// receive-phase (client-side) problem and must stay a 408, not 500.
-			if rec, ok := gCtx.Writer.(*timeoutResponseRecorder); ok {
-				rec.bodyReceived.Store(true)
-			}
-		}
 		if err := gCtx.ShouldBindBodyWith(req, binding.JSON); err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, read parameters from request body fail", mlog.Err(err),
 				mlog.Any("url", gCtx.Request.URL.Path))
@@ -715,7 +702,8 @@ func (h *HandlersV2) checkAuthorizationV2(ctx context.Context, c *gin.Context, i
 	ctx, authErr := proxy.PrivilegeInterceptorWithMetaCache(h.metaCache)(ctx, req)
 	if authErr != nil {
 		if !ignoreErr {
-			HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
+			recordErrorType(c, authErr)
+			HTTPReturn(c, projectedAuthorizationStatus(c, authErr), gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
 		}
 		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(authErr), nil, c.FullPath(), hookutil.ActionAuthorize)
 		return authErr
@@ -755,14 +743,15 @@ func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Cont
 		ctx = ginCtx.Request.Context()
 	}
 	if checkLimit {
-		_, err := CheckLimiter(ctx, req, pxy)
+		limited, err := CheckLimiter(ctx, req, pxy)
 		if err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, fail to check limiter", mlog.Err(err), mlog.String("method", fullMethod))
-			if !isRateLimitClass(err) {
+			if !limited {
 				// Limiter infrastructure failure, not a quota decision — surface
 				// the real server error instead of masquerading as 429/1807.
 				hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(err), nil, ginCtx.FullPath(), hookutil.ActionAuthorize)
-				HTTPAbortReturn(ginCtx, projectedStatus(err), gin.H{
+				recordErrorType(ginCtx, err)
+				HTTPAbortReturn(ginCtx, projectedStatusForRequest(ginCtx, err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),
 				})
@@ -798,7 +787,7 @@ func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Cont
 	if err == nil {
 		status, ok := requestutil.GetStatusFromResponse(response)
 		if ok {
-			err = merr.Error(status)
+			err = errorFromStatusForHTTP(status)
 		}
 	}
 
@@ -808,11 +797,7 @@ func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Cont
 		recordErrorType(ginCtx, err)
 		mlog.Warn(ctx, "high level restful api, grpc call failed", mlog.Err(err))
 		if !ignoreErr {
-			// Replay-safety identity is the ROUTE the client called (same key space
-			// as the timeout middleware), not this RPC step: a composite handler like
-			// createCollection must not advertise a retriable status for its load
-			// step when replaying means re-running the whole composite.
-			HTTPAbortReturn(ginCtx, projectedStatusForRequest(ginCtx, err, routeToMethod[ginCtx.FullPath()]), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(ginCtx, projectedStatusForRequest(ginCtx, err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		}
 	}
 	return response, err
@@ -1397,7 +1382,7 @@ func (h *HandlersV2) flush(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if err == nil {
 		err = h.waitForFlush(ctx, dbName, httpReq.CollectionName, resp.(*milvuspb.FlushResponse))
 		if err != nil {
-			HTTPReturn(c, projectedStatusForRequest(c, err, routeToMethod[c.FullPath()]), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPReturn(c, projectedStatusForRequest(c, err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return resp, err
 		}
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
@@ -4143,7 +4128,8 @@ func (h *HandlersV2) checkImportPrivilege(ctx context.Context, c *gin.Context, d
 		CollectionName: collectionName,
 	})
 	if authErr != nil {
-		HTTPReturn(c, http.StatusForbidden, gin.H{
+		recordErrorType(c, authErr)
+		HTTPReturn(c, projectedAuthorizationStatus(c, authErr), gin.H{
 			HTTPReturnCode:    merr.Code(authErr),
 			HTTPReturnMessage: authErr.Error(),
 		})

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -437,21 +437,34 @@ type (
 func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 	return func(gCtx *gin.Context) {
 		req := newReq()
+		// Receive phase: read the raw body first and cache it (ShouldBindBodyWith
+		// below reuses gin.BodyBytesKey), then mark the body as received BEFORE
+		// decoding. A timeout during the CPU-heavy JSON decode of an already
+		// received body is then attributed to server-side processing (500),
+		// not a slow-client 408 that a gateway would auto-retry into the same decode.
+		if body, readErr := io.ReadAll(gCtx.Request.Body); readErr == nil {
+			gCtx.Set(gin.BodyBytesKey, body)
+			// mark received only on a successful read: a read failure is itself a
+			// receive-phase (client-side) problem and must stay a 408, not 500.
+			if rec, ok := gCtx.Writer.(*timeoutResponseRecorder); ok {
+				rec.bodyReceived.Store(true)
+			}
+		}
 		if err := gCtx.ShouldBindBodyWith(req, binding.JSON); err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, read parameters from request body fail", mlog.Err(err),
 				mlog.Any("url", gCtx.Request.URL.Path))
 			if _, ok := err.(validator.ValidationErrors); ok {
-				HTTPAbortReturn(gCtx, http.StatusOK, gin.H{
+				HTTPAbortReturn(gCtx, projectedStatus(merr.ErrMissingRequiredParameters), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrMissingRequiredParameters),
 					HTTPReturnMessage: merr.ErrMissingRequiredParameters.Error() + ", error: " + err.Error(),
 				})
 			} else if err == io.EOF {
-				HTTPAbortReturn(gCtx, http.StatusOK, gin.H{
+				HTTPAbortReturn(gCtx, projectedStatus(merr.ErrIncorrectParameterFormat), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
 					HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", the request body should be nil, however {} is valid",
 				})
 			} else {
-				HTTPAbortReturn(gCtx, http.StatusOK, gin.H{
+				HTTPAbortReturn(gCtx, projectedStatus(merr.ErrIncorrectParameterFormat), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
 					HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", error: " + err.Error(),
 				})
@@ -745,8 +758,18 @@ func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Cont
 		_, err := CheckLimiter(ctx, req, pxy)
 		if err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, fail to check limiter", mlog.Err(err), mlog.String("method", fullMethod))
+			if !isRateLimitClass(err) {
+				// Limiter infrastructure failure, not a quota decision — surface
+				// the real server error instead of masquerading as 429/1807.
+				hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(err), nil, ginCtx.FullPath(), hookutil.ActionAuthorize)
+				HTTPAbortReturn(ginCtx, projectedStatus(err), gin.H{
+					HTTPReturnCode:    merr.Code(err),
+					HTTPReturnMessage: err.Error(),
+				})
+				return nil, RestRequestInterceptorErr
+			}
 			hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrHTTPRateLimit), nil, ginCtx.FullPath(), hookutil.ActionAuthorize)
-			HTTPAbortReturn(ginCtx, http.StatusOK, gin.H{
+			HTTPAbortReturn(ginCtx, projectedStatus(merr.ErrHTTPRateLimit), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrHTTPRateLimit),
 				HTTPReturnMessage: merr.ErrHTTPRateLimit.Error() + ", error: " + err.Error(),
 			})
@@ -782,10 +805,14 @@ func (h *HandlersV2) wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Cont
 	if err != nil {
 		// Expose the exact classification (incl. boundary InputError marks) to
 		// the REST access log; key must match accesslog/info.ContextErrorType.
-		ginCtx.Set("error_type", merr.GetErrorType(err).String())
+		recordErrorType(ginCtx, err)
 		mlog.Warn(ctx, "high level restful api, grpc call failed", mlog.Err(err))
 		if !ignoreErr {
-			HTTPAbortReturn(ginCtx, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			// Replay-safety identity is the ROUTE the client called (same key space
+			// as the timeout middleware), not this RPC step: a composite handler like
+			// createCollection must not advertise a retriable status for its load
+			// step when replaying means re-running the whole composite.
+			HTTPAbortReturn(ginCtx, projectedStatusForRequest(ginCtx, err, routeToMethod[ginCtx.FullPath()]), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		}
 	}
 	return response, err
@@ -958,8 +985,9 @@ func (h *HandlersV2) getCollectionLoadState(ctx context.Context, c *gin.Context,
 	}
 	switch resp.(*milvuspb.GetLoadStateResponse).State {
 	case commonpb.LoadState_LoadStateNotExist:
-		err = merr.WrapErrCollectionNotFound(req.CollectionName)
-		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		err = merr.WrapErrAsInputError(merr.WrapErrCollectionNotFound(req.CollectionName))
+		recordErrorType(c, err)
+		HTTPReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return resp, err
 	case commonpb.LoadState_LoadStateNotLoad:
 		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: gin.H{
@@ -1123,7 +1151,7 @@ func (h *HandlersV2) addCollectionFunction(ctx context.Context, c *gin.Context, 
 	}
 	fSchema, err := genFunctionSchema(ctx, &httpReq.Function)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1150,7 +1178,7 @@ func (h *HandlersV2) alterCollectionFunction(ctx context.Context, c *gin.Context
 	}
 	fSchema, err := genFunctionSchema(ctx, &httpReq.Function)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1202,7 +1230,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 			err := merr.WrapErrParameterInvalidMsg(
 				"indexParams.fieldName %q must match outputField.fieldName %q",
 				httpReq.IndexParam.FieldName, httpReq.OutputField.FieldName)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -1211,7 +1239,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 		var err error
 		extraParams, err = convertToExtraParams(*httpReq.IndexParam)
 		if err != nil {
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -1221,7 +1249,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 	}
 	fSchema, err := genFunctionSchema(ctx, &httpReq.Function)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1229,7 +1257,7 @@ func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Cont
 	}
 	fieldSchema, err := httpReq.OutputField.GetProto(ctx)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1369,7 +1397,7 @@ func (h *HandlersV2) flush(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if err == nil {
 		err = h.waitForFlush(ctx, dbName, httpReq.CollectionName, resp.(*milvuspb.FlushResponse))
 		if err != nil {
-			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPReturn(c, projectedStatusForRequest(c, err, routeToMethod[c.FullPath()]), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return resp, err
 		}
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
@@ -1437,13 +1465,13 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 
 	if httpReq.Schema.IsStructArrayField() {
 		err := merr.WrapErrParameterInvalidMsg("StructArray field must be added through /v2/vectordb/collections/struct_fields/add")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
 	schemaProto, err := httpReq.Schema.GetProto(ctx)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -1482,12 +1510,12 @@ func (h *HandlersV2) dropCollectionField(ctx context.Context, c *gin.Context, an
 	hasFieldID := httpReq.FieldID != nil
 	if hasFieldName == hasFieldID {
 		err := merr.WrapErrParameterInvalidMsg("exactly one of fieldName or fieldId is required")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 	if hasFieldID && *httpReq.FieldID <= 0 {
 		err := merr.WrapErrParameterInvalidMsg("fieldId must be greater than 0")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -1523,7 +1551,7 @@ func (h *HandlersV2) addCollectionStructField(ctx context.Context, c *gin.Contex
 
 	schemaProto, err := httpReq.Schema.GetStructArrayProto(ctx)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -1567,7 +1595,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, query with consistency_level invalid", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: "consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded, err:" + err.Error(),
 		})
@@ -1576,7 +1604,7 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1609,10 +1637,11 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		outputData, err := buildQueryResp(int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, fail to deal with query result", mlog.Any("response", resp), mlog.Err(err))
-			HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturn(c, projectedStatus(merr.ErrInvalidSearchResult), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 				HTTPReturnMessage: resultErrMessage(err),
 			})
+			return merr.Status(merr.ErrInvalidSearchResult), err
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
 			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
@@ -1645,7 +1674,8 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 	body, _ := c.Get(gin.BodyBytesKey)
 	filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 	if err != nil {
-		HTTPReturn(c, http.StatusOK, gin.H{
+		recordErrorType(c, err)
+		HTTPReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 			HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: " + err.Error(),
 		})
@@ -1662,7 +1692,7 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, query with consistency_level invalid", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: "consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded, err:" + err.Error(),
 		})
@@ -1678,10 +1708,11 @@ func (h *HandlersV2) get(ctx context.Context, c *gin.Context, anyReq any, dbName
 		outputData, err := buildQueryResp(int64(0), queryResp.OutputFields, queryResp.FieldsData, nil, nil, allowJS, collSchema)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, fail to deal with get result", mlog.Any("response", resp), mlog.Err(err))
-			HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturn(c, projectedStatus(merr.ErrInvalidSearchResult), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 				HTTPReturnMessage: resultErrMessage(err),
 			})
+			return merr.Status(merr.ErrInvalidSearchResult), err
 		} else {
 			scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(queryResp.GetStatus())
 			if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
@@ -1720,7 +1751,7 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1732,7 +1763,8 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 		body, _ := c.Get(gin.BodyBytesKey)
 		filter, idTemplateValues, err := checkGetPrimaryKey(collSchema, gjson.Get(string(body.([]byte)), DefaultPrimaryFieldName))
 		if err != nil {
-			HTTPReturn(c, http.StatusOK, gin.H{
+			recordErrorType(c, err)
+			HTTPReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 				HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: " + err.Error(),
 			})
@@ -1773,7 +1805,7 @@ func (h *HandlersV2) insert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, false)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, fail to deal with insert data", mlog.Err(err), mlog.String("body", string(body.([]byte))))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrInvalidInsertData), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrInvalidInsertData),
 			HTTPReturnMessage: merr.ErrInvalidInsertData.Error() + ", error: " + err.Error(),
 		})
@@ -1784,7 +1816,7 @@ func (h *HandlersV2) insert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	req.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, true, false)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, fail to deal with insert data", mlog.Any("data", httpReq.Data), mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrInvalidInsertData), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrInvalidInsertData),
 			HTTPReturnMessage: merr.ErrInvalidInsertData.Error() + ", error: " + err.Error(),
 		})
@@ -1819,10 +1851,11 @@ func (h *HandlersV2) insert(ctx context.Context, c *gin.Context, anyReq any, dbN
 				HTTPReturnCost: cost,
 			})
 		default:
-			HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturn(c, projectedStatus(merr.ErrCheckPrimaryKey), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 				HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: unsupported primary key data type",
 			})
+			return resp, merr.ErrCheckPrimaryKey
 		}
 	}
 	return resp, err
@@ -1839,7 +1872,7 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	}
 	fieldOps, err := buildFieldPartialUpdateOps(httpReq.FieldOps)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -1857,7 +1890,7 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, httpReq.PartialUpdate)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, fail to deal with upsert data", mlog.Any("body", body), mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrInvalidInsertData), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrInvalidInsertData),
 			HTTPReturnMessage: merr.ErrInvalidInsertData.Error() + ", error: " + err.Error(),
 		})
@@ -1868,7 +1901,7 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 	req.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, false, httpReq.PartialUpdate)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, fail to deal with upsert data", mlog.Any("data", httpReq.Data), mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrInvalidInsertData), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrInvalidInsertData),
 			HTTPReturnMessage: merr.ErrInvalidInsertData.Error() + ", error: " + err.Error(),
 		})
@@ -1937,10 +1970,11 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 				})
 			}
 		default:
-			HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturn(c, projectedStatus(merr.ErrCheckPrimaryKey), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 				HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: unsupported primary key data type",
 			})
+			return resp, merr.ErrCheckPrimaryKey
 		}
 	}
 	return resp, err
@@ -2072,7 +2106,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, search with consistency_level invalid", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: "consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded, err:" + err.Error(),
 		})
@@ -2092,7 +2126,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 
 	// Primary keys and query vectors are mutually exclusive
 	if hasIDs && hasData {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: "primary keys (ids) and query vectors (data) are mutually exclusive. Please provide either 'ids' or 'data', not both",
 		})
@@ -2101,7 +2135,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 
 	// At least one of ids or data must be provided
 	if !hasIDs && !hasData {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrMissingRequiredParameters), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrMissingRequiredParameters),
 			HTTPReturnMessage: "either 'ids' (for primary key search) or 'data' (for vector search) must be provided",
 		})
@@ -2111,22 +2145,22 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	if httpReq.SearchAggregation != nil {
 		if hasIDs {
 			err := merr.WrapErrParameterInvalidMsg("ids and searchAggregation cannot be used simultaneously")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		if httpReq.Offset != 0 {
 			err := merr.WrapErrParameterInvalidMsg("offset is not supported with searchAggregation")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		if searchParamsContainAny(httpReq.SearchParams, proxy.OffsetKey) {
 			err := merr.WrapErrParameterInvalidMsg("searchParams.offset is not supported with searchAggregation")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		if httpReq.GroupByField != "" || httpReq.GroupSize != nil || httpReq.StrictGroupSize != nil {
 			err := merr.WrapErrParameterInvalidMsg("groupingField/groupSize/strictGroupSize and searchAggregation cannot be used simultaneously")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		if searchParamsContainAny(httpReq.SearchParams,
@@ -2134,18 +2168,18 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			// wording kept compatible: the group_by_field(s) sentence is what
 			// clients and the REST e2e suite already pin on
 			err := merr.WrapErrParameterInvalidMsg("searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously, and neither can group_size/strict_group_size")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		if len(httpReq.OrderByFields) > 0 {
 			err := merr.WrapErrParameterInvalidMsg("orderByFields and searchAggregation cannot be used simultaneously")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 		req.SearchAggregation, err = convertSearchAggregationReq(httpReq.SearchAggregation)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, convert SearchAggregation failed", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 	}
@@ -2154,7 +2188,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	// dedicated field (first key wins on the proxy side), so reject the ambiguity.
 	if len(httpReq.OrderByFields) > 0 && searchParamsContainAny(httpReq.SearchParams, proxy.OrderByFieldsKey) {
 		err := merr.WrapErrParameterInvalidMsg("ambiguous order by: use either orderByFields or searchParams.order_by_fields, not both")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -2168,7 +2202,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			proxy.GroupByFieldKey, proxy.GroupByFieldsKey, proxy.GroupSizeKey, proxy.StrictGroupSize) {
 		err := merr.WrapErrParameterInvalidMsg(
 			"ambiguous grouping: use either the top-level groupingField/groupSize/strictGroupSize or the searchParams group keys, not both")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -2183,7 +2217,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		searchParamsRootContainAny(httpReq.SearchParams, proxy.GroupSizeKey, proxy.StrictGroupSize) {
 		err := merr.WrapErrParameterInvalidMsg(
 			"searchParams group_size/strict_group_size require a group field")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 
@@ -2199,7 +2233,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 				if _, present := nested[key]; present {
 					err := merr.WrapErrParameterInvalidMsg(
 						"searchParams.params cannot carry %s; use the top-level grouping fields or searchParams.%s", key, key)
-					HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+					HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 					return nil, err
 				}
 			}
@@ -2209,7 +2243,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	searchParams, err := generateSearchParams(httpReq.SearchParams)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, generate SearchParams failed", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -2219,7 +2253,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)})
 	searchParams, err = appendGroupParams(searchParams, httpReq.GroupByField, httpReq.GroupSize, httpReq.StrictGroupSize)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 	if len(httpReq.OrderByFields) > 0 {
@@ -2227,13 +2261,13 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	}
 	if len(httpReq.FunctionScore.Functions) != 0 {
 		if req.FunctionScore, err = genFunctionScore(ctx, &httpReq.FunctionScore); err != nil {
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 	}
 	if len(httpReq.FunctionChains) != 0 {
 		if req.FunctionChains, err = genFunctionChains(httpReq.FunctionChains); err != nil {
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 	}
@@ -2242,7 +2276,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		// Search by primary keys
 		primaryField, ok := getPrimaryField(collSchema)
 		if !ok {
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 				HTTPReturnMessage: "collection has no primary key field",
 			})
@@ -2253,7 +2287,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		ids, err := convertIDsToSchemapbIDs(httpReq.Ids, primaryField)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, convert ids to schemapb.IDs failed", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 				HTTPReturnMessage: merr.ErrParameterInvalid.Error() + ", error: " + err.Error(),
 			})
@@ -2275,7 +2309,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		placeholderGroup, err := generatePlaceholderGroup(ctx, string(body.([]byte)), collSchema, httpReq.AnnsField)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, search with vector invalid", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrIncorrectParameterFormat), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
 				HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", error: " + err.Error(),
 			})
@@ -2290,7 +2324,7 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	templateValues, err := generateExpressionTemplate(httpReq.ExprParams)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -2309,10 +2343,11 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			outputData, err := buildSearchAggregationResp(searchResp.Results, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search aggregation result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
+				HTTPReturn(c, projectedStatus(merr.ErrInvalidSearchResult), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 					HTTPReturnMessage: resultErrMessage(err),
 				})
+				return merr.Status(merr.ErrInvalidSearchResult), err
 			} else {
 				respBody := gin.H{
 					HTTPReturnCode:     merr.Code(nil),
@@ -2337,10 +2372,11 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
+				HTTPReturn(c, projectedStatus(merr.ErrInvalidSearchResult), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 					HTTPReturnMessage: resultErrMessage(err),
 				})
+				return merr.Status(merr.ErrInvalidSearchResult), err
 			} else {
 				if len(searchResp.Results.Recalls) > 0 {
 					if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
@@ -2402,7 +2438,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	req.ConsistencyLevel, req.UseDefaultConsistency, err = convertConsistencyLevel(httpReq.ConsistencyLevel)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, search with consistency_level invalid", mlog.Err(err))
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: "consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded, err:" + err.Error(),
 		})
@@ -2412,18 +2448,18 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 
 	if httpReq.SearchAggregation != nil {
 		err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for hybrid search")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 	if len(httpReq.FunctionChains) != 0 {
 		err := merr.WrapErrParameterInvalidMsg("functionChains is not supported for hybrid search yet")
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 	for _, subReq := range httpReq.Search {
 		if subReq.SearchAggregation != nil {
 			err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for hybrid search")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 	}
@@ -2439,7 +2475,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		searchParams, err := generateSearchParams(subReq.SearchParams)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, generate SearchParams failed", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2451,7 +2487,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		placeholderGroup, err := generatePlaceholderGroup(ctx, searchArray[i].Raw, collSchema, subReq.AnnsField)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, search with vector invalid", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(merr.ErrIncorrectParameterFormat), gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
 				HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", error: " + err.Error(),
 			})
@@ -2472,7 +2508,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		subTemplateValues, err := generateExpressionTemplate(subReq.ExprParams)
 		if err != nil {
 			mlog.Warn(ctx, "high level restful api, invalid expression template parameter", mlog.Err(err))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2493,12 +2529,12 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	}
 	req.RankParams, err = appendGroupParams(req.RankParams, httpReq.GroupByField, httpReq.GroupSize, httpReq.StrictGroupSize)
 	if err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}
 	if len(httpReq.FunctionScore.Functions) != 0 {
 		if req.FunctionScore, err = genFunctionScore(ctx, &httpReq.FunctionScore); err != nil {
-			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
+			HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
 			return nil, err
 		}
 	}
@@ -2516,10 +2552,11 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			outputData, err := buildQueryResp(0, searchResp.Results.OutputFields, searchResp.Results.FieldsData, searchResp.Results.Ids, searchResp.Results.Scores, allowJS, collSchema)
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, fail to deal with search result", mlog.Any("result", searchResp.Results), mlog.Err(err))
-				HTTPReturn(c, http.StatusOK, gin.H{
+				HTTPReturn(c, projectedStatus(merr.ErrInvalidSearchResult), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
 					HTTPReturnMessage: resultErrMessage(err),
 				})
+				return merr.Status(merr.ErrInvalidSearchResult), err
 			} else {
 				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
 					HTTPReturnStream(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: outputData, HTTPReturnCost: cost, HTTPReturnTopks: searchResp.Results.Topks, HTTPReturnScannedRemoteBytes: scannedRemoteBytes, HTTPReturnScannedTotalBytes: scannedTotalBytes, HTTPReturnCacheHitRatio: cacheHitRatio})
@@ -2622,7 +2659,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		err := merr.WrapErrParameterInvalid("schema.externalSource/schema.externalSpec", "top-level externalSource/externalSpec",
 			"externalSource and externalSpec must be set under schema when creating an external collection")
 		mlog.Warn(ctx, "high level restful api, create external collection with top-level external config fail", mlog.Err(err), requestLogField)
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -2639,7 +2676,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid("schema.fields", "empty schema fields",
 				"external collection is not supported by quick create; provide schema.fields with externalField")
 			mlog.Warn(ctx, "high level restful api, quickly create external collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2649,7 +2686,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid("schema", "functions",
 				"functions are not supported for quickly create collection")
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2671,7 +2708,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid("FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector", httpReq.VectorFieldType,
 				"vectorFieldType can only be [FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector], default: FloatVector")
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2682,7 +2719,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid(int32(0), httpReq.Dimension,
 				"dimension should not be specified for SparseFloatVector quick create")
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2693,7 +2730,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid("collectionName & dimension", "collectionName",
 				"dimension is required for quickly create collection(default metric type: "+DefaultMetricType+")")
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2704,7 +2741,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		}
 		if err := validateMetricTypeForQuickCreate(quickCreateVectorDataType, httpReq.MetricType); err != nil {
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2726,7 +2763,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			err := merr.WrapErrParameterInvalid("Int64, Varchar", httpReq.IDType,
 				"idType can only be [Int64, VarChar], default: Int64")
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), requestLogField)
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2742,8 +2779,9 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		if enStr, ok := httpReq.Params["enableDynamicField"]; ok {
 			enableDynamic, err = strconv.ParseBool(fmt.Sprintf("%v", enStr))
 			if err != nil {
+				err = merr.WrapErrParameterInvalidMsg("parse enableDynamicField failed, err: %v", err)
 				mlog.Warn(ctx, "high level restful api, parse enableDynamicField fail", mlog.Err(err), requestLogField)
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: "parse enableDynamicField fail, err:" + err.Error(),
 				})
@@ -2800,7 +2838,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		for _, function := range httpReq.Schema.Functions {
 			f, err := genFunctionSchema(ctx, &function)
 			if err != nil {
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 					HTTPReturnMessage: err.Error(),
 				})
@@ -2815,7 +2853,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			fieldDataType, ok := schemapb.DataType_value[field.DataType]
 			if !ok {
 				mlog.Warn(ctx, "field's data type is invalid(case sensitive).", mlog.Any("fieldDataType", field.DataType), mlog.Any("field", field))
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 					HTTPReturnMessage: merr.ErrParameterInvalid.Error() + ", data type " + field.DataType + " is invalid(case sensitive).",
 				})
@@ -2836,7 +2874,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			fieldSchema.DefaultValue, err = convertDefaultValue(field.DefaultValue, dataType)
 			if err != nil {
 				mlog.Warn(ctx, "convert defaultValue fail", mlog.Any("defaultValue", field.DefaultValue))
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: "convert defaultValue fail, err:" + err.Error(),
 				})
@@ -2845,7 +2883,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			if dataType == schemapb.DataType_Array {
 				if _, ok := schemapb.DataType_value[field.ElementDataType]; !ok {
 					mlog.Warn(ctx, "element's data type is invalid(case sensitive).", mlog.Any("elementDataType", field.ElementDataType), mlog.Any("field", field))
-					HTTPAbortReturn(c, http.StatusOK, gin.H{
+					HTTPAbortReturn(c, projectedStatus(merr.ErrParameterInvalid), gin.H{
 						HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 						HTTPReturnMessage: merr.ErrParameterInvalid.Error() + ", element data type " + field.ElementDataType + " is invalid(case sensitive).",
 					})
@@ -2881,7 +2919,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			if _, dup := fieldNames[structField.FieldName]; dup {
 				err := merr.WrapErrParameterInvalidMsg("duplicated field name: %s", structField.FieldName)
 				mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), requestLogField)
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),
 				})
@@ -2891,7 +2929,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			if err != nil {
 				mlog.Warn(ctx, "high level restful api, convert struct array field fail",
 					mlog.String("structField", structField.FieldName), mlog.Err(err))
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),
 				})
@@ -2908,7 +2946,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	}
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, marshal collection schema fail", mlog.Err(err), requestLogField)
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(merr.ErrMarshalCollectionSchema), gin.H{
 			HTTPReturnCode:    merr.Code(merr.ErrMarshalCollectionSchema),
 			HTTPReturnMessage: merr.ErrMarshalCollectionSchema.Error() + ", error: " + err.Error(),
 		})
@@ -2927,7 +2965,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	consistencyLevel, err := consistencyLevelForCreateCollection(httpReq)
 	if err != nil {
 		mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), requestLogField)
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		HTTPAbortReturn(c, projectedStatus(err), gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})
@@ -2946,7 +2984,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		}
 		if ttlPropertySet {
 			err := merr.WrapErrParameterInvalidMsg("collection TTL is specified multiple times")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -2958,7 +2996,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	if _, ok := httpReq.Params["ttlSeconds"]; ok {
 		if ttlPropertySet {
 			err := merr.WrapErrParameterInvalidMsg("collection TTL is specified multiple times")
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -3028,7 +3066,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		}
 		for _, indexParam := range httpReq.IndexParams {
 			if _, ok := fieldNames[indexParam.FieldName]; !ok {
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(merr.ErrMissingRequiredParameters), gin.H{
 					HTTPReturnCode:    merr.Code(merr.ErrMissingRequiredParameters),
 					HTTPReturnMessage: merr.ErrMissingRequiredParameters.Error() + ", error: `" + indexParam.FieldName + "` hasn't defined in schema",
 				})
@@ -3045,7 +3083,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			if err != nil {
 				// will not happen
 				mlog.Warn(ctx, "high level restful api, convertToExtraParams fail", mlog.Err(err), requestLogField)
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPAbortReturn(c, projectedStatus(err), gin.H{
 					HTTPReturnCode:    merr.Code(err),
 					HTTPReturnMessage: err.Error(),
 				})
@@ -3769,7 +3807,7 @@ func (h *HandlersV2) createIndex(ctx context.Context, c *gin.Context, anyReq any
 		if err != nil {
 			// will not happen
 			mlog.Warn(ctx, "high level restful api, convertToExtraParams fail", mlog.Err(err), mlog.Any("request", anyReq))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPAbortReturn(c, projectedStatus(err), gin.H{
 				HTTPReturnCode:    merr.Code(err),
 				HTTPReturnMessage: err.Error(),
 			})
@@ -4199,7 +4237,7 @@ func (h *HandlersV2) getExportSnapshotState(ctx context.Context, c *gin.Context,
 	jobID, err := strconv.ParseInt(httpReq.GetJobID(), 10, 64)
 	if err != nil {
 		paramErr := merr.WrapErrParameterInvalid("int64 jobId", httpReq.GetJobID(), err.Error())
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		HTTPAbortReturn(c, projectedStatus(paramErr), gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
 		return nil, paramErr
 	}
 	req := &milvuspb.GetExportSnapshotStateRequest{
@@ -4241,7 +4279,7 @@ func (h *HandlersV2) getRestoreSnapshotState(ctx context.Context, c *gin.Context
 	jobID, err := strconv.ParseInt(httpReq.GetJobID(), 10, 64)
 	if err != nil {
 		paramErr := merr.WrapErrParameterInvalid("int64 jobId", httpReq.GetJobID(), err.Error())
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		HTTPAbortReturn(c, projectedStatus(paramErr), gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
 		return nil, paramErr
 	}
 	req := &milvuspb.GetRestoreSnapshotStateRequest{
@@ -4313,7 +4351,7 @@ func (h *HandlersV2) commitImportJob(ctx context.Context, c *gin.Context, anyReq
 	jobID, err := strconv.ParseInt(jobIDGetter.GetJobID(), 10, 64)
 	if err != nil {
 		paramErr := merr.WrapErrParameterInvalid("int64 jobId", jobIDGetter.GetJobID(), err.Error())
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		HTTPAbortReturn(c, projectedStatus(paramErr), gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
 		return nil, paramErr
 	}
 	if err := h.checkImportJobAuth(ctx, c, dbName, jobIDGetter.GetJobID()); err != nil {
@@ -4360,7 +4398,7 @@ func (h *HandlersV2) abortImportJob(ctx context.Context, c *gin.Context, anyReq 
 	jobID, err := strconv.ParseInt(jobIDGetter.GetJobID(), 10, 64)
 	if err != nil {
 		paramErr := merr.WrapErrParameterInvalid("int64 jobId", jobIDGetter.GetJobID(), err.Error())
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		HTTPAbortReturn(c, projectedStatus(paramErr), gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
 		return nil, paramErr
 	}
 	if err := h.checkImportJobAuth(ctx, c, dbName, jobIDGetter.GetJobID()); err != nil {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -437,7 +437,22 @@ type (
 func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 	return func(gCtx *gin.Context) {
 		req := newReq()
-		if err := gCtx.ShouldBindBodyWith(req, binding.JSON); err != nil {
+		body, readErr := io.ReadAll(gCtx.Request.Body)
+		if readErr != nil {
+			mlog.Warn(context.TODO(), "high level restful api, read parameters from request body fail", mlog.Err(readErr),
+				mlog.Any("url", gCtx.Request.URL.Path))
+			status := projectedBodyReadStatus(gCtx, readErr)
+			if status != http.StatusOK {
+				recordErrorType(gCtx, readErr)
+			}
+			HTTPAbortReturn(gCtx, status, gin.H{
+				HTTPReturnCode:    merr.Code(merr.ErrIncorrectParameterFormat),
+				HTTPReturnMessage: merr.ErrIncorrectParameterFormat.Error() + ", error: " + readErr.Error(),
+			})
+			return
+		}
+		gCtx.Set(gin.BodyBytesKey, body)
+		if err := binding.JSON.BindBody(body, req); err != nil {
 			mlog.Warn(context.TODO(), "high level restful api, read parameters from request body fail", mlog.Err(err),
 				mlog.Any("url", gCtx.Request.URL.Path))
 			if _, ok := err.(validator.ValidationErrors); ok {
@@ -1840,7 +1855,7 @@ func (h *HandlersV2) insert(ctx context.Context, c *gin.Context, anyReq any, dbN
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 				HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: unsupported primary key data type",
 			})
-			return resp, merr.ErrCheckPrimaryKey
+			return merr.Status(merr.ErrCheckPrimaryKey), merr.ErrCheckPrimaryKey
 		}
 	}
 	return resp, err
@@ -1959,7 +1974,7 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 				HTTPReturnCode:    merr.Code(merr.ErrCheckPrimaryKey),
 				HTTPReturnMessage: merr.ErrCheckPrimaryKey.Error() + ", error: unsupported primary key data type",
 			})
-			return resp, merr.ErrCheckPrimaryKey
+			return merr.Status(merr.ErrCheckPrimaryKey), merr.ErrCheckPrimaryKey
 		}
 	}
 	return resp, err

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -897,33 +897,46 @@ func TestTimeoutMiddlewarePassesDeadline(t *testing.T) {
 }
 
 func TestTimeoutMiddlewareRejectsInvalidRequestTimeout(t *testing.T) {
-	for _, requestTimeout := range []string{"3.5", "abc"} {
-		t.Run(requestTimeout, func(t *testing.T) {
-			ginHandler := gin.New()
-			path := "/middleware/timeout/invalid"
-			called := make(chan struct{}, 1)
-			ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
-				called <- struct{}{}
-				HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
-			}))
+	paramtable.Init()
+	projectionKey := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("projection=%t", enabled), func(t *testing.T) {
+			paramtable.Get().Save(projectionKey, fmt.Sprintf("%t", enabled))
+			defer paramtable.Get().Reset(projectionKey)
 
-			req := httptest.NewRequest(http.MethodPost, path, nil)
-			req.Header.Set(mhttp.HTTPHeaderRequestTimeout, requestTimeout)
-			w := httptest.NewRecorder()
-			ginHandler.ServeHTTP(w, req)
+			for _, requestTimeout := range []string{"3.5", "abc", "0", "-1", "9223372037"} {
+				t.Run(requestTimeout, func(t *testing.T) {
+					ginHandler := gin.New()
+					path := "/middleware/timeout/invalid"
+					called := make(chan struct{}, 1)
+					ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+						called <- struct{}{}
+						HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+					}))
 
-			assert.Equal(t, http.StatusOK, w.Code)
-			returnBody := &ReturnErrMsg{}
-			err := json.Unmarshal(w.Body.Bytes(), returnBody)
-			assert.NoError(t, err)
-			assert.Equal(t, merr.Code(merr.ErrParameterInvalid), returnBody.Code)
-			assert.Contains(t, returnBody.Message, mhttp.HTTPHeaderRequestTimeout)
-			assert.Contains(t, returnBody.Message, requestTimeout)
+					req := httptest.NewRequest(http.MethodPost, path, nil)
+					req.Header.Set(mhttp.HTTPHeaderRequestTimeout, requestTimeout)
+					w := httptest.NewRecorder()
+					ginHandler.ServeHTTP(w, req)
 
-			select {
-			case <-called:
-				t.Fatal("handler was invoked for invalid Request-Timeout")
-			default:
+					expectedStatus := http.StatusOK
+					if enabled {
+						expectedStatus = http.StatusBadRequest
+					}
+					assert.Equal(t, expectedStatus, w.Code)
+					returnBody := &ReturnErrMsg{}
+					err := json.Unmarshal(w.Body.Bytes(), returnBody)
+					assert.NoError(t, err)
+					assert.Equal(t, merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+					assert.Contains(t, returnBody.Message, mhttp.HTTPHeaderRequestTimeout)
+					assert.Contains(t, returnBody.Message, requestTimeout)
+
+					select {
+					case <-called:
+						t.Fatal("handler was invoked for invalid Request-Timeout")
+					default:
+					}
+				})
 			}
 		})
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2314,8 +2314,8 @@ func TestCreateCollection(t *testing.T) {
 		path: path,
 		requestBody: []byte(`{"collectionName": "` + DefaultCollectionName + `", "dimension": 2, "idType": "Varchar",` +
 			`"params": {"max_length": 256, "enableDynamicField": 100, "shardsNum": 2, "consistencyLevel": "unknown", "ttlSeconds": 3600}}`),
-		errMsg:  "parse enableDynamicField fail, err:strconv.ParseBool: parsing \"100\": invalid syntax",
-		errCode: 65535,
+		errMsg:  "parse enableDynamicField fail, err:parse enableDynamicField failed, err: strconv.ParseBool: parsing \"100\": invalid syntax: invalid parameter",
+		errCode: 1100,
 	})
 
 	for _, testcase := range postTestCases {

--- a/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/snapshot_handler_v2.go
@@ -175,7 +175,7 @@ func (h *HandlersV2) unpinSnapshotData(ctx context.Context, c *gin.Context, anyR
 	pinID, err := strconv.ParseInt(httpReq.PinID, 10, 64)
 	if err != nil || pinID <= 0 {
 		paramErr := merr.WrapErrParameterInvalidMsg("pinId must be a positive decimal int64, got %q", httpReq.PinID)
-		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
+		HTTPAbortReturn(c, projectedStatus(paramErr), gin.H{HTTPReturnCode: merr.Code(paramErr), HTTPReturnMessage: paramErr.Error()})
 		return nil, paramErr
 	}
 	req := &milvuspb.UnpinSnapshotDataRequest{

--- a/internal/distributed/proxy/httpserver/status_projection.go
+++ b/internal/distributed/proxy/httpserver/status_projection.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -33,34 +34,16 @@ import (
 // away before the response was written"; net/http has no constant for it.
 const statusClientClosedRequest = 499
 
-// statusOverrides pins codes whose correct status differs from what the coarse
-// buckets (InputError→400, retriable→503, other→500) would assign. The
-// discipline: a row may exist ONLY for codes with verified single provenance —
-// every construction site in the repo must agree with the projected semantic.
-// A code that is a mere state observation with mixed producers (user mistake
-// on one path, internal race/normalized system failure on another) must NOT
-// get a directional status; it falls to the neutral 500. That is why the
-// resource-state codes (collection/partition not loaded 101/201, index not
-// found 700, snapshot not found 2600) deliberately have no rows: each has
-// system/transient producers (failed-load normalization, rebalance windows,
-// meta races) besides the user-mistake path.
-//   - the auth trio is single-provenance (credential/permission state) and
-//     InputError-marked; without rows they would flatten to 400;
-//   - the limit codes 4/8/9 would fall to 503/500; they stay 429 here, with
-//     the replay-unsafe refinement applied in projectedStatusForMethod;
-//   - 1807 is minted only by the HTTP layer's pre-execution admission;
-//   - timeout has no override: every server-side deadline falls to the neutral
-//     500, while the timeout middleware reserves 408 for an incomplete request
-//     upload. Canceled (10000) also has no row: without provenance it stays a
-//     monitored 500, and only projectedStatusForRequest upgrades it to 499 on
-//     proven client cancel.
+// statusOverrides contains only classifications that this boundary can prove
+// from the error itself. Authentication/authorization have dedicated HTTP
+// statuses, while ErrHTTPRateLimit is created only after the HTTP-layer limiter
+// rejects a request before execution. Mixed-provenance downstream limit,
+// retryable, timeout, and resource-state errors deliberately fall through to
+// the neutral 500.
 var statusOverrides = map[int32]int{
 	merr.Code(merr.ErrNeedAuthenticate):          http.StatusUnauthorized,
 	merr.Code(merr.ErrPrivilegeNotAuthenticated): http.StatusUnauthorized,
 	merr.Code(merr.ErrPrivilegeNotPermitted):     http.StatusForbidden,
-	merr.Code(merr.ErrServiceTooManyRequests):    http.StatusTooManyRequests,
-	merr.Code(merr.ErrServiceRateLimit):          http.StatusTooManyRequests,
-	merr.Code(merr.ErrServiceQuotaExceeded):      http.StatusTooManyRequests,
 	merr.Code(merr.ErrHTTPRateLimit):             http.StatusTooManyRequests,
 	// SchemaMismatch (109) is marked InputError upstream, but it is a transient
 	// WAL schema-version race (concurrent DDL) that every other consumer
@@ -72,55 +55,9 @@ var statusOverrides = map[int32]int{
 	merr.Code(merr.ErrCollectionSchemaMismatch): http.StatusInternalServerError,
 }
 
-// replaySafeMethods is the allowlist of v2 RPCs that may advertise the
-// retriable statuses (503 and the RPC-borne 429 codes). It
-// is READS ONLY, on purpose: a read mutates no server state, so replaying it is
-// unconditionally safe and no per-method reasoning can regress. Every mutation
-// — even ones that look idempotent (load/release converge, import commit is a
-// state-machine no-op) — is excluded, because a mutation's replay-safety is an
-// implementation detail that can and did surface edge cases (expr-delete's
-// fresh-snapshot re-evaluation, streaming flush re-sealing growings, an
-// import abort re-broadcasting a rollback for a self-failed job). The fail-safe
-// cost of excluding a genuinely-idempotent mutation is only a lost auto-retry,
-// never data duplication; the body still carries the real code for a
-// deliberate, method-aware client retry.
-//
-// A method absent here defaults to replay-unsafe (503→500, and 429→500 for the
-// RPC-borne limit codes). Keyed by routeToMethod's short method names: the
-// funnel resolves the ROUTE to its method via routeToMethod[FullPath], so a
-// composite handler's internal RPC steps are judged by the route the client
-// actually called.
-var replaySafeMethods = map[string]struct{}{
-	// reads (mutate nothing → replay is unconditionally safe)
-	"Search": {}, "HybridSearch": {}, "Query": {}, "RunAnalyzer": {},
-	"HasCollection": {}, "HasPartition": {},
-	"DescribeCollection": {}, "DescribeDatabase": {}, "DescribeIndex": {},
-	"DescribeAlias": {}, "DescribeSnapshot": {}, "DescribeResourceGroup": {},
-	"ShowCollections": {}, "ShowPartitions": {},
-	"ListAliases": {}, "ListCredUsers": {}, "ListDatabases": {}, "ListImports": {},
-	"ListPrivilegeGroups": {}, "ListRefreshExternalCollectionJobs": {},
-	"ListRestoreSnapshotJobs": {}, "ListSnapshots": {}, "ListResourceGroups": {},
-	"ListFileResources":       {},
-	"GetCollectionStatistics": {}, "GetCompactionState": {}, "GetExportSnapshotState": {},
-	"GetImportProgress": {}, "GetLoadingProgress": {}, "GetLoadState": {},
-	"GetPartitionStatistics": {}, "GetQuotaMetrics": {},
-	"GetRefreshExternalCollectionProgress": {}, "GetRestoreSnapshotState": {},
-	"GetSegmentsInfo": {},
-	"SelectGrant":     {}, "SelectRole": {}, "SelectUser": {},
-}
-
-// isReplaySafe uses an allowlist so anything not explicitly classified as
-// replay-safe remains unsafe by default.
-func isReplaySafe(method string) bool {
-	_, safe := replaySafeMethods[method]
-	return safe
-}
-
 // errToHTTPStatus projects a merr classification onto a standard HTTP status.
-// The wire round-trip preserves the inputs it relies on: merr.Status writes
-// Retriable and the is_input_error flag, merr.Error reads them back; a legacy
-// status carrying only the old ErrorCode reconstructs as a non-retriable
-// SystemError and lands on 500, never on a retriable class.
+// The projection is intentionally conservative: only explicit input and auth
+// classifications receive client-facing statuses; everything else is 500.
 func errToHTTPStatus(err error) int {
 	if err == nil {
 		return http.StatusOK
@@ -131,9 +68,6 @@ func errToHTTPStatus(err error) int {
 	if merr.GetErrorType(err) == merr.InputError {
 		return http.StatusBadRequest
 	}
-	if merr.IsRetryableErr(err) {
-		return http.StatusServiceUnavailable
-	}
 	if code, ok := grpcCodeToHTTPStatus(err); ok {
 		return code
 	}
@@ -141,12 +75,10 @@ func errToHTTPStatus(err error) int {
 }
 
 // grpcCodeToHTTPStatus recovers the status of a raw gRPC error that reached the
-// funnel without a merr wrapping — a hook rejecting with InvalidArgument
-// (hook_interceptor.go) or a transport-level Unavailable — which merr.Code
-// otherwise collapses to the generic 500. Only codes whose meaning is
-// unambiguous and matches this layer's scheme are mapped; everything else
-// returns false so the caller keeps the neutral 500. A merr error has no
-// GRPCStatus(), so status.FromError reports ok=false and this never fires for it.
+// funnel without a merr wrapping. Only explicit input/auth codes are mapped;
+// transport, timeout, cancellation without HTTP provenance, and every other
+// raw gRPC error stay 500. A merr error has no GRPCStatus(), so FromError
+// reports ok=false and this never fires for it.
 func grpcCodeToHTTPStatus(err error) (int, bool) {
 	st, ok := grpcstatus.FromError(err)
 	if !ok || st.Code() == codes.OK {
@@ -159,8 +91,6 @@ func grpcCodeToHTTPStatus(err error) (int, bool) {
 		return http.StatusUnauthorized, true
 	case codes.PermissionDenied:
 		return http.StatusForbidden, true
-	case codes.Unavailable:
-		return http.StatusServiceUnavailable, true
 	}
 	return 0, false
 }
@@ -200,39 +130,6 @@ func errorTypeForAccessLog(err error) merr.ErrorType {
 	}
 }
 
-// isRateLimitClass reports whether err is an actual quota/limit rejection —
-// the only errors the 429 + ErrHTTPRateLimit envelope may represent.
-func isRateLimitClass(err error) bool {
-	return statusOverrides[merr.Code(err)] == http.StatusTooManyRequests
-}
-
-// projectedStatusForMethod replaces the explicitly retriable statuses — 503
-// and the RPC-borne 429 codes — with a generic 500 for methods whose replay is
-// unsafe. A 500 reports the server failure honestly but cannot prevent a
-// gateway configured to retry every 5xx; callers must not automatically replay
-// mutations without idempotency or proof that the request was not applied.
-func projectedStatusForMethod(err error, method string) int {
-	status := projectedStatus(err)
-	if isReplaySafe(method) {
-		return status
-	}
-	switch status {
-	case http.StatusServiceUnavailable:
-		return http.StatusInternalServerError
-	case http.StatusTooManyRequests:
-		// 1807 is minted only by the HTTP layer's pre-execution admission —
-		// provably before any side effect — so its retry invitation stays
-		// honest on any method. The RPC-borne limit codes (4/8/9) can also
-		// surface mid-execution (a later delete batch hitting a full queue
-		// after earlier batches committed) or from static ceilings, so on a
-		// replay-unsafe method they must not explicitly advertise retryability.
-		if merr.Code(err) != merr.Code(merr.ErrHTTPRateLimit) {
-			return http.StatusInternalServerError
-		}
-	}
-	return status
-}
-
 // middlewareTimeoutStatus separates only the boundary that is provable here:
 // an incomplete request upload is 408, while every timeout after body receipt
 // is a server-side 500. Gate-off keeps the pre-existing 408 for compatibility.
@@ -247,9 +144,9 @@ func middlewareTimeoutStatus(bodyReceived bool) int {
 // only when the request context itself was canceled — the signal that proves
 // the caller went away. Both merr CanceledCode and a raw gRPC Canceled status
 // are accepted under that guard; without the provenance, cancellation stays
-// the monitored 500 from projectedStatusForMethod.
-func projectedStatusForRequest(gCtx *gin.Context, err error, method string) int {
-	status := projectedStatusForMethod(err, method)
+// the neutral 500.
+func projectedStatusForRequest(gCtx *gin.Context, err error) int {
+	status := projectedStatus(err)
 	if gCtx == nil {
 		return status
 	}
@@ -259,4 +156,26 @@ func projectedStatusForRequest(gCtx *gin.Context, err error, method string) int 
 		return statusClientClosedRequest
 	}
 	return status
+}
+
+// projectedAuthorizationStatus preserves the legacy 403 used for authorization
+// interceptor failures while the feature is disabled. With standard statuses
+// enabled, only explicit auth failures remain 401/403; infrastructure failures
+// and proven client cancellation become 500/499.
+func projectedAuthorizationStatus(gCtx *gin.Context, err error) int {
+	if !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+		return http.StatusForbidden
+	}
+	return projectedStatusForRequest(gCtx, err)
+}
+
+// errorFromStatusForHTTP restores the input classification that old peers could
+// carry only as deprecated IllegalArgument. It is intentionally local to the
+// REST response boundary so shared retry and gRPC behavior remain unchanged.
+func errorFromStatusForHTTP(status *commonpb.Status) error {
+	err := merr.Error(status)
+	if err != nil && status.GetCode() == 0 && status.GetErrorCode() == commonpb.ErrorCode_IllegalArgument {
+		return merr.WrapErrAsInputError(err)
+	}
+	return err
 }

--- a/internal/distributed/proxy/httpserver/status_projection.go
+++ b/internal/distributed/proxy/httpserver/status_projection.go
@@ -1,0 +1,262 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// statusClientClosedRequest is the nginx/Envoy convention for "client went
+// away before the response was written"; net/http has no constant for it.
+const statusClientClosedRequest = 499
+
+// statusOverrides pins codes whose correct status differs from what the coarse
+// buckets (InputError→400, retriable→503, other→500) would assign. The
+// discipline: a row may exist ONLY for codes with verified single provenance —
+// every construction site in the repo must agree with the projected semantic.
+// A code that is a mere state observation with mixed producers (user mistake
+// on one path, internal race/normalized system failure on another) must NOT
+// get a directional status; it falls to the neutral 500. That is why the
+// resource-state codes (collection/partition not loaded 101/201, index not
+// found 700, snapshot not found 2600) deliberately have no rows: each has
+// system/transient producers (failed-load normalization, rebalance windows,
+// meta races) besides the user-mistake path.
+//   - the auth trio is single-provenance (credential/permission state) and
+//     InputError-marked; without rows they would flatten to 400;
+//   - the limit codes 4/8/9 would fall to 503/500; they stay 429 here, with
+//     the replay-unsafe refinement applied in projectedStatusForMethod;
+//   - 1807 is minted only by the HTTP layer's pre-execution admission;
+//   - timeout has no override: every server-side deadline falls to the neutral
+//     500, while the timeout middleware reserves 408 for an incomplete request
+//     upload. Canceled (10000) also has no row: without provenance it stays a
+//     monitored 500, and only projectedStatusForRequest upgrades it to 499 on
+//     proven client cancel.
+var statusOverrides = map[int32]int{
+	merr.Code(merr.ErrNeedAuthenticate):          http.StatusUnauthorized,
+	merr.Code(merr.ErrPrivilegeNotAuthenticated): http.StatusUnauthorized,
+	merr.Code(merr.ErrPrivilegeNotPermitted):     http.StatusForbidden,
+	merr.Code(merr.ErrServiceTooManyRequests):    http.StatusTooManyRequests,
+	merr.Code(merr.ErrServiceRateLimit):          http.StatusTooManyRequests,
+	merr.Code(merr.ErrServiceQuotaExceeded):      http.StatusTooManyRequests,
+	merr.Code(merr.ErrHTTPRateLimit):             http.StatusTooManyRequests,
+	// SchemaMismatch (109) is marked InputError upstream, but it is a transient
+	// WAL schema-version race (concurrent DDL) that every other consumer
+	// retries (requestutil Retry bucket, Go SDK evicts its schema cache and
+	// replays). A blind HTTP replay is the wrong recovery — the client must
+	// refresh schema and rebuild — and unsafe on the fan-out write path, so it
+	// is neutralized to 500 (don't blame the request or explicitly advertise
+	// retryability) rather than left at 400 (would drop rows) or exposed as 503.
+	merr.Code(merr.ErrCollectionSchemaMismatch): http.StatusInternalServerError,
+}
+
+// replaySafeMethods is the allowlist of v2 RPCs that may advertise the
+// retriable statuses (503 and the RPC-borne 429 codes). It
+// is READS ONLY, on purpose: a read mutates no server state, so replaying it is
+// unconditionally safe and no per-method reasoning can regress. Every mutation
+// — even ones that look idempotent (load/release converge, import commit is a
+// state-machine no-op) — is excluded, because a mutation's replay-safety is an
+// implementation detail that can and did surface edge cases (expr-delete's
+// fresh-snapshot re-evaluation, streaming flush re-sealing growings, an
+// import abort re-broadcasting a rollback for a self-failed job). The fail-safe
+// cost of excluding a genuinely-idempotent mutation is only a lost auto-retry,
+// never data duplication; the body still carries the real code for a
+// deliberate, method-aware client retry.
+//
+// A method absent here defaults to replay-unsafe (503→500, and 429→500 for the
+// RPC-borne limit codes). Keyed by routeToMethod's short method names: the
+// funnel resolves the ROUTE to its method via routeToMethod[FullPath], so a
+// composite handler's internal RPC steps are judged by the route the client
+// actually called.
+var replaySafeMethods = map[string]struct{}{
+	// reads (mutate nothing → replay is unconditionally safe)
+	"Search": {}, "HybridSearch": {}, "Query": {}, "RunAnalyzer": {},
+	"HasCollection": {}, "HasPartition": {},
+	"DescribeCollection": {}, "DescribeDatabase": {}, "DescribeIndex": {},
+	"DescribeAlias": {}, "DescribeSnapshot": {}, "DescribeResourceGroup": {},
+	"ShowCollections": {}, "ShowPartitions": {},
+	"ListAliases": {}, "ListCredUsers": {}, "ListDatabases": {}, "ListImports": {},
+	"ListPrivilegeGroups": {}, "ListRefreshExternalCollectionJobs": {},
+	"ListRestoreSnapshotJobs": {}, "ListSnapshots": {}, "ListResourceGroups": {},
+	"ListFileResources":       {},
+	"GetCollectionStatistics": {}, "GetCompactionState": {}, "GetExportSnapshotState": {},
+	"GetImportProgress": {}, "GetLoadingProgress": {}, "GetLoadState": {},
+	"GetPartitionStatistics": {}, "GetQuotaMetrics": {},
+	"GetRefreshExternalCollectionProgress": {}, "GetRestoreSnapshotState": {},
+	"GetSegmentsInfo": {},
+	"SelectGrant":     {}, "SelectRole": {}, "SelectUser": {},
+}
+
+// isReplaySafe uses an allowlist so anything not explicitly classified as
+// replay-safe remains unsafe by default.
+func isReplaySafe(method string) bool {
+	_, safe := replaySafeMethods[method]
+	return safe
+}
+
+// errToHTTPStatus projects a merr classification onto a standard HTTP status.
+// The wire round-trip preserves the inputs it relies on: merr.Status writes
+// Retriable and the is_input_error flag, merr.Error reads them back; a legacy
+// status carrying only the old ErrorCode reconstructs as a non-retriable
+// SystemError and lands on 500, never on a retriable class.
+func errToHTTPStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	if status, ok := statusOverrides[merr.Code(err)]; ok {
+		return status
+	}
+	if merr.GetErrorType(err) == merr.InputError {
+		return http.StatusBadRequest
+	}
+	if merr.IsRetryableErr(err) {
+		return http.StatusServiceUnavailable
+	}
+	if code, ok := grpcCodeToHTTPStatus(err); ok {
+		return code
+	}
+	return http.StatusInternalServerError
+}
+
+// grpcCodeToHTTPStatus recovers the status of a raw gRPC error that reached the
+// funnel without a merr wrapping — a hook rejecting with InvalidArgument
+// (hook_interceptor.go) or a transport-level Unavailable — which merr.Code
+// otherwise collapses to the generic 500. Only codes whose meaning is
+// unambiguous and matches this layer's scheme are mapped; everything else
+// returns false so the caller keeps the neutral 500. A merr error has no
+// GRPCStatus(), so status.FromError reports ok=false and this never fires for it.
+func grpcCodeToHTTPStatus(err error) (int, bool) {
+	st, ok := grpcstatus.FromError(err)
+	if !ok || st.Code() == codes.OK {
+		return 0, false
+	}
+	switch st.Code() {
+	case codes.InvalidArgument:
+		return http.StatusBadRequest, true
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized, true
+	case codes.PermissionDenied:
+		return http.StatusForbidden, true
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable, true
+	}
+	return 0, false
+}
+
+// projectedStatus is the status every error-carrying REST response goes
+// through. With proxy.http.standardErrorStatus off (the default) it keeps the
+// legacy 200-envelope contract; the body keeps the code/message envelope in
+// both modes.
+func projectedStatus(err error) int {
+	if !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+		return http.StatusOK
+	}
+	return errToHTTPStatus(err)
+}
+
+// recordErrorType stamps the access-log classification for a locally-written
+// error response. wrapperProxy sets it at the funnel from the same err; local
+// sites that write HTTPReturn directly — especially where the body code is a
+// different sentinel than the status-driving err — must set it too, or the
+// access log falls back to the numeric body code and reports a class that
+// disagrees with the projected status. Key matches accesslog/info.ContextErrorType.
+func recordErrorType(c *gin.Context, err error) {
+	c.Set("error_type", errorTypeForAccessLog(err).String())
+}
+
+// errorTypeForAccessLog keeps the access-log attribution aligned with the HTTP
+// projection for raw gRPC client errors, which carry no merr classification.
+func errorTypeForAccessLog(err error) merr.ErrorType {
+	if merr.GetErrorType(err) == merr.InputError {
+		return merr.InputError
+	}
+	switch grpcstatus.Code(err) {
+	case codes.InvalidArgument, codes.Unauthenticated, codes.PermissionDenied:
+		return merr.InputError
+	default:
+		return merr.SystemError
+	}
+}
+
+// isRateLimitClass reports whether err is an actual quota/limit rejection —
+// the only errors the 429 + ErrHTTPRateLimit envelope may represent.
+func isRateLimitClass(err error) bool {
+	return statusOverrides[merr.Code(err)] == http.StatusTooManyRequests
+}
+
+// projectedStatusForMethod replaces the explicitly retriable statuses — 503
+// and the RPC-borne 429 codes — with a generic 500 for methods whose replay is
+// unsafe. A 500 reports the server failure honestly but cannot prevent a
+// gateway configured to retry every 5xx; callers must not automatically replay
+// mutations without idempotency or proof that the request was not applied.
+func projectedStatusForMethod(err error, method string) int {
+	status := projectedStatus(err)
+	if isReplaySafe(method) {
+		return status
+	}
+	switch status {
+	case http.StatusServiceUnavailable:
+		return http.StatusInternalServerError
+	case http.StatusTooManyRequests:
+		// 1807 is minted only by the HTTP layer's pre-execution admission —
+		// provably before any side effect — so its retry invitation stays
+		// honest on any method. The RPC-borne limit codes (4/8/9) can also
+		// surface mid-execution (a later delete batch hitting a full queue
+		// after earlier batches committed) or from static ceilings, so on a
+		// replay-unsafe method they must not explicitly advertise retryability.
+		if merr.Code(err) != merr.Code(merr.ErrHTTPRateLimit) {
+			return http.StatusInternalServerError
+		}
+	}
+	return status
+}
+
+// middlewareTimeoutStatus separates only the boundary that is provable here:
+// an incomplete request upload is 408, while every timeout after body receipt
+// is a server-side 500. Gate-off keeps the pre-existing 408 for compatibility.
+func middlewareTimeoutStatus(bodyReceived bool) int {
+	if !bodyReceived || !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+		return http.StatusRequestTimeout
+	}
+	return http.StatusInternalServerError
+}
+
+// projectedStatusForRequest upgrades a canceled error to 499 (client closed)
+// only when the request context itself was canceled — the signal that proves
+// the caller went away. Both merr CanceledCode and a raw gRPC Canceled status
+// are accepted under that guard; without the provenance, cancellation stays
+// the monitored 500 from projectedStatusForMethod.
+func projectedStatusForRequest(gCtx *gin.Context, err error, method string) int {
+	status := projectedStatusForMethod(err, method)
+	if gCtx == nil {
+		return status
+	}
+	if status == http.StatusInternalServerError &&
+		(merr.Code(err) == merr.CanceledCode || grpcstatus.Code(err) == codes.Canceled) &&
+		errors.Is(gCtx.Request.Context().Err(), context.Canceled) {
+		return statusClientClosedRequest
+	}
+	return status
+}

--- a/internal/distributed/proxy/httpserver/status_projection.go
+++ b/internal/distributed/proxy/httpserver/status_projection.go
@@ -74,19 +74,17 @@ func errToHTTPStatus(err error) int {
 	return http.StatusInternalServerError
 }
 
-// grpcCodeToHTTPStatus recovers the status of a raw gRPC error that reached the
-// funnel without a merr wrapping. Only explicit input/auth codes are mapped;
-// transport, timeout, cancellation without HTTP provenance, and every other
-// raw gRPC error stay 500. A merr error has no GRPCStatus(), so FromError
-// reports ok=false and this never fires for it.
+// grpcCodeToHTTPStatus recovers explicit authentication and authorization
+// statuses from a raw gRPC error. InvalidArgument is deliberately not mapped:
+// HookInterceptor uses it for every Mock/Before/After hook failure, including
+// server failures after the handler has already run, so the code alone cannot
+// prove input blame. An explicitly input-marked error is handled above.
 func grpcCodeToHTTPStatus(err error) (int, bool) {
 	st, ok := grpcstatus.FromError(err)
 	if !ok || st.Code() == codes.OK {
 		return 0, false
 	}
 	switch st.Code() {
-	case codes.InvalidArgument:
-		return http.StatusBadRequest, true
 	case codes.Unauthenticated:
 		return http.StatusUnauthorized, true
 	case codes.PermissionDenied:
@@ -116,14 +114,20 @@ func recordErrorType(c *gin.Context, err error) {
 	c.Set("error_type", errorTypeForAccessLog(err).String())
 }
 
-// errorTypeForAccessLog keeps the access-log attribution aligned with the HTTP
-// projection for raw gRPC client errors, which carry no merr classification.
+// errorTypeForAccessLog keeps access-log attribution aligned with the HTTP
+// projection, including the conservative treatment of unclassified gRPC errors.
 func errorTypeForAccessLog(err error) merr.ErrorType {
+	// Schema mismatch is input-classified by the shared merr sentinel for legacy
+	// retry consumers, but this HTTP boundary projects the transient schema race
+	// as 500, so its access-log attribution must remain system-owned as well.
+	if merr.Code(err) == merr.Code(merr.ErrCollectionSchemaMismatch) {
+		return merr.SystemError
+	}
 	if merr.GetErrorType(err) == merr.InputError {
 		return merr.InputError
 	}
 	switch grpcstatus.Code(err) {
-	case codes.InvalidArgument, codes.Unauthenticated, codes.PermissionDenied:
+	case codes.Unauthenticated, codes.PermissionDenied:
 		return merr.InputError
 	default:
 		return merr.SystemError
@@ -133,21 +137,36 @@ func errorTypeForAccessLog(err error) merr.ErrorType {
 // middlewareTimeoutStatus separates only the boundary that is provable here:
 // an incomplete request upload is 408, while every timeout after body receipt
 // is a server-side 500. Gate-off keeps the pre-existing 408 for compatibility.
-func middlewareTimeoutStatus(bodyReceived bool) int {
-	if !bodyReceived || !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+// standardErrorStatus is a per-request snapshot so one timeout decision cannot
+// observe two different config values.
+func middlewareTimeoutStatus(bodyReceived, standardErrorStatus bool) int {
+	if !bodyReceived || !standardErrorStatus {
 		return http.StatusRequestTimeout
 	}
 	return http.StatusInternalServerError
 }
 
-// projectedStatusForRequest upgrades a canceled error to 499 (client closed)
-// only when the request context itself was canceled — the signal that proves
-// the caller went away. Both merr CanceledCode and a raw gRPC Canceled status
-// are accepted under that guard; without the provenance, cancellation stays
-// the neutral 500.
-func projectedStatusForRequest(gCtx *gin.Context, err error) int {
-	status := projectedStatus(err)
-	if gCtx == nil {
+// projectedBodyReadStatus classifies failures returned while receiving the
+// request body before JSON decoding starts. A canceled request context proves
+// that the caller went away; a timeout-capable read error proves a receive-phase
+// timeout; all other transport failures remain the neutral 500.
+func projectedBodyReadStatus(gCtx *gin.Context, err error) int {
+	if !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+		return http.StatusOK
+	}
+	if gCtx != nil && gCtx.Request != nil &&
+		errors.Is(gCtx.Request.Context().Err(), context.Canceled) {
+		return statusClientClosedRequest
+	}
+	var timeoutErr interface{ Timeout() bool }
+	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+		return http.StatusRequestTimeout
+	}
+	return http.StatusInternalServerError
+}
+
+func applyRequestCancellationStatus(gCtx *gin.Context, err error, status int) int {
+	if gCtx == nil || gCtx.Request == nil {
 		return status
 	}
 	if status == http.StatusInternalServerError &&
@@ -158,15 +177,25 @@ func projectedStatusForRequest(gCtx *gin.Context, err error) int {
 	return status
 }
 
+// projectedStatusForRequest upgrades a canceled error to 499 (client closed)
+// only when the request context itself was canceled — the signal that proves
+// the caller went away. Both merr CanceledCode and a raw gRPC Canceled status
+// are accepted under that guard; without the provenance, cancellation stays
+// the neutral 500.
+func projectedStatusForRequest(gCtx *gin.Context, err error) int {
+	return applyRequestCancellationStatus(gCtx, err, projectedStatus(err))
+}
+
 // projectedAuthorizationStatus preserves the legacy 403 used for authorization
 // interceptor failures while the feature is disabled. With standard statuses
 // enabled, only explicit auth failures remain 401/403; infrastructure failures
 // and proven client cancellation become 500/499.
 func projectedAuthorizationStatus(gCtx *gin.Context, err error) int {
-	if !paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool() {
+	standardErrorStatus := paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool()
+	if !standardErrorStatus {
 		return http.StatusForbidden
 	}
-	return projectedStatusForRequest(gCtx, err)
+	return applyRequestCancellationStatus(gCtx, err, errToHTTPStatus(err))
 }
 
 // errorFromStatusForHTTP restores the input classification that old peers could

--- a/internal/distributed/proxy/httpserver/status_projection_test.go
+++ b/internal/distributed/proxy/httpserver/status_projection_test.go
@@ -47,25 +47,26 @@ func TestErrToHTTPStatus(t *testing.T) {
 		{"need authenticate", merr.ErrNeedAuthenticate, http.StatusUnauthorized},
 		{"not authenticated", merr.ErrPrivilegeNotAuthenticated, http.StatusUnauthorized},
 		{"not permitted", merr.ErrPrivilegeNotPermitted, http.StatusForbidden},
-		{"queue full", merr.ErrServiceTooManyRequests, http.StatusTooManyRequests},
-		{"rate limit", merr.ErrServiceRateLimit, http.StatusTooManyRequests},
-		{"quota exceeded", merr.ErrServiceQuotaExceeded, http.StatusTooManyRequests},
-		{"http rate limit", merr.ErrHTTPRateLimit, http.StatusTooManyRequests},
+		{"downstream queue full", merr.ErrServiceTooManyRequests, http.StatusInternalServerError},
+		{"downstream rate limit", merr.ErrServiceRateLimit, http.StatusInternalServerError},
+		{"downstream quota exceeded", merr.ErrServiceQuotaExceeded, http.StatusInternalServerError},
+		{"http pre-execution rate limit", merr.ErrHTTPRateLimit, http.StatusTooManyRequests},
 		{"input sentinel", merr.ErrParameterInvalid, http.StatusBadRequest},
 		{"boundary-marked input", merr.WrapErrAsInputError(merr.ErrCollectionNotFound), http.StatusBadRequest},
-		{"collection not loaded: mixed provenance, neutral", merr.ErrCollectionNotLoaded, http.StatusInternalServerError},
-		{"schema mismatch: transient race, neutralized", merr.ErrCollectionSchemaMismatch, http.StatusInternalServerError},
-		{"retriable system", merr.ErrServiceUnavailable, http.StatusServiceUnavailable},
+		{"collection not loaded", merr.ErrCollectionNotLoaded, http.StatusInternalServerError},
+		{"schema mismatch", merr.ErrCollectionSchemaMismatch, http.StatusInternalServerError},
+		{"retriable system", merr.ErrServiceUnavailable, http.StatusInternalServerError},
 		{"non-retriable system", merr.ErrServiceInternal, http.StatusInternalServerError},
 		{"non-merr error", assert.AnError, http.StatusInternalServerError},
 		{"deadline exceeded", context.DeadlineExceeded, http.StatusInternalServerError},
 		{"canceled without provenance", context.Canceled, http.StatusInternalServerError},
-		{"raw grpc InvalidArgument (hook reject)", status.Error(codes.InvalidArgument, "x"), http.StatusBadRequest},
-		{"raw grpc Unavailable (transport)", status.Error(codes.Unavailable, "x"), http.StatusServiceUnavailable},
+		{"raw grpc InvalidArgument", status.Error(codes.InvalidArgument, "x"), http.StatusBadRequest},
+		{"raw grpc Unauthenticated", status.Error(codes.Unauthenticated, "x"), http.StatusUnauthorized},
+		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), http.StatusForbidden},
+		{"raw grpc Unavailable", status.Error(codes.Unavailable, "x"), http.StatusInternalServerError},
 		{"raw grpc DeadlineExceeded", status.Error(codes.DeadlineExceeded, "x"), http.StatusInternalServerError},
 		{"raw grpc Canceled without provenance", status.Error(codes.Canceled, "x"), http.StatusInternalServerError},
-		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), http.StatusForbidden},
-		{"raw grpc NotFound stays neutral 500", status.Error(codes.NotFound, "x"), http.StatusInternalServerError},
+		{"raw grpc NotFound", status.Error(codes.NotFound, "x"), http.StatusInternalServerError},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,38 +96,35 @@ func TestErrorTypeForAccessLog(t *testing.T) {
 	}
 }
 
-// The classification must survive the status round-trip the REST layer
-// actually receives: wrapperProxy rebuilds the error via merr.Error(status).
 func TestErrToHTTPStatusSurvivesWire(t *testing.T) {
 	roundTrip := func(err error) error { return merr.Error(merr.Status(err)) }
 
 	assert.Equal(t, http.StatusBadRequest, errToHTTPStatus(roundTrip(merr.ErrParameterInvalid)))
 	assert.Equal(t, http.StatusBadRequest, errToHTTPStatus(roundTrip(merr.WrapErrAsInputError(merr.ErrCollectionNotFound))))
-	assert.Equal(t, http.StatusTooManyRequests, errToHTTPStatus(roundTrip(merr.ErrServiceRateLimit)))
-	assert.Equal(t, http.StatusServiceUnavailable, errToHTTPStatus(roundTrip(merr.ErrServiceUnavailable)))
+	assert.Equal(t, http.StatusInternalServerError, errToHTTPStatus(roundTrip(merr.ErrServiceRateLimit)))
+	assert.Equal(t, http.StatusInternalServerError, errToHTTPStatus(roundTrip(merr.ErrServiceUnavailable)))
 
-	// A legacy peer fills only the old ErrorCode: no Retriable, no input flag.
-	// It must land on the non-retriable 500, never on a retriable class.
-	legacy := merr.Error(&commonpb.Status{ErrorCode: commonpb.ErrorCode_UnexpectedError, Reason: "legacy"})
-	assert.Equal(t, http.StatusInternalServerError, errToHTTPStatus(legacy))
+	legacyInput := &commonpb.Status{ErrorCode: commonpb.ErrorCode_IllegalArgument, Reason: "legacy input"}
+	assert.Equal(t, http.StatusBadRequest, errToHTTPStatus(errorFromStatusForHTTP(legacyInput)))
+
+	legacySystem := &commonpb.Status{ErrorCode: commonpb.ErrorCode_UnexpectedError, Reason: "legacy system"}
+	assert.Equal(t, http.StatusInternalServerError, errToHTTPStatus(errorFromStatusForHTTP(legacySystem)))
 }
 
 func TestProjectedStatusGate(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
 
-	// default: off, everything keeps the 200 envelope
 	assert.Equal(t, http.StatusOK, projectedStatus(merr.ErrServiceRateLimit))
 	assert.Equal(t, http.StatusOK, projectedStatus(merr.ErrParameterInvalid))
 
 	paramtable.Get().Save(key, "true")
 	defer paramtable.Get().Reset(key)
-	assert.Equal(t, http.StatusTooManyRequests, projectedStatus(merr.ErrServiceRateLimit))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatus(merr.ErrServiceRateLimit))
 	assert.Equal(t, http.StatusBadRequest, projectedStatus(merr.ErrParameterInvalid))
 	assert.Equal(t, http.StatusOK, projectedStatus(nil))
 }
 
-// 499 requires proof the caller went away; otherwise canceled stays 500.
 func TestProjectedStatusForRequest(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
@@ -144,41 +142,38 @@ func TestProjectedStatusForRequest(t *testing.T) {
 		c.Request = req
 		return c
 	}
-	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), context.Canceled, "Search"))
-	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), status.Error(codes.Canceled, "x"), "Search"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), context.Canceled, "Search"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), status.Error(codes.Canceled, "x"), "Search"))
-	// non-canceled statuses pass through untouched
-	assert.Equal(t, http.StatusServiceUnavailable, projectedStatusForRequest(newGinCtx(true), merr.ErrServiceUnavailable, "Search"))
 
-	// A deadline is server-side once the request body has arrived, regardless
-	// of whether the error is a Go context or a raw gRPC status.
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), context.DeadlineExceeded, "Search"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(true), status.Error(codes.DeadlineExceeded, "x"), "Search"))
+	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), context.Canceled))
+	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), status.Error(codes.Canceled, "x")))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), context.Canceled))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), status.Error(codes.Canceled, "x")))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(true), merr.ErrServiceUnavailable))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(true), context.DeadlineExceeded))
 }
 
-func TestProjectedStatusForMethodTimeout(t *testing.T) {
+func TestProjectedAuthorizationStatus(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/x", nil)
+
+	assert.Equal(t, http.StatusForbidden, projectedAuthorizationStatus(c, assert.AnError))
+
 	paramtable.Get().Save(key, "true")
 	defer paramtable.Get().Reset(key)
-
-	// Every server-side timeout is 500, independently of replay safety.
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "Insert"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "PinSnapshotData"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "Search"))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(status.Error(codes.DeadlineExceeded, "x"), "Search"))
-	// 503 unsafe downgrade unchanged
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, "PinSnapshotData"))
+	assert.Equal(t, http.StatusForbidden, projectedAuthorizationStatus(c, status.Error(codes.PermissionDenied, "denied")))
+	assert.Equal(t, http.StatusUnauthorized, projectedAuthorizationStatus(c, status.Error(codes.Unauthenticated, "missing")))
+	assert.Equal(t, http.StatusInternalServerError, projectedAuthorizationStatus(c, assert.AnError))
+	canceledCtx, cancel := context.WithCancel(c.Request.Context())
+	cancel()
+	c.Request = c.Request.WithContext(canceledCtx)
+	assert.Equal(t, statusClientClosedRequest, projectedAuthorizationStatus(c, context.Canceled))
 }
 
-// The middleware timer branch separates incomplete request upload from every
-// timeout after body receipt.
 func TestMiddlewareTimeoutStatus(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
 
-	// Gate off preserves the pre-existing 408 regardless of body progress.
 	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(true))
 	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
 
@@ -186,148 +181,65 @@ func TestMiddlewareTimeoutStatus(t *testing.T) {
 	defer paramtable.Get().Reset(key)
 	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
 	assert.Equal(t, http.StatusInternalServerError, middlewareTimeoutStatus(true))
-
-	assert.False(t, isReplaySafe("Insert"))
-	assert.False(t, isReplaySafe("Upsert"))
-	assert.False(t, isReplaySafe("Import"))
-	// job-creating endpoints that return a server-generated handle
-	assert.False(t, isReplaySafe("ManualCompaction"))
-	assert.False(t, isReplaySafe("RestoreSnapshot"))
-	assert.False(t, isReplaySafe("RestoreExternalSnapshot"))
-	assert.False(t, isReplaySafe("ExportSnapshot"))
-	assert.False(t, isReplaySafe("RefreshExternalCollection"))
-	// count-delta transfer: replay moves another NumReplica batch
-	assert.False(t, isReplaySafe("TransferMaster"))
-	assert.False(t, isReplaySafe("AlterCollectionFunction"))
-	// unknown method is unsafe by default (fail-safe)
-	assert.False(t, isReplaySafe("BrandNewMethod"))
-	// control-plane DDL is policy-excluded even though idempotent
-	assert.False(t, isReplaySafe("CreateCollection"))
-	assert.False(t, isReplaySafe("CreateIndex"))
-	assert.False(t, isReplaySafe("OperatePrivilege"))
-	// reads stay safe; every mutation (incl. load/commit) is unsafe by policy
-	assert.True(t, isReplaySafe("Search"))
-	assert.True(t, isReplaySafe("Query"))
-	assert.False(t, isReplaySafe("Delete"))
-	assert.False(t, isReplaySafe("Flush"))
-	assert.False(t, isReplaySafe("LoadCollection"))
-	assert.False(t, isReplaySafe("CommitImport"))
-	assert.False(t, isReplaySafe("AbortImport"))
 }
 
-// wrapperPost must flip the recorder's bodyReceived flag once the full body is
-// read, even if JSON decoding then fails. Engine.HandleContext resets c.Writer,
-// so the handler is invoked directly
-// with the recorder installed as the Writer, matching what timeoutMiddleware
-// hands the handler goroutine.
-func TestWrapperPostSetsBodyReceived(t *testing.T) {
-	paramtable.Init()
-	handler := wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
-		return nil, nil
+func TestBodyReadTracker(t *testing.T) {
+	t.Run("complete", func(t *testing.T) {
+		recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+		body := &bodyReadTracker{
+			ReadCloser:   io.NopCloser(bytes.NewReader([]byte(`{"bad json`))),
+			bodyReceived: &recorder.bodyReceived,
+		}
+		_, err := io.ReadAll(body)
+		assert.NoError(t, err)
+		assert.True(t, recorder.bodyReceived.Load())
 	})
 
-	send := func(body io.Reader) *timeoutResponseRecorder {
+	t.Run("read failure", func(t *testing.T) {
 		recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
-		c := gin.CreateTestContextOnly(httptest.NewRecorder(), gin.New())
-		c.Request = httptest.NewRequest(http.MethodPost, "/bound", body)
-		// wrapperPost asserts the username the auth middleware normally sets
-		c.Set(ContextUsername, "root")
-		c.Writer = recorder
-		handler(c)
-		return recorder
-	}
-
-	assert.True(t, send(bytes.NewReader([]byte(`{}`))).bodyReceived.Load(), "successful bind must set the flag")
-	assert.True(t, send(bytes.NewReader([]byte(`{"bad json`))).bodyReceived.Load(), "decode failure after a complete read must set the flag")
-	assert.False(t, send(iotest.ErrReader(assert.AnError)).bodyReceived.Load(), "body read failure must leave the flag unset")
+		body := &bodyReadTracker{
+			ReadCloser:   io.NopCloser(iotest.ErrReader(assert.AnError)),
+			bodyReceived: &recorder.bodyReceived,
+		}
+		_, err := io.ReadAll(body)
+		assert.Error(t, err)
+		assert.False(t, recorder.bodyReceived.Load())
+	})
 }
 
-// Guard against registry drift: every route the middleware can resolve must be
-// explicitly classified as replay-safe (allowlisted) or in the known-unsafe
-// set below. A new route that is neither fails here, forcing a deliberate
-// replay-safety decision instead of silently inheriting the fail-safe 500.
-func TestReplaySafetyCoversAllRoutes(t *testing.T) {
-	knownUnsafe := map[string]struct{}{
-		// replay duplicates data or allocates a second server-side effect
-		"Insert": {}, "Upsert": {}, "Import": {}, "PinSnapshotData": {},
-		"ManualCompaction": {}, "RestoreSnapshot": {}, "RestoreExternalSnapshot": {},
-		"ExportSnapshot": {}, "RefreshExternalCollection": {},
-		// count-delta request (NumReplica), not desired-state: replay moves another batch
-		"TransferMaster": {},
-		// bumps schema version + rebroadcasts even on an identical request
-		"AlterCollectionFunction": {},
-		// expr-delete re-evaluates its predicate at a fresh TSO snapshot per
-		// attempt; partial-apply + replay deletes rows inserted in between
-		"Delete": {},
-		// streaming flush seals newly-created growings on every strictly-newer
-		// attempt (fresh TSO passes the fence) — not convergent under replay
-		"Flush": {},
-		// allowlist is reads-only: every remaining mutation is excluded by policy
-		"LoadCollection": {}, "LoadPartitions": {}, "ReleaseCollection": {}, "ReleasePartitions": {},
-		"CommitImport": {},
-		// self-failed import job re-broadcasts rollback on each abort (not a no-op)
-		"AbortImport": {},
-		// idempotent but control-plane heavy: excluded by policy (see
-		// replaySafeMethods) — unattended retry of admin ops is undesirable
-		"TruncateCollection": {}, "CreateCollection": {}, "DropCollection": {}, "RenameCollection": {},
-		"CreatePartition": {}, "DropPartition": {},
-		"CreateIndex": {}, "DropIndex": {}, "AlterIndex": {},
-		"CreateAlias": {}, "DropAlias": {}, "AlterAlias": {},
-		"CreateDatabase": {}, "DropDatabase": {}, "AlterDatabase": {},
-		"AlterCollection": {}, "AlterCollectionField": {}, "AlterCollectionSchema": {},
-		"AddCollectionFunction": {}, "DropCollectionFunction": {}, "AddCollectionStructField": {},
-		"CreateSnapshot": {}, "DropSnapshot": {}, "UnpinSnapshotData": {},
-		"CreateCredential": {}, "UpdateCredential": {}, "DeleteCredential": {},
-		"CreateRole": {}, "DropRole": {}, "AlterRole": {},
-		"CreatePrivilegeGroup": {}, "DropPrivilegeGroup": {},
-		"OperatePrivilege": {}, "OperatePrivilegeGroup": {}, "OperatePrivilegeV2": {}, "OperateUserRole": {},
-		"CreateResourceGroup": {}, "DropResourceGroup": {}, "UpdateResourceGroups": {},
-		"AddFileResource": {}, "RemoveFileResource": {},
-	}
-	for route, method := range routeToMethod {
-		_, safe := replaySafeMethods[method]
-		_, unsafe := knownUnsafe[method]
-		assert.Truef(t, safe != unsafe,
-			"route %q -> method %q is unclassified (safe=%v unsafe=%v); add it to replaySafeMethods or the known-unsafe set",
-			route, method, safe, unsafe)
-	}
-}
-
-func TestIsRateLimitClass(t *testing.T) {
-	assert.True(t, isRateLimitClass(merr.ErrServiceRateLimit))
-	assert.True(t, isRateLimitClass(merr.ErrHTTPRateLimit))
-	assert.True(t, isRateLimitClass(merr.ErrServiceQuotaExceeded))
-	assert.False(t, isRateLimitClass(merr.ErrServiceNotReady))
-	assert.False(t, isRateLimitClass(assert.AnError))
-	assert.False(t, isRateLimitClass(nil))
-}
-
-// 503 must not be advertised on methods whose replay duplicates data.
-func TestProjectedStatusForMethod(t *testing.T) {
+func TestTimeoutMiddlewareClassifiesBodyReceipt(t *testing.T) {
 	paramtable.Init()
-	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
-	paramtable.Get().Save(key, "true")
-	defer paramtable.Get().Reset(key)
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.StandardErrorStatus.Key, "true")
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "20")
+	defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.StandardErrorStatus.Key)
+	defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
 
-	const insert = "Insert"
-	const upsert = "Upsert"
-	const search = "Search"
-	// retriable → 503 downgraded to 500 only on replay-unsafe methods
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, insert))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, upsert))
-	assert.Equal(t, http.StatusServiceUnavailable, projectedStatusForMethod(merr.ErrServiceUnavailable, search))
-	// RPC-borne limit codes (4/8/9) can arrive mid-execution, so on a
-	// replay-unsafe method they must not invite a replay; only the HTTP
-	// pre-admission 1807 is provably pre-side-effect and keeps 429 anywhere.
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceRateLimit, insert))
-	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceTooManyRequests, insert))
-	assert.Equal(t, http.StatusTooManyRequests, projectedStatusForMethod(merr.ErrHTTPRateLimit, insert))
-	assert.Equal(t, http.StatusTooManyRequests, projectedStatusForMethod(merr.ErrServiceRateLimit, search))
-	assert.Equal(t, http.StatusBadRequest, projectedStatusForMethod(merr.ErrParameterInvalid, insert))
+	ginHandler := gin.New()
+	ginHandler.Use(func(c *gin.Context) {
+		c.Set(ContextUsername, "root")
+		c.Next()
+	})
+	ginHandler.POST("/complete", timeoutMiddleware(wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})))
+	ginHandler.POST("/incomplete", timeoutMiddleware(wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+		return nil, nil
+	})))
+
+	completeReq := httptest.NewRequest(http.MethodPost, "/complete", bytes.NewReader([]byte(`{}`)))
+	completeResp := httptest.NewRecorder()
+	ginHandler.ServeHTTP(completeResp, completeReq)
+	assert.Equal(t, http.StatusInternalServerError, completeResp.Code)
+
+	reader, writer := io.Pipe()
+	incompleteReq := httptest.NewRequest(http.MethodPost, "/incomplete", reader)
+	incompleteResp := httptest.NewRecorder()
+	ginHandler.ServeHTTP(incompleteResp, incompleteReq)
+	assert.Equal(t, http.StatusRequestTimeout, incompleteResp.Code)
+	assert.NoError(t, writer.Close())
 }
 
-// Gate-on behavior through the real request path: the status line changes,
-// the body keeps the code/message envelope.
 func TestProjectedStatusThroughHandlers(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
@@ -336,8 +248,6 @@ func TestProjectedStatusThroughHandlers(t *testing.T) {
 
 	h := &HandlersV2{metaCache: func() proxy.Cache { return nil }}
 	ginHandler := gin.Default()
-	// wrapperPost asserts ContextUsername unconditionally once binding
-	// succeeds; the auth middleware (auth disabled) is what sets it.
 	app := ginHandler.Group("", genAuthMiddleWare(false))
 	app.POST("/param", wrapperPost(func() any { return &CollectionNameReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
 		return nil, nil
@@ -349,7 +259,6 @@ func TestProjectedStatusThroughHandlers(t *testing.T) {
 			})
 		})
 	}
-	// real v2 routes so the route-keyed projection resolves routeToMethod
 	app.POST("/v2/vectordb/entities/hybrid_search", rpcErrRoute(merr.ErrServiceRateLimit))
 	app.POST("/v2/vectordb/entities/search", rpcErrRoute(merr.ErrServiceUnavailable))
 
@@ -360,8 +269,8 @@ func TestProjectedStatusThroughHandlers(t *testing.T) {
 		wantCode   int32
 	}{
 		{"/param", `{}`, http.StatusBadRequest, merr.Code(merr.ErrMissingRequiredParameters)},
-		{"/v2/vectordb/entities/hybrid_search", `{}`, http.StatusTooManyRequests, merr.Code(merr.ErrServiceRateLimit)},
-		{"/v2/vectordb/entities/search", `{}`, http.StatusServiceUnavailable, merr.Code(merr.ErrServiceUnavailable)},
+		{"/v2/vectordb/entities/hybrid_search", `{}`, http.StatusInternalServerError, merr.Code(merr.ErrServiceRateLimit)},
+		{"/v2/vectordb/entities/search", `{}`, http.StatusInternalServerError, merr.Code(merr.ErrServiceUnavailable)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {
@@ -370,7 +279,7 @@ func TestProjectedStatusThroughHandlers(t *testing.T) {
 			ginHandler.ServeHTTP(w, req)
 			assert.Equal(t, tc.wantStatus, w.Code)
 			returnBody := &ReturnErrMsg{}
-			assert.Nil(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
 			assert.Equal(t, tc.wantCode, returnBody.Code)
 		})
 	}

--- a/internal/distributed/proxy/httpserver/status_projection_test.go
+++ b/internal/distributed/proxy/httpserver/status_projection_test.go
@@ -1,0 +1,377 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/iotest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestErrToHTTPStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, http.StatusOK},
+		{"need authenticate", merr.ErrNeedAuthenticate, http.StatusUnauthorized},
+		{"not authenticated", merr.ErrPrivilegeNotAuthenticated, http.StatusUnauthorized},
+		{"not permitted", merr.ErrPrivilegeNotPermitted, http.StatusForbidden},
+		{"queue full", merr.ErrServiceTooManyRequests, http.StatusTooManyRequests},
+		{"rate limit", merr.ErrServiceRateLimit, http.StatusTooManyRequests},
+		{"quota exceeded", merr.ErrServiceQuotaExceeded, http.StatusTooManyRequests},
+		{"http rate limit", merr.ErrHTTPRateLimit, http.StatusTooManyRequests},
+		{"input sentinel", merr.ErrParameterInvalid, http.StatusBadRequest},
+		{"boundary-marked input", merr.WrapErrAsInputError(merr.ErrCollectionNotFound), http.StatusBadRequest},
+		{"collection not loaded: mixed provenance, neutral", merr.ErrCollectionNotLoaded, http.StatusInternalServerError},
+		{"schema mismatch: transient race, neutralized", merr.ErrCollectionSchemaMismatch, http.StatusInternalServerError},
+		{"retriable system", merr.ErrServiceUnavailable, http.StatusServiceUnavailable},
+		{"non-retriable system", merr.ErrServiceInternal, http.StatusInternalServerError},
+		{"non-merr error", assert.AnError, http.StatusInternalServerError},
+		{"deadline exceeded", context.DeadlineExceeded, http.StatusInternalServerError},
+		{"canceled without provenance", context.Canceled, http.StatusInternalServerError},
+		{"raw grpc InvalidArgument (hook reject)", status.Error(codes.InvalidArgument, "x"), http.StatusBadRequest},
+		{"raw grpc Unavailable (transport)", status.Error(codes.Unavailable, "x"), http.StatusServiceUnavailable},
+		{"raw grpc DeadlineExceeded", status.Error(codes.DeadlineExceeded, "x"), http.StatusInternalServerError},
+		{"raw grpc Canceled without provenance", status.Error(codes.Canceled, "x"), http.StatusInternalServerError},
+		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), http.StatusForbidden},
+		{"raw grpc NotFound stays neutral 500", status.Error(codes.NotFound, "x"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, errToHTTPStatus(tc.err))
+		})
+	}
+}
+
+func TestErrorTypeForAccessLog(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want merr.ErrorType
+	}{
+		{"merr input", merr.ErrParameterInvalid, merr.InputError},
+		{"merr system", merr.ErrServiceInternal, merr.SystemError},
+		{"raw grpc InvalidArgument", status.Error(codes.InvalidArgument, "x"), merr.InputError},
+		{"raw grpc Unauthenticated", status.Error(codes.Unauthenticated, "x"), merr.InputError},
+		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), merr.InputError},
+		{"raw grpc Unavailable", status.Error(codes.Unavailable, "x"), merr.SystemError},
+		{"raw grpc Canceled", status.Error(codes.Canceled, "x"), merr.SystemError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, errorTypeForAccessLog(tc.err))
+		})
+	}
+}
+
+// The classification must survive the status round-trip the REST layer
+// actually receives: wrapperProxy rebuilds the error via merr.Error(status).
+func TestErrToHTTPStatusSurvivesWire(t *testing.T) {
+	roundTrip := func(err error) error { return merr.Error(merr.Status(err)) }
+
+	assert.Equal(t, http.StatusBadRequest, errToHTTPStatus(roundTrip(merr.ErrParameterInvalid)))
+	assert.Equal(t, http.StatusBadRequest, errToHTTPStatus(roundTrip(merr.WrapErrAsInputError(merr.ErrCollectionNotFound))))
+	assert.Equal(t, http.StatusTooManyRequests, errToHTTPStatus(roundTrip(merr.ErrServiceRateLimit)))
+	assert.Equal(t, http.StatusServiceUnavailable, errToHTTPStatus(roundTrip(merr.ErrServiceUnavailable)))
+
+	// A legacy peer fills only the old ErrorCode: no Retriable, no input flag.
+	// It must land on the non-retriable 500, never on a retriable class.
+	legacy := merr.Error(&commonpb.Status{ErrorCode: commonpb.ErrorCode_UnexpectedError, Reason: "legacy"})
+	assert.Equal(t, http.StatusInternalServerError, errToHTTPStatus(legacy))
+}
+
+func TestProjectedStatusGate(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+
+	// default: off, everything keeps the 200 envelope
+	assert.Equal(t, http.StatusOK, projectedStatus(merr.ErrServiceRateLimit))
+	assert.Equal(t, http.StatusOK, projectedStatus(merr.ErrParameterInvalid))
+
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+	assert.Equal(t, http.StatusTooManyRequests, projectedStatus(merr.ErrServiceRateLimit))
+	assert.Equal(t, http.StatusBadRequest, projectedStatus(merr.ErrParameterInvalid))
+	assert.Equal(t, http.StatusOK, projectedStatus(nil))
+}
+
+// 499 requires proof the caller went away; otherwise canceled stays 500.
+func TestProjectedStatusForRequest(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	newGinCtx := func(canceled bool) *gin.Context {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		if canceled {
+			reqCtx, cancel := context.WithCancel(req.Context())
+			cancel()
+			req = req.WithContext(reqCtx)
+		}
+		c.Request = req
+		return c
+	}
+	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), context.Canceled, "Search"))
+	assert.Equal(t, statusClientClosedRequest, projectedStatusForRequest(newGinCtx(true), status.Error(codes.Canceled, "x"), "Search"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), context.Canceled, "Search"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), status.Error(codes.Canceled, "x"), "Search"))
+	// non-canceled statuses pass through untouched
+	assert.Equal(t, http.StatusServiceUnavailable, projectedStatusForRequest(newGinCtx(true), merr.ErrServiceUnavailable, "Search"))
+
+	// A deadline is server-side once the request body has arrived, regardless
+	// of whether the error is a Go context or a raw gRPC status.
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(false), context.DeadlineExceeded, "Search"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForRequest(newGinCtx(true), status.Error(codes.DeadlineExceeded, "x"), "Search"))
+}
+
+func TestProjectedStatusForMethodTimeout(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	// Every server-side timeout is 500, independently of replay safety.
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "Insert"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "PinSnapshotData"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(context.DeadlineExceeded, "Search"))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(status.Error(codes.DeadlineExceeded, "x"), "Search"))
+	// 503 unsafe downgrade unchanged
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, "PinSnapshotData"))
+}
+
+// The middleware timer branch separates incomplete request upload from every
+// timeout after body receipt.
+func TestMiddlewareTimeoutStatus(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+
+	// Gate off preserves the pre-existing 408 regardless of body progress.
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(true))
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
+
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
+	assert.Equal(t, http.StatusInternalServerError, middlewareTimeoutStatus(true))
+
+	assert.False(t, isReplaySafe("Insert"))
+	assert.False(t, isReplaySafe("Upsert"))
+	assert.False(t, isReplaySafe("Import"))
+	// job-creating endpoints that return a server-generated handle
+	assert.False(t, isReplaySafe("ManualCompaction"))
+	assert.False(t, isReplaySafe("RestoreSnapshot"))
+	assert.False(t, isReplaySafe("RestoreExternalSnapshot"))
+	assert.False(t, isReplaySafe("ExportSnapshot"))
+	assert.False(t, isReplaySafe("RefreshExternalCollection"))
+	// count-delta transfer: replay moves another NumReplica batch
+	assert.False(t, isReplaySafe("TransferMaster"))
+	assert.False(t, isReplaySafe("AlterCollectionFunction"))
+	// unknown method is unsafe by default (fail-safe)
+	assert.False(t, isReplaySafe("BrandNewMethod"))
+	// control-plane DDL is policy-excluded even though idempotent
+	assert.False(t, isReplaySafe("CreateCollection"))
+	assert.False(t, isReplaySafe("CreateIndex"))
+	assert.False(t, isReplaySafe("OperatePrivilege"))
+	// reads stay safe; every mutation (incl. load/commit) is unsafe by policy
+	assert.True(t, isReplaySafe("Search"))
+	assert.True(t, isReplaySafe("Query"))
+	assert.False(t, isReplaySafe("Delete"))
+	assert.False(t, isReplaySafe("Flush"))
+	assert.False(t, isReplaySafe("LoadCollection"))
+	assert.False(t, isReplaySafe("CommitImport"))
+	assert.False(t, isReplaySafe("AbortImport"))
+}
+
+// wrapperPost must flip the recorder's bodyReceived flag once the full body is
+// read, even if JSON decoding then fails. Engine.HandleContext resets c.Writer,
+// so the handler is invoked directly
+// with the recorder installed as the Writer, matching what timeoutMiddleware
+// hands the handler goroutine.
+func TestWrapperPostSetsBodyReceived(t *testing.T) {
+	paramtable.Init()
+	handler := wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+		return nil, nil
+	})
+
+	send := func(body io.Reader) *timeoutResponseRecorder {
+		recorder := newTimeoutResponseRecorder(&bytes.Buffer{})
+		c := gin.CreateTestContextOnly(httptest.NewRecorder(), gin.New())
+		c.Request = httptest.NewRequest(http.MethodPost, "/bound", body)
+		// wrapperPost asserts the username the auth middleware normally sets
+		c.Set(ContextUsername, "root")
+		c.Writer = recorder
+		handler(c)
+		return recorder
+	}
+
+	assert.True(t, send(bytes.NewReader([]byte(`{}`))).bodyReceived.Load(), "successful bind must set the flag")
+	assert.True(t, send(bytes.NewReader([]byte(`{"bad json`))).bodyReceived.Load(), "decode failure after a complete read must set the flag")
+	assert.False(t, send(iotest.ErrReader(assert.AnError)).bodyReceived.Load(), "body read failure must leave the flag unset")
+}
+
+// Guard against registry drift: every route the middleware can resolve must be
+// explicitly classified as replay-safe (allowlisted) or in the known-unsafe
+// set below. A new route that is neither fails here, forcing a deliberate
+// replay-safety decision instead of silently inheriting the fail-safe 500.
+func TestReplaySafetyCoversAllRoutes(t *testing.T) {
+	knownUnsafe := map[string]struct{}{
+		// replay duplicates data or allocates a second server-side effect
+		"Insert": {}, "Upsert": {}, "Import": {}, "PinSnapshotData": {},
+		"ManualCompaction": {}, "RestoreSnapshot": {}, "RestoreExternalSnapshot": {},
+		"ExportSnapshot": {}, "RefreshExternalCollection": {},
+		// count-delta request (NumReplica), not desired-state: replay moves another batch
+		"TransferMaster": {},
+		// bumps schema version + rebroadcasts even on an identical request
+		"AlterCollectionFunction": {},
+		// expr-delete re-evaluates its predicate at a fresh TSO snapshot per
+		// attempt; partial-apply + replay deletes rows inserted in between
+		"Delete": {},
+		// streaming flush seals newly-created growings on every strictly-newer
+		// attempt (fresh TSO passes the fence) — not convergent under replay
+		"Flush": {},
+		// allowlist is reads-only: every remaining mutation is excluded by policy
+		"LoadCollection": {}, "LoadPartitions": {}, "ReleaseCollection": {}, "ReleasePartitions": {},
+		"CommitImport": {},
+		// self-failed import job re-broadcasts rollback on each abort (not a no-op)
+		"AbortImport": {},
+		// idempotent but control-plane heavy: excluded by policy (see
+		// replaySafeMethods) — unattended retry of admin ops is undesirable
+		"TruncateCollection": {}, "CreateCollection": {}, "DropCollection": {}, "RenameCollection": {},
+		"CreatePartition": {}, "DropPartition": {},
+		"CreateIndex": {}, "DropIndex": {}, "AlterIndex": {},
+		"CreateAlias": {}, "DropAlias": {}, "AlterAlias": {},
+		"CreateDatabase": {}, "DropDatabase": {}, "AlterDatabase": {},
+		"AlterCollection": {}, "AlterCollectionField": {}, "AlterCollectionSchema": {},
+		"AddCollectionFunction": {}, "DropCollectionFunction": {}, "AddCollectionStructField": {},
+		"CreateSnapshot": {}, "DropSnapshot": {}, "UnpinSnapshotData": {},
+		"CreateCredential": {}, "UpdateCredential": {}, "DeleteCredential": {},
+		"CreateRole": {}, "DropRole": {}, "AlterRole": {},
+		"CreatePrivilegeGroup": {}, "DropPrivilegeGroup": {},
+		"OperatePrivilege": {}, "OperatePrivilegeGroup": {}, "OperatePrivilegeV2": {}, "OperateUserRole": {},
+		"CreateResourceGroup": {}, "DropResourceGroup": {}, "UpdateResourceGroups": {},
+		"AddFileResource": {}, "RemoveFileResource": {},
+	}
+	for route, method := range routeToMethod {
+		_, safe := replaySafeMethods[method]
+		_, unsafe := knownUnsafe[method]
+		assert.Truef(t, safe != unsafe,
+			"route %q -> method %q is unclassified (safe=%v unsafe=%v); add it to replaySafeMethods or the known-unsafe set",
+			route, method, safe, unsafe)
+	}
+}
+
+func TestIsRateLimitClass(t *testing.T) {
+	assert.True(t, isRateLimitClass(merr.ErrServiceRateLimit))
+	assert.True(t, isRateLimitClass(merr.ErrHTTPRateLimit))
+	assert.True(t, isRateLimitClass(merr.ErrServiceQuotaExceeded))
+	assert.False(t, isRateLimitClass(merr.ErrServiceNotReady))
+	assert.False(t, isRateLimitClass(assert.AnError))
+	assert.False(t, isRateLimitClass(nil))
+}
+
+// 503 must not be advertised on methods whose replay duplicates data.
+func TestProjectedStatusForMethod(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	const insert = "Insert"
+	const upsert = "Upsert"
+	const search = "Search"
+	// retriable → 503 downgraded to 500 only on replay-unsafe methods
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, insert))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceUnavailable, upsert))
+	assert.Equal(t, http.StatusServiceUnavailable, projectedStatusForMethod(merr.ErrServiceUnavailable, search))
+	// RPC-borne limit codes (4/8/9) can arrive mid-execution, so on a
+	// replay-unsafe method they must not invite a replay; only the HTTP
+	// pre-admission 1807 is provably pre-side-effect and keeps 429 anywhere.
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceRateLimit, insert))
+	assert.Equal(t, http.StatusInternalServerError, projectedStatusForMethod(merr.ErrServiceTooManyRequests, insert))
+	assert.Equal(t, http.StatusTooManyRequests, projectedStatusForMethod(merr.ErrHTTPRateLimit, insert))
+	assert.Equal(t, http.StatusTooManyRequests, projectedStatusForMethod(merr.ErrServiceRateLimit, search))
+	assert.Equal(t, http.StatusBadRequest, projectedStatusForMethod(merr.ErrParameterInvalid, insert))
+}
+
+// Gate-on behavior through the real request path: the status line changes,
+// the body keeps the code/message envelope.
+func TestProjectedStatusThroughHandlers(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	paramtable.Get().Save(key, "true")
+	defer paramtable.Get().Reset(key)
+
+	h := &HandlersV2{metaCache: func() proxy.Cache { return nil }}
+	ginHandler := gin.Default()
+	// wrapperPost asserts ContextUsername unconditionally once binding
+	// succeeds; the auth middleware (auth disabled) is what sets it.
+	app := ginHandler.Group("", genAuthMiddleWare(false))
+	app.POST("/param", wrapperPost(func() any { return &CollectionNameReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+		return nil, nil
+	}))
+	rpcErrRoute := func(rpcErr error) gin.HandlerFunc {
+		return wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
+			return h.wrapperProxy(ctx, c, req, false, false, "/milvus.proto.milvus.MilvusService/Search", func(reqCtx context.Context, req any) (any, error) {
+				return nil, rpcErr
+			})
+		})
+	}
+	// real v2 routes so the route-keyed projection resolves routeToMethod
+	app.POST("/v2/vectordb/entities/hybrid_search", rpcErrRoute(merr.ErrServiceRateLimit))
+	app.POST("/v2/vectordb/entities/search", rpcErrRoute(merr.ErrServiceUnavailable))
+
+	cases := []struct {
+		path       string
+		body       string
+		wantStatus int
+		wantCode   int32
+	}{
+		{"/param", `{}`, http.StatusBadRequest, merr.Code(merr.ErrMissingRequiredParameters)},
+		{"/v2/vectordb/entities/hybrid_search", `{}`, http.StatusTooManyRequests, merr.Code(merr.ErrServiceRateLimit)},
+		{"/v2/vectordb/entities/search", `{}`, http.StatusServiceUnavailable, merr.Code(merr.ErrServiceUnavailable)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader([]byte(tc.body)))
+			w := httptest.NewRecorder()
+			ginHandler.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			returnBody := &ReturnErrMsg{}
+			assert.Nil(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, tc.wantCode, returnBody.Code)
+		})
+	}
+}

--- a/internal/distributed/proxy/httpserver/status_projection_test.go
+++ b/internal/distributed/proxy/httpserver/status_projection_test.go
@@ -23,19 +23,31 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"testing/iotest"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+type timeoutReadError struct{}
+
+func (timeoutReadError) Error() string { return "request body read timeout" }
+func (timeoutReadError) Timeout() bool { return true }
 
 func TestErrToHTTPStatus(t *testing.T) {
 	cases := []struct {
@@ -60,7 +72,9 @@ func TestErrToHTTPStatus(t *testing.T) {
 		{"non-merr error", assert.AnError, http.StatusInternalServerError},
 		{"deadline exceeded", context.DeadlineExceeded, http.StatusInternalServerError},
 		{"canceled without provenance", context.Canceled, http.StatusInternalServerError},
-		{"raw grpc InvalidArgument", status.Error(codes.InvalidArgument, "x"), http.StatusBadRequest},
+		{"raw grpc InvalidArgument is ambiguous", status.Error(codes.InvalidArgument, "x"), http.StatusInternalServerError},
+		{"system-marked raw grpc InvalidArgument", merr.WrapErrAsSysError(status.Error(codes.InvalidArgument, "x")), http.StatusInternalServerError},
+		{"explicitly marked raw grpc InvalidArgument", merr.WrapErrAsInputError(status.Error(codes.InvalidArgument, "x")), http.StatusBadRequest},
 		{"raw grpc Unauthenticated", status.Error(codes.Unauthenticated, "x"), http.StatusUnauthorized},
 		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), http.StatusForbidden},
 		{"raw grpc Unavailable", status.Error(codes.Unavailable, "x"), http.StatusInternalServerError},
@@ -83,7 +97,10 @@ func TestErrorTypeForAccessLog(t *testing.T) {
 	}{
 		{"merr input", merr.ErrParameterInvalid, merr.InputError},
 		{"merr system", merr.ErrServiceInternal, merr.SystemError},
-		{"raw grpc InvalidArgument", status.Error(codes.InvalidArgument, "x"), merr.InputError},
+		{"schema mismatch HTTP override", merr.ErrCollectionSchemaMismatch, merr.SystemError},
+		{"raw grpc InvalidArgument is ambiguous", status.Error(codes.InvalidArgument, "x"), merr.SystemError},
+		{"system-marked raw grpc InvalidArgument", merr.WrapErrAsSysError(status.Error(codes.InvalidArgument, "x")), merr.SystemError},
+		{"explicitly marked raw grpc InvalidArgument", merr.WrapErrAsInputError(status.Error(codes.InvalidArgument, "x")), merr.InputError},
 		{"raw grpc Unauthenticated", status.Error(codes.Unauthenticated, "x"), merr.InputError},
 		{"raw grpc PermissionDenied", status.Error(codes.PermissionDenied, "x"), merr.InputError},
 		{"raw grpc Unavailable", status.Error(codes.Unavailable, "x"), merr.SystemError},
@@ -123,6 +140,43 @@ func TestProjectedStatusGate(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, projectedStatus(merr.ErrServiceRateLimit))
 	assert.Equal(t, http.StatusBadRequest, projectedStatus(merr.ErrParameterInvalid))
 	assert.Equal(t, http.StatusOK, projectedStatus(nil))
+}
+
+func TestIdempotencyKeyHandlerProjectsOnlyV2Errors(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	defer paramtable.Get().Reset(key)
+
+	engine := gin.New()
+	engine.Use(IdempotencyKeyHandlerFunc)
+	engine.POST("/v1/vector/insert", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	engine.POST("/v2/vectordb/entities/insert", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+	tests := []struct {
+		name    string
+		enabled bool
+		path    string
+		want    int
+	}{
+		{"default v2 keeps legacy envelope", false, "/v2/vectordb/entities/insert", http.StatusOK},
+		{"enabled v1 keeps legacy envelope", true, "/v1/vector/insert", http.StatusOK},
+		{"enabled v2 projects input error", true, "/v2/vectordb/entities/insert", http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			paramtable.Get().Save(key, strconv.FormatBool(tc.enabled))
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			req.Header.Set(HTTPHeaderIdempotencyKey, "invalid\tkey")
+			w := httptest.NewRecorder()
+
+			engine.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.want, w.Code)
+			response := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), response))
+			assert.Equal(t, merr.Code(merr.ErrParameterInvalid), response.Code)
+		})
+	}
 }
 
 func TestProjectedStatusForRequest(t *testing.T) {
@@ -171,16 +225,84 @@ func TestProjectedAuthorizationStatus(t *testing.T) {
 }
 
 func TestMiddlewareTimeoutStatus(t *testing.T) {
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(true, false))
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false, false))
+	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false, true))
+	assert.Equal(t, http.StatusInternalServerError, middlewareTimeoutStatus(true, true))
+}
+
+func TestWrapperPostClassifiesBodyReadFailures(t *testing.T) {
 	paramtable.Init()
 	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
-
-	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(true))
-	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
-
-	paramtable.Get().Save(key, "true")
 	defer paramtable.Get().Reset(key)
-	assert.Equal(t, http.StatusRequestTimeout, middlewareTimeoutStatus(false))
-	assert.Equal(t, http.StatusInternalServerError, middlewareTimeoutStatus(true))
+
+	cases := []struct {
+		name          string
+		enabled       bool
+		body          io.Reader
+		cancelRequest bool
+		wantStatus    int
+		wantErrorType bool
+	}{
+		{"legacy timeout", false, iotest.ErrReader(timeoutReadError{}), false, http.StatusOK, false},
+		{"malformed JSON", true, bytes.NewBufferString(`{"x"`), false, http.StatusBadRequest, false},
+		{"client canceled", true, iotest.ErrReader(assert.AnError), true, statusClientClosedRequest, true},
+		{"receive timeout", true, iotest.ErrReader(timeoutReadError{}), false, http.StatusRequestTimeout, true},
+		{"other read failure", true, iotest.ErrReader(assert.AnError), false, http.StatusInternalServerError, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			paramtable.Get().Save(key, strconv.FormatBool(tc.enabled))
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req := httptest.NewRequest(http.MethodPost, "/bind", tc.body)
+			if tc.cancelRequest {
+				ctx, cancel := context.WithCancel(req.Context())
+				cancel()
+				req = req.WithContext(ctx)
+			}
+			c.Request = req
+			called := false
+			wrapperPost(func() any { return &DefaultReq{} }, func(context.Context, *gin.Context, any, string) (interface{}, error) {
+				called = true
+				return nil, nil
+			})(c)
+
+			assert.False(t, called)
+			assert.Equal(t, tc.wantStatus, w.Code)
+			body := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), body))
+			assert.Equal(t, merr.Code(merr.ErrIncorrectParameterFormat), body.Code)
+			_, hasErrorType := c.Get("error_type")
+			assert.Equal(t, tc.wantErrorType, hasErrorType)
+			if hasErrorType {
+				assert.Equal(t, merr.SystemError.String(), c.GetString("error_type"))
+			}
+		})
+	}
+}
+
+func TestTimeoutMiddlewareInstallsBodyTrackerOnlyWhenProjectionEnabled(t *testing.T) {
+	paramtable.Init()
+	key := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	defer paramtable.Get().Reset(key)
+
+	for _, enabled := range []bool{false, true} {
+		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
+			paramtable.Get().Save(key, strconv.FormatBool(enabled))
+			tracked := make(chan bool, 1)
+			engine := gin.New()
+			engine.POST("/track", timeoutMiddleware(func(c *gin.Context) {
+				_, ok := c.Request.Body.(*bodyReadTracker)
+				tracked <- ok
+				c.Status(http.StatusNoContent)
+			}))
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/track", bytes.NewBufferString(`{}`)))
+			assert.Equal(t, enabled, <-tracked)
+		})
+	}
 }
 
 func TestBodyReadTracker(t *testing.T) {
@@ -214,14 +336,15 @@ func TestTimeoutMiddlewareClassifiesBodyReceipt(t *testing.T) {
 	defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.StandardErrorStatus.Key)
 	defer paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
 
+	completeHandlerRelease := make(chan struct{})
 	ginHandler := gin.New()
 	ginHandler.Use(func(c *gin.Context) {
 		c.Set(ContextUsername, "root")
 		c.Next()
 	})
 	ginHandler.POST("/complete", timeoutMiddleware(wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
-		<-ctx.Done()
-		return nil, ctx.Err()
+		<-completeHandlerRelease
+		return nil, nil
 	})))
 	ginHandler.POST("/incomplete", timeoutMiddleware(wrapperPost(func() any { return &DefaultReq{} }, func(ctx context.Context, c *gin.Context, req any, dbName string) (interface{}, error) {
 		return nil, nil
@@ -230,6 +353,7 @@ func TestTimeoutMiddlewareClassifiesBodyReceipt(t *testing.T) {
 	completeReq := httptest.NewRequest(http.MethodPost, "/complete", bytes.NewReader([]byte(`{}`)))
 	completeResp := httptest.NewRecorder()
 	ginHandler.ServeHTTP(completeResp, completeReq)
+	close(completeHandlerRelease)
 	assert.Equal(t, http.StatusInternalServerError, completeResp.Code)
 
 	reader, writer := io.Pipe()
@@ -281,6 +405,55 @@ func TestProjectedStatusThroughHandlers(t *testing.T) {
 			returnBody := &ReturnErrMsg{}
 			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
 			assert.Equal(t, tc.wantCode, returnBody.Code)
+		})
+	}
+}
+
+func TestMalformedMutationResponseCountsAsProcessedFailure(t *testing.T) {
+	paramtable.Init()
+	standardStatusKey := paramtable.Get().HTTPCfg.StandardErrorStatus.Key
+	quotaKey := paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key
+	paramtable.Get().Save(standardStatusKey, "true")
+	paramtable.Get().Save(quotaKey, "false")
+	defer paramtable.Get().Reset(standardStatusKey)
+	defer paramtable.Get().Reset(quotaKey)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Twice()
+	mp.EXPECT().Insert(mock.Anything, mock.Anything).Return(&milvuspb.MutationResult{
+		Status: commonSuccessStatus,
+		IDs:    &schemapb.IDs{},
+	}, nil).Once()
+	mp.EXPECT().Upsert(mock.Anything, mock.Anything).Return(&milvuspb.MutationResult{
+		Status: commonSuccessStatus,
+		IDs:    &schemapb.IDs{},
+	}, nil).Once()
+	server := initHTTPServerV2(mp, false)
+	body := `{"collectionName":"book","data":[{"book_id":1,"word_count":10,"book_intro":[0.1,0.2]}]}`
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+
+	for _, action := range []string{InsertAction, UpsertAction} {
+		t.Run(action, func(t *testing.T) {
+			path := versionalV2(EntityCategory, action)
+			method := routeToMethod[path]
+			failed := metrics.ProxyFunctionCall.WithLabelValues(nodeID, method, metrics.FailLabel, metrics.CauseSystem, DefaultDbName, "book")
+			rejected := metrics.ProxyFunctionCall.WithLabelValues(nodeID, method, metrics.RejectedLabel, metrics.CauseSystem, DefaultDbName, "book")
+			failedBefore := testutil.ToFloat64(failed)
+			rejectedBefore := testutil.ToFloat64(rejected)
+
+			w := httptest.NewRecorder()
+			server.ServeHTTP(w, httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body)))
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			response := &ReturnErrMsg{}
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), response))
+			assert.Equal(t, merr.Code(merr.ErrCheckPrimaryKey), response.Code)
+			assert.Equal(t, failedBefore+1, testutil.ToFloat64(failed))
+			assert.Equal(t, rejectedBefore, testutil.ToFloat64(rejected))
 		})
 	}
 }

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -71,6 +72,12 @@ type timeoutResponseRecorder struct {
 	status      int
 	size        int
 	closeNotify chan bool
+	// bodyReceived flips once wrapperPost finishes reading the request body; the
+	// timer branch reads it to tell a slow-upload 408 from a server-side 500.
+	// It lives here because the recorder is the per-request object both sides
+	// already share (via handlerCtx.Writer) — no extra allocation or context-key
+	// traffic on the hot path.
+	bodyReceived atomic.Bool
 }
 
 func newTimeoutResponseRecorder(buf *bytes.Buffer) *timeoutResponseRecorder {
@@ -222,6 +229,9 @@ var timeoutContextKeysToPropagate = []string{
 	ContextRequest,
 	ContextResponse,
 	"traceID",
+	// key must match accesslog/info.ContextErrorType; without it the access
+	// log falls back to the numeric body code and misses boundary relabels.
+	"error_type",
 }
 
 func propagateTimeoutContextKeys(dst *gin.Context, src *gin.Context) {
@@ -243,7 +253,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		if requestTimeout != "" {
 			timeoutSecond, err := strconv.ParseInt(requestTimeout, 10, 64)
 			if err != nil {
-				HTTPAbortReturn(gCtx, http.StatusOK, gin.H{
+				HTTPAbortReturn(gCtx, projectedStatus(merr.ErrParameterInvalid), gin.H{
 					mhttp.HTTPReturnCode: merr.Code(merr.ErrParameterInvalid),
 					mhttp.HTTPReturnMessage: merr.WrapErrParameterInvalidMsg(
 						"%s parse failed, err: %s",
@@ -318,7 +328,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 			if traceID, ok := getTraceID(gCtx); ok {
 				setTraceIDHeaderTo(realWriter.Header(), traceID)
 			}
-			realWriter.WriteHeader(http.StatusRequestTimeout)
+			realWriter.WriteHeader(middlewareTimeoutStatus(recorder.bodyReceived.Load()))
 			body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
 			realWriter.Write(body)
 		}

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -72,12 +73,28 @@ type timeoutResponseRecorder struct {
 	status      int
 	size        int
 	closeNotify chan bool
-	// bodyReceived flips once wrapperPost finishes reading the request body; the
+	// bodyReceived flips when the decoder reaches the request body's EOF; the
 	// timer branch reads it to tell a slow-upload 408 from a server-side 500.
 	// It lives here because the recorder is the per-request object both sides
 	// already share (via handlerCtx.Writer) — no extra allocation or context-key
 	// traffic on the hot path.
 	bodyReceived atomic.Bool
+}
+
+// bodyReadTracker marks the request body complete only when the underlying
+// stream reaches EOF. The decoder remains the sole reader, so read failures are
+// returned unchanged and a partially consumed body is never read a second time.
+type bodyReadTracker struct {
+	io.ReadCloser
+	bodyReceived *atomic.Bool
+}
+
+func (r *bodyReadTracker) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err == io.EOF {
+		r.bodyReceived.Store(true)
+	}
+	return n, err
 }
 
 func newTimeoutResponseRecorder(buf *bytes.Buffer) *timeoutResponseRecorder {
@@ -252,14 +269,24 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		requestTimeout := gCtx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout)
 		if requestTimeout != "" {
 			timeoutSecond, err := strconv.ParseInt(requestTimeout, 10, 64)
-			if err != nil {
-				HTTPAbortReturn(gCtx, projectedStatus(merr.ErrParameterInvalid), gin.H{
-					mhttp.HTTPReturnCode: merr.Code(merr.ErrParameterInvalid),
-					mhttp.HTTPReturnMessage: merr.WrapErrParameterInvalidMsg(
+			const maxRequestTimeoutSeconds = int64(1<<63-1) / int64(time.Second)
+			if err != nil || timeoutSecond <= 0 || timeoutSecond > maxRequestTimeoutSeconds {
+				invalidErr := merr.WrapErrParameterInvalidMsg(
+					"%s must be an integer between 1 and %d seconds, actual: %s",
+					mhttp.HTTPHeaderRequestTimeout,
+					maxRequestTimeoutSeconds,
+					requestTimeout,
+				)
+				if err != nil {
+					invalidErr = merr.WrapErrParameterInvalidMsg(
 						"%s parse failed, err: %s",
 						mhttp.HTTPHeaderRequestTimeout,
 						err.Error(),
-					).Error(),
+					)
+				}
+				HTTPAbortReturn(gCtx, projectedStatus(invalidErr), gin.H{
+					mhttp.HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+					mhttp.HTTPReturnMessage: invalidErr.Error(),
 				})
 				return
 			}
@@ -277,6 +304,9 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		buffer := bufPool.Get()
 		buffer.Reset()
 		recorder := newTimeoutResponseRecorder(buffer)
+		if req.Body != nil {
+			req.Body = &bodyReadTracker{ReadCloser: req.Body, bodyReceived: &recorder.bodyReceived}
+		}
 		handlerCtx := gCtx.Copy()
 		handlerCtx.Request = req
 		handlerCtx.Writer = recorder

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -265,6 +265,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 	}
 	bufPool := &BufferPool{}
 	return func(gCtx *gin.Context) {
+		standardErrorStatus := paramtable.Get().HTTPCfg.StandardErrorStatus.GetAsBool()
 		timeout := paramtable.Get().HTTPCfg.RequestTimeoutMs.GetAsDuration(time.Millisecond)
 		requestTimeout := gCtx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout)
 		if requestTimeout != "" {
@@ -304,7 +305,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		buffer := bufPool.Get()
 		buffer.Reset()
 		recorder := newTimeoutResponseRecorder(buffer)
-		if req.Body != nil {
+		if standardErrorStatus && req.Body != nil {
 			req.Body = &bodyReadTracker{ReadCloser: req.Body, bodyReceived: &recorder.bodyReceived}
 		}
 		handlerCtx := gCtx.Copy()
@@ -358,7 +359,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 			if traceID, ok := getTraceID(gCtx); ok {
 				setTraceIDHeaderTo(realWriter.Header(), traceID)
 			}
-			realWriter.WriteHeader(middlewareTimeoutStatus(recorder.bodyReceived.Load()))
+			realWriter.WriteHeader(middlewareTimeoutStatus(recorder.bodyReceived.Load(), standardErrorStatus))
 			body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
 			realWriter.Write(body)
 		}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -4480,12 +4480,21 @@ func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent
 
 	request, ok := req.(proto.Message)
 	if !ok {
-		return nil, merr.WrapErrParameterInvalidMsg("wrong req format when check limiter")
+		return nil, merr.WrapErrAsSysError(merr.WrapErrParameterInvalidMsg("wrong req format when check limiter"))
 	}
 
 	metaCache := getProxyMetaCache(pxy)
 	dbID, collectionIDToPartIDs, rt, n, err := proxy.GetRequestInfo(ctx, metaCache(), request)
 	if err != nil {
+		// A caller lookup failure (input-classified at the proxy meta boundary)
+		// cannot be a limit rejection — proceed and let the handler surface the
+		// real error, mirroring the gRPC rate_limit_interceptor. Anything else
+		// (meta cache not ready, transient fetch failures) must not fail open
+		// into unmetered traffic: hand it back as the server error it is.
+		if merr.GetErrorType(err) == merr.InputError {
+			mlog.RatedWarn(ctx, 1, "httpV1/V2 server fail to resolve request for limiter, proceed without rate check", mlog.Err(err))
+			return nil, nil
+		}
 		return nil, err
 	}
 	err = limiter.Check(dbID, collectionIDToPartIDs, rt, n)

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -4467,20 +4467,26 @@ func formatInt64(intArray []int64) []string {
 	return stringArray
 }
 
-func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent) (any, error) {
+// CheckLimiter returns limited=true only when the HTTP-layer limiter made an
+// explicit pre-execution rejection. Errors from acquiring or preparing the
+// limiter are infrastructure failures and return limited=false.
+func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent) (limited bool, err error) {
 	if !paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.GetAsBool() {
-		return nil, nil
+		return false, nil
 	}
 	// apply limiter for http/http2 server
 	limiter, err := pxy.GetRateLimiter()
 	if err != nil {
 		mlog.Error(ctx, "Get proxy rate limiter for httpV1/V2 server failed", mlog.Err(err))
-		return nil, err
+		// GetRateLimiter historically reports an uninitialized limiter with a
+		// parameter-invalid sentinel, but at this boundary it is infrastructure,
+		// never a client input error.
+		return false, merr.WrapErrAsSysError(err)
 	}
 
 	request, ok := req.(proto.Message)
 	if !ok {
-		return nil, merr.WrapErrAsSysError(merr.WrapErrParameterInvalidMsg("wrong req format when check limiter"))
+		return false, merr.WrapErrAsSysError(merr.WrapErrParameterInvalidMsg("wrong req format when check limiter"))
 	}
 
 	metaCache := getProxyMetaCache(pxy)
@@ -4493,19 +4499,19 @@ func CheckLimiter(ctx context.Context, req interface{}, pxy types.ProxyComponent
 		// into unmetered traffic: hand it back as the server error it is.
 		if merr.GetErrorType(err) == merr.InputError {
 			mlog.RatedWarn(ctx, 1, "httpV1/V2 server fail to resolve request for limiter, proceed without rate check", mlog.Err(err))
-			return nil, nil
+			return false, nil
 		}
-		return nil, err
+		return false, err
 	}
 	err = limiter.Check(dbID, collectionIDToPartIDs, rt, n)
 	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
 	metrics.ProxyRateLimitReqCount.WithLabelValues(nodeID, rt.String(), metrics.TotalLabel).Inc()
 	if err != nil {
 		metrics.ProxyRateLimitReqCount.WithLabelValues(nodeID, rt.String(), metrics.FailLabel).Inc()
-		return proxy.GetFailedResponse(req, err), err
+		return true, err
 	}
 	metrics.ProxyRateLimitReqCount.WithLabelValues(nodeID, rt.String(), metrics.SuccessLabel).Inc()
-	return nil, nil
+	return false, nil
 }
 
 func convertConsistencyLevel(reqConsistencyLevel string) (commonpb.ConsistencyLevel, bool, error) {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -5624,7 +5624,14 @@ func IdempotencyKeyHandlerFunc(c *gin.Context) {
 	// unchecked key would ride along on every coordinator RPC of any v1 or v2
 	// route -- see ValidateIdempotencyKey for what that costs.
 	if err := interceptor.ValidateIdempotencyKey(key); err != nil {
-		HTTPAbortReturn(c, http.StatusOK, gin.H{
+		status := http.StatusOK
+		// This middleware is registered on the whole HTTP engine, before the v1
+		// and v2 groups diverge. Apply the opt-in projection only to v2 so v1 and
+		// the default disabled mode retain the legacy 200 envelope.
+		if strings.HasPrefix(c.FullPath(), "/v2/vectordb/") {
+			status = projectedStatus(err)
+		}
+		HTTPAbortReturn(c, status, gin.H{
 			HTTPReturnCode:    merr.Code(err),
 			HTTPReturnMessage: err.Error(),
 		})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -429,7 +429,7 @@ func (node *Proxy) SetQueryNodeCreator(f func(ctx context.Context, addr string, 
 // GetRateLimiter returns the rateLimiter in Proxy.
 func (node *Proxy) GetRateLimiter() (types.Limiter, error) {
 	if node.simpleLimiter == nil {
-		return nil, merr.WrapErrServiceUnavailable("rate limiter not initialized in Proxy")
+		return nil, merr.WrapErrParameterInvalidMsg("nil rate limiter in Proxy")
 	}
 	return node.simpleLimiter, nil
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -429,7 +429,7 @@ func (node *Proxy) SetQueryNodeCreator(f func(ctx context.Context, addr string, 
 // GetRateLimiter returns the rateLimiter in Proxy.
 func (node *Proxy) GetRateLimiter() (types.Limiter, error) {
 	if node.simpleLimiter == nil {
-		return nil, merr.WrapErrParameterInvalidMsg("nil rate limiter in Proxy")
+		return nil, merr.WrapErrServiceUnavailable("rate limiter not initialized in Proxy")
 	}
 	return node.simpleLimiter, nil
 }

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -26,6 +26,7 @@ type httpConfig struct {
 	NativeJSONResponse    ParamItem `refreshable:"true"`
 	LegacyArrayResponse   ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
+	StandardErrorStatus   ParamItem `refreshable:"true"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
 	DQLAdmissionEnabled   ParamItem `refreshable:"true"`
 	ReadHeaderTimeout     ParamItem `refreshable:"false"`
@@ -141,6 +142,25 @@ string wherever one appears, including inside either kind of array.`,
 		Export:       true,
 	}
 	p.EnablePprof.Init(base.mgr)
+
+	p.StandardErrorStatus = ParamItem{
+		Key:          "proxy.http.standardErrorStatus",
+		DefaultValue: "false",
+		Version:      "3.0.2",
+		Doc: `high-level restful api, project business errors to standard HTTP statuses instead of always returning
+200 with the error only in the body (v2 endpoints only; the body keeps the same code/message envelope either way).
+Mapping: input 400, auth 401/403, rate/quota 429, proven client cancellation 499, retriable system 503, incomplete
+request upload timeout 408, and server-side timeout/other system errors 500. Explicitly retriable statuses (503 and
+429 from RPC-borne limit codes) are advertised only for read operations, which mutate nothing and are safe to
+replay; mutations surface them as a generic 500 to avoid claiming that replay is safe. A 500 does not prevent a
+gateway configured to retry every 5xx, so clients and gateways must not automatically replay mutation routes
+without idempotency or proof that the request was not applied. Pre-execution limiter infrastructure 503 and HTTP
+pre-admission 429 can apply to both read and mutation routes because no business side effect has started.
+Off by default; enabling flips access-log method_status from Failed to HttpError<code>.`,
+		PanicIfEmpty: false,
+		Export:       true,
+	}
+	p.StandardErrorStatus.Init(base.mgr)
 
 	p.RequestTimeoutMs = ParamItem{
 		Key:          "proxy.http.requestTimeoutMs",

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -149,13 +149,11 @@ string wherever one appears, including inside either kind of array.`,
 		Version:      "3.0.2",
 		Doc: `high-level restful api, project business errors to standard HTTP statuses instead of always returning
 200 with the error only in the body (v2 endpoints only; the body keeps the same code/message envelope either way).
-Mapping: input 400, auth 401/403, rate/quota 429, proven client cancellation 499, retriable system 503, incomplete
-request upload timeout 408, and server-side timeout/other system errors 500. Explicitly retriable statuses (503 and
-429 from RPC-borne limit codes) are advertised only for read operations, which mutate nothing and are safe to
-replay; mutations surface them as a generic 500 to avoid claiming that replay is safe. A 500 does not prevent a
-gateway configured to retry every 5xx, so clients and gateways must not automatically replay mutation routes
-without idempotency or proof that the request was not applied. Pre-execution limiter infrastructure 503 and HTTP
-pre-admission 429 can apply to both read and mutation routes because no business side effect has started.
+Mapping: explicit input 400, explicit authentication/authorization 401/403, HTTP-layer pre-execution rejection 429,
+proven client cancellation 499, incomplete request upload timeout 408, and every other error 500. The projection uses
+only facts proven at the HTTP boundary; downstream limit, retryable, timeout, and unknown errors all remain 500. A
+status does not prevent gateways from retrying, so mutation routes still require gateway retry exclusions or
+end-to-end idempotency when duplicate execution must be impossible.
 Off by default; enabling flips access-log method_status from Failed to HttpError<code>.`,
 		PanicIfEmpty: false,
 		Export:       true,


### PR DESCRIPTION
issue: #52991 (Section 1 — error projection)

## What

The v2 REST layer returns business errors in a code/message body envelope, but
most failures historically kept HTTP 200. Status-driven clients, gateways,
SLOs, and alerts therefore could not classify failures without parsing the
body.

This PR adds an opt-in projection layer behind
`proxy.http.standardErrorStatus` while preserving the existing body envelope:

| failure | HTTP status |
|---|---|
| explicitly classified input error | 400 |
| explicit authentication / authorization failure | 401 / 403 |
| incomplete request upload timeout | 408 |
| HTTP-layer pre-execution rate limit | 429 |
| proven client cancellation | 499 |
| every other error | 500 |

The projection uses only facts proven at the HTTP boundary. Raw gRPC
`Unauthenticated` and `PermissionDenied` retain their explicit 401/403
semantics; raw `InvalidArgument`, `Unavailable`, downstream rate/quota errors,
retryable errors, and timeouts after body receipt remain 500 unless an
explicit `merr` input classification proves the request is invalid.
`CollectionSchemaMismatch` remains a deliberate 500 exception because the
shared sentinel is input-classified for legacy consumers but represents a
transient schema-version race at this boundary.

## Retry semantics

The projection does not distinguish read and mutation routes and does not
claim that any status prevents retries. HTTP 500 can still be retried by a
client or gateway configured for generic 5xx retries, so mutation routes need
gateway retry exclusions or an end-to-end idempotency mechanism when duplicate
execution must be impossible.

## Cancellation and timeout provenance

- A cancellation becomes 499 only when both the returned error is canceled and
  the HTTP request context proves that the client went away.
- A timeout while the request body is still incomplete returns 408.
- Every timeout after body receipt and every timeout without client-cancellation
  proof returns 500.

## Compatibility and observability

- The switch is off by default and applies only to v2 endpoints.
- The body keeps the same code/message envelope in both modes.
- Auth failures keep their existing 401/403 behavior regardless of the switch.
- Access logs record the projected `input_error` / `system_error`
  classification, including recognized raw gRPC authentication and
  authorization errors.
- Invalid `enableDynamicField` values retain parameter-invalid code 1100
  instead of the generic unexpected code.

## Tests

- Projection buckets, raw gRPC provenance, cancellation, timeout, and wire
  round-trip coverage.
- Handler-level request parsing, rate limiting, idempotency-key validation,
  response conversion, access-log classification, and timeout-boundary
  coverage.
