### PR TITLE
test: align boost-ranker invalid-filter assertion with server wording

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
@@ -809,5 +809,5 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
+            check_items={"err_code": 1100, "err_msg": "parse scorer filter failed"},
         )


### PR DESCRIPTION
`test_search_boost_ranker_invalid_filter` asserts that the error message for an
invalid boost-ranker filter contains `parse expr failed`. That wording no longer
exists anywhere in the server, so the case fails deterministically on master.

#52778 (6648d9371b) changed `CreateSearchScorer` from

```go
return nil, merr.WrapErrQueryPlan(err, "parse expr failed")
```

to

```go
// merr.Wrap, not WrapErrQueryPlan: the latter replaces the inner
// code, so an over-limit scorer filter surfaced as 2201 while the
// identical main predicate surfaced as 1102.
return nil, merr.Wrap(err, "parse scorer filter failed")
```

The server still rejects the request as intended, with the same code the test
expects — preserving that code was the point of the change. Only the
human-readable substring moved, so this is a stale assertion, not a product
regression.

## Change

```diff
-            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
+            check_items={"err_code": 1100, "err_msg": "parse scorer filter failed"},
```

`parse scorer filter failed` is the current server phrase, and it matches the
convention of the other three cases in this file, which each pin the specific
server-side phrase for the failure under test (`must set weight params`,
`segment scorer with group_by`).

## Verification

- `parse expr failed` appears nowhere in `internal/`, `pkg/` or `tests/` after
  this change — the assertion could never have matched.
- `parse scorer filter failed` is emitted at
  `internal/parser/planparserv2/plan_parser_v2.go:447`, and is a substring of
  the message quoted in the issue:
  `failed to create query plan: parse scorer filter failed: cannot parse expression: ...`
- `CheckTasks.err_res` compares `err_msg` as a plain substring
  (`tests/python_client/check/func_check.py:172`); the `err_code` assertion
  there is commented out, so the substring was the only failing condition.
- Swept the other error literals changed by 6648d9371b (the
  `bloom_match`/`roaring_match` → `membership_match` rename): the integration
  suites exercising them were updated in that same commit, so this is the only
  assertion the refactor left stranded. The other three assertions in this file
  still match current source.

**Not verified:** the case was not executed against a live server — no Milvus
instance was available in the environment this was prepared in. The change is
verified statically against the message quoted in the issue.

issue: #53083

🤖 Generated with [Claude Code](https://claude.com/claude-code)