### PR TITLE
fix: use sparse data type for index raw data estimation

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -559,9 +559,10 @@ IndexFactory::VecIndexLoadResource(
                                      num_rows,
                                      dim,
                                      config);
-            has_raw_data =
-                knowhere::IndexStaticFaced<knowhere::fp32>::HasRawData(
-                    index_type, index_version, config);
+            has_raw_data = knowhere::IndexStaticFaced<
+                knowhere::sparse_u32_f32>::HasRawData(index_type,
+                                                      index_version,
+                                                      config);
             break;
         case milvus::DataType::VECTOR_INT8:
             resource = knowhere::IndexStaticFaced<

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -338,6 +338,24 @@ TEST_P(IndexLoadTest, ResourceEstimate) {
     ASSERT_EQ(request.max_disk_cost, expected.max_disk_cost);
 }
 
+TEST(IndexLoadTest, SparseIndexResourceEstimateHasRawData) {
+    milvus::segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_type = milvus::DataType::VECTOR_SPARSE_U32_F32;
+    load_index_info.element_type = milvus::DataType::NONE;
+    load_index_info.index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC},
+        {"metric_type", knowhere::metric::IP},
+    };
+    load_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    load_index_info.index_size = 1024 * 1024;
+    load_index_info.num_rows = 1024;
+
+    auto request = EstimateLoadIndexResource(&load_index_info);
+
+    EXPECT_TRUE(request.has_raw_data);
+}
+
 TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
     milvus::segcore::LoadIndexInfo loadIndexInfo;
     ASSERT_FALSE(loadIndexInfo.load_resource_request.has_value());


### PR DESCRIPTION
## What this PR does

Fix sparse index resource estimation to query Knowhere's static capabilities through `IndexStaticFaced<knowhere::sparse_u32_f32>`.

Fixes #53105

## Root cause

`IndexFactory::VecIndexLoadResource` already used the sparse data type when estimating the resource cost, but the subsequent `HasRawData` query used the dense `knowhere::fp32` specialization.

Sparse index implementations are registered in Knowhere's `sparse_u32_f32` static registry. Looking them up in the `fp32` registry therefore missed the index type, emitted `unhandled create config for indexType`, fell back to `BaseConfig`, and returned `has_raw_data=false`.

## Impact

- Every sparse index resource estimate could emit a Knowhere warning, adding avoidable log pressure on a frequently called QueryNode path.
- The fallback result was functionally wrong for internal concurrent sparse indexes that retain raw data. In particular, `SPARSE_INVERTED_INDEX_CC` with metric `IP` reports `has_raw_data=true` through the correct sparse specialization.
- For ordinary sealed `SPARSE_INVERTED_INDEX`, the result remains `false`; this change removes the incorrect lookup and warning without changing that expected result.

## Changes

- Use the `sparse_u32_f32` specialization for the sparse-vector `HasRawData` query.
- Add a regression test using `SPARSE_INVERTED_INDEX_CC` with `IP`, whose expected `has_raw_data=true` distinguishes the registered sparse handler from fallback behavior.

## Verification

- [x] Built Milvus C++ code successfully on macOS arm64.
- [x] Passed `IndexLoadTest.SparseIndexResourceEstimateHasRawData`.
- [x] Passed the new test plus all 22 parameterized index resource-estimation cases (23 tests total).
- [x] Confirmed the test output contains no `unhandled create config` warning.
- [x] Passed `git diff --check`.
- [ ] `make verifiers` completed the full C++ build, then stopped at the formatting gate because `clang-format-15` is not installed locally (the available formatter is clang-format 19). No code or test failure was reported before that environment check.
