### PR TITLE
enhance: [2.6] reject RESTful DQL requests before decode when queue is full

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -381,6 +381,11 @@ proxy:
     port:  # high-level restful api
     acceptTypeAllowInt64: true # high-level restful api, whether http client can deal with int64
     enablePprof: true # Whether to enable pprof middleware on the metrics port
+    # high-level restful api, reject a search/query request with HTTP 429 while the proxy's DQL task
+    # queue is full, before the request body is decoded. The scheduler rejects such a request with the same
+    # TooManyRequests error anyway, but only after the body has been decoded; admission moves the same verdict before that
+    # cost. Disabling restores the old always-decode behavior.
+    dqlAdmissionEnabled: true
     hstsMaxAge: 31536000 # Strict-Transport-Security max-age in seconds
     hstsIncludeSubDomains: false # Include subdomains in Strict-Transport-Security
     enableHSTS: false # Whether to enable setting the Strict-Transport-Security header

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -58,14 +58,60 @@ import (
 )
 
 type HandlersV2 struct {
-	proxy     types.ProxyComponent
-	checkAuth bool
+	proxy        types.ProxyComponent
+	dqlQueueFull func() bool
+	checkAuth    bool
 }
 
+// The probe NewHandlersV2 asserts for must stay on the concrete proxy: a
+// rename must fail the build rather than silently disable admission.
+var _ interface{ IsDQLQueueFull() bool } = (*proxy.Proxy)(nil)
+
 func NewHandlersV2(proxyClient types.ProxyComponent) *HandlersV2 {
-	return &HandlersV2{
-		proxy:     proxyClient,
-		checkAuth: proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool(),
+	h := &HandlersV2{
+		proxy:        proxyClient,
+		dqlQueueFull: func() bool { return false },
+		checkAuth:    proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool(),
+	}
+	// a component without the probe (e.g. a remote proxy client) admits everything
+	if provider, ok := proxyClient.(interface{ IsDQLQueueFull() bool }); ok {
+		h.dqlQueueFull = provider.IsDQLQueueFull
+	}
+	return h
+}
+
+// dqlAdmission rejects a DQL request with 429 while the proxy's DQL queue is
+// full, before the body is decoded. The scheduler's Enqueue stays the
+// authority; this only pre-fires the TooManyRequests verdict Enqueue would
+// return after the decoding cost had already been paid, so admitting a request
+// that later hits a full queue (or vice versa) is benign.
+func (h *HandlersV2) dqlAdmission(handler gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if paramtable.Get().HTTPCfg.DQLAdmissionEnabled.GetAsBool() && h.dqlQueueFull() {
+			err := merr.WrapErrTooManyRequests(int32(proxy.Params.ProxyCfg.MaxTaskNum.GetAsInt()))
+			// admission aborts before wrapperPost, the only ProxyFunctionCall
+			// site for v2 routes, so the rejection is recorded here. The
+			// method comes from the route; db and collection stay empty:
+			// neither authoritative value exists before decode, and a
+			// client-controlled header must not mint or shift per-database
+			// series.
+			if methodTag, ok := routeToMethod[c.FullPath()]; ok {
+				nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+				metrics.ProxyFunctionCall.WithLabelValues(nodeID, methodTag, metrics.TotalLabel, metrics.CauseNA, "", "").Inc()
+				label, cause := requestutil.ParseMetricLabel(nil, err)
+				metrics.ProxyFunctionCall.WithLabelValues(nodeID, methodTag, label, cause, "", "").Inc()
+			}
+			c.Header("Retry-After", "1")
+			// Retry-After is not CORS-safelisted; expose it so browser
+			// callers can read the retry delay.
+			c.Header("Access-Control-Expose-Headers", "Retry-After")
+			HTTPAbortReturn(c, http.StatusTooManyRequests, gin.H{
+				HTTPReturnCode:    merr.Code(err),
+				HTTPReturnMessage: err.Error(),
+			})
+			return
+		}
+		handler(c)
 	}
 }
 
@@ -210,18 +256,18 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(DataBaseCategory+AlterAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqWithProperties{} }, wrapperTraceLog(h.alterDatabase))))
 	router.POST(DataBaseCategory+AlterPropertiesAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqWithProperties{} }, wrapperTraceLog(h.alterDatabase))))
 	// Query
-	router.POST(EntityCategory+QueryAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
+	router.POST(EntityCategory+QueryAction, h.dqlAdmission(restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &QueryReqV2{
 			Limit:        100,
 			OutputFields: []string{DefaultOutputFields},
 		}
-	}, wrapperTraceLog(h.query))), true))
+	}, wrapperTraceLog(h.query))), true)))
 	// Get
-	router.POST(EntityCategory+GetAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
+	router.POST(EntityCategory+GetAction, h.dqlAdmission(restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &CollectionIDReq{
 			OutputFields: []string{DefaultOutputFields},
 		}
-	}, wrapperTraceLog(h.get))), true))
+	}, wrapperTraceLog(h.get))), true)))
 	// Delete
 	router.POST(EntityCategory+DeleteAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &CollectionFilterReq{}
@@ -235,23 +281,23 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 		return &CollectionDataReq{}
 	}, wrapperTraceLog(h.upsert))), false))
 	// Search
-	router.POST(EntityCategory+SearchAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
+	router.POST(EntityCategory+SearchAction, h.dqlAdmission(restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &SearchReqV2{
 			Limit: 100,
 		}
-	}, wrapperTraceLog(h.search))), true))
+	}, wrapperTraceLog(h.search))), true)))
 	// advanced_search, backward compatible uri
-	router.POST(EntityCategory+AdvancedSearchAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
+	router.POST(EntityCategory+AdvancedSearchAction, h.dqlAdmission(restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &HybridSearchReq{
 			Limit: 100,
 		}
-	}, wrapperTraceLog(h.advancedSearch))), true))
+	}, wrapperTraceLog(h.advancedSearch))), true)))
 	// HybridSearch
-	router.POST(EntityCategory+HybridSearchAction, restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
+	router.POST(EntityCategory+HybridSearchAction, h.dqlAdmission(restfulSizeMiddleware(timeoutMiddleware(wrapperPost(func() any {
 		return &HybridSearchReq{
 			Limit: 100,
 		}
-	}, wrapperTraceLog(h.advancedSearch))), true))
+	}, wrapperTraceLog(h.advancedSearch))), true)))
 
 	router.POST(PartitionCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionNameReq{} }, wrapperTraceLog(h.listPartitions))))
 	router.POST(PartitionCategory+HasAction, timeoutMiddleware(wrapperPost(func() any { return &PartitionReq{} }, wrapperTraceLog(h.hasPartitions))))

--- a/internal/distributed/proxy/httpserver/handler_v2_admission_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_admission_test.go
@@ -1,0 +1,147 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+type dqlFullProxy struct {
+	mockProxyComponent
+	full bool
+}
+
+func (m *dqlFullProxy) IsDQLQueueFull() bool { return m.full }
+
+func postJSONBody(server http.Handler, path string, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+	return w
+}
+
+func TestDQLAdmissionRejectsBeforeDecode(t *testing.T) {
+	server := initHTTPServerV2(&dqlFullProxy{full: true}, false)
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+	// admission runs outside restfulSizeMiddleware: a rejected request must
+	// not add its client-declared size to the restful byte accounting
+	receiveBytes := metrics.ProxyReceiveBytes.WithLabelValues("0", "", "", "")
+	receiveBytesBefore := testutil.ToFloat64(receiveBytes)
+	for _, action := range []string{QueryAction, GetAction, SearchAction, AdvancedSearchAction, HybridSearchAction} {
+		methodTag := routeToMethod[versionalV2(EntityCategory, action)]
+		total := metrics.ProxyFunctionCall.WithLabelValues(nodeID, methodTag, metrics.TotalLabel, metrics.CauseNA, "", "")
+		rejected := metrics.ProxyFunctionCall.WithLabelValues(nodeID, methodTag, metrics.RejectedLabel, metrics.CauseSystem, "", "")
+		totalBefore, rejectedBefore := testutil.ToFloat64(total), testutil.ToFloat64(rejected)
+
+		// "{" is not decodable JSON: a decoded request would fail with
+		// ErrIncorrectParameterFormat, so a 429 proves admission fired first
+		w := postJSONBody(server, versionalV2(EntityCategory, action), "{")
+		assert.Equal(t, http.StatusTooManyRequests, w.Code, action)
+		assert.Equal(t, "1", w.Header().Get("Retry-After"), action)
+		// Retry-After is not CORS-safelisted: browser callers need it exposed
+		assert.Equal(t, "Retry-After", w.Header().Get("Access-Control-Expose-Headers"), action)
+		returnBody := &ReturnErrMsg{}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody), action)
+		assert.Equal(t, merr.Code(merr.ErrServiceTooManyRequests), returnBody.Code, action)
+
+		// the rejection is visible in the request counters wrapperPost never reached
+		assert.Equal(t, totalBefore+1, testutil.ToFloat64(total), action)
+		assert.Equal(t, rejectedBefore+1, testutil.ToFloat64(rejected), action)
+	}
+	assert.Equal(t, receiveBytesBefore, testutil.ToFloat64(receiveBytes))
+}
+
+func TestDQLAdmissionSparesNonDQLRoutes(t *testing.T) {
+	server := initHTTPServerV2(&dqlFullProxy{full: true}, false)
+
+	// DDL is served normally by the mock component
+	w := postJSONBody(server, versionalV2(DataBaseCategory, ListAction), "{}")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// DML falls through to body decoding instead of being rejected
+	w = postJSONBody(server, versionalV2(EntityCategory, InsertAction), "{")
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(merr.ErrIncorrectParameterFormat), returnBody.Code)
+}
+
+func TestDQLAdmissionPassesWhenNotFull(t *testing.T) {
+	server := initHTTPServerV2(&dqlFullProxy{full: false}, false)
+	w := postJSONBody(server, versionalV2(EntityCategory, SearchAction), "{")
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(merr.ErrIncorrectParameterFormat), returnBody.Code)
+}
+
+func TestDQLAdmissionDisabled(t *testing.T) {
+	key := paramtable.Get().HTTPCfg.DQLAdmissionEnabled.Key
+	paramtable.Get().Save(key, "false")
+	defer paramtable.Get().Reset(key)
+
+	server := initHTTPServerV2(&dqlFullProxy{full: true}, false)
+	w := postJSONBody(server, versionalV2(EntityCategory, SearchAction), "{")
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(merr.ErrIncorrectParameterFormat), returnBody.Code)
+}
+
+func TestDQLAdmissionDBLabelStaysEmpty(t *testing.T) {
+	// the DB-Name header is client-controlled and not authoritative (the body
+	// value wins after decode): it must neither mint a series nor shift
+	// rejection counts between databases
+	server := initHTTPServerV2(&dqlFullProxy{full: true}, false)
+	nodeID := strconv.FormatInt(paramtable.GetNodeID(), 10)
+	headerDB := metrics.ProxyFunctionCall.WithLabelValues(nodeID, "Search", metrics.RejectedLabel, metrics.CauseSystem, "my_db", "")
+	empty := metrics.ProxyFunctionCall.WithLabelValues(nodeID, "Search", metrics.RejectedLabel, metrics.CauseSystem, "", "")
+	headerDBBefore, emptyBefore := testutil.ToFloat64(headerDB), testutil.ToFloat64(empty)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), strings.NewReader("{"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HTTPHeaderDBName, "my_db")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Equal(t, headerDBBefore, testutil.ToFloat64(headerDB), "header value must not become a label")
+	assert.Equal(t, emptyBefore+1, testutil.ToFloat64(empty))
+}
+
+func TestDQLAdmissionWithoutProbe(t *testing.T) {
+	// a component that does not expose IsDQLQueueFull admits everything
+	server := initHTTPServerV2(&mockProxyComponent{}, false)
+	w := postJSONBody(server, versionalV2(EntityCategory, SearchAction), "{")
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+	assert.Equal(t, merr.Code(merr.ErrIncorrectParameterFormat), returnBody.Code)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -150,6 +150,13 @@ func (node *Proxy) GetStateCode() commonpb.StateCode {
 	return commonpb.StateCode(node.stateCode.Load())
 }
 
+// IsDQLQueueFull reports whether the next DQL enqueue would be rejected with
+// TooManyRequests. The REST layer probes it (via interface assertion) to
+// reject search/query before paying for body decoding.
+func (node *Proxy) IsDQLQueueFull() bool {
+	return node.sched != nil && node.sched.dqQueue.isFull()
+}
+
 // Register registers proxy at etcd
 func (node *Proxy) Register() error {
 	node.session.Register()

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -85,6 +85,14 @@ func (queue *baseTaskQueue) utFull() bool {
 	return int64(queue.unissuedTasks.Len()) >= queue.getMaxTaskNum()
 }
 
+// isFull is the lock-acquiring counterpart of utFull; utFull assumes the
+// caller already holds utLock.
+func (queue *baseTaskQueue) isFull() bool {
+	queue.utLock.RLock()
+	defer queue.utLock.RUnlock()
+	return queue.utFull()
+}
+
 func (queue *baseTaskQueue) addUnissuedTask(t task) error {
 	queue.utLock.Lock()
 	defer queue.utLock.Unlock()

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -38,6 +38,33 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
+func TestBaseTaskQueue_isFull(t *testing.T) {
+	queue := newBaseTaskQueue(newMockTsoAllocator())
+	queue.setMaxTaskNum(2)
+
+	assert.False(t, queue.isFull())
+	assert.NoError(t, queue.Enqueue(newDefaultMockTask()))
+	assert.False(t, queue.isFull())
+	assert.NoError(t, queue.Enqueue(newDefaultMockTask()))
+	assert.True(t, queue.isFull())
+
+	queue.PopUnissuedTask()
+	assert.False(t, queue.isFull())
+}
+
+func TestProxy_IsDQLQueueFull(t *testing.T) {
+	node := &Proxy{}
+	assert.False(t, node.IsDQLQueueFull())
+
+	sched, err := newTaskScheduler(context.Background(), newMockTsoAllocator())
+	assert.NoError(t, err)
+	node.sched = sched
+	sched.dqQueue.setMaxTaskNum(1)
+	assert.False(t, node.IsDQLQueueFull())
+	assert.NoError(t, sched.dqQueue.Enqueue(newDefaultMockDqlTask()))
+	assert.True(t, node.IsDQLQueueFull())
+}
+
 func TestBaseTaskQueue(t *testing.T) {
 	var err error
 	var unissuedTask task

--- a/pkg/util/paramtable/http_param.go
+++ b/pkg/util/paramtable/http_param.go
@@ -23,6 +23,7 @@ type httpConfig struct {
 	AcceptTypeAllowInt64  ParamItem `refreshable:"true"`
 	EnablePprof           ParamItem `refreshable:"false"`
 	RequestTimeoutMs      ParamItem `refreshable:"true"`
+	DQLAdmissionEnabled   ParamItem `refreshable:"true"`
 	HSTSMaxAge            ParamItem `refreshable:"false"`
 	HSTSIncludeSubDomains ParamItem `refreshable:"false"`
 	EnableHSTS            ParamItem `refreshable:"false"`
@@ -84,6 +85,18 @@ func (p *httpConfig) init(base *BaseTable) {
 		Export:       false,
 	}
 	p.RequestTimeoutMs.Init(base.mgr)
+
+	p.DQLAdmissionEnabled = ParamItem{
+		Key:          "proxy.http.dqlAdmissionEnabled",
+		DefaultValue: "true",
+		Version:      "2.6.23",
+		Doc: `high-level restful api, reject a search/query request with HTTP 429 while the proxy's DQL task
+queue is full, before the request body is decoded. The scheduler rejects such a request with the same
+TooManyRequests error anyway, but only after the body has been decoded; admission moves the same verdict before that
+cost. Disabling restores the old always-decode behavior.`,
+		Export: true,
+	}
+	p.DQLAdmissionEnabled.Init(base.mgr)
 
 	p.HSTSMaxAge = ParamItem{
 		Key:          "proxy.http.hstsMaxAge",

--- a/pkg/util/paramtable/http_param_test.go
+++ b/pkg/util/paramtable/http_param_test.go
@@ -31,5 +31,6 @@ func TestHTTPConfig_Init(t *testing.T) {
 	assert.Equal(t, cfg.Port.GetValue(), "")
 	assert.Equal(t, cfg.AcceptTypeAllowInt64.GetValue(), "true")
 	assert.Equal(t, cfg.EnablePprof.GetAsBool(), true)
+	assert.Equal(t, cfg.DQLAdmissionEnabled.GetAsBool(), true)
 	assert.Equal(t, cfg.EnableWebUI.GetAsBool(), true)
 }


### PR DESCRIPTION
Cherry-pick of #52986 to 2.6.

Add an admission middleware on the v2 RESTful DQL routes (`search`/`query`/`get`/`advanced_search`/`hybrid_search`): while the proxy's DQL task queue is full, the request is rejected with HTTP 429 + `Retry-After` before the body is read or decoded. The scheduler rejects such a request with the same TooManyRequests error anyway, but only after paying the HTTP body read, JSON decode and task-creation CPU — under a REST request flood that pre-scheduler cost is what saturates the proxy.

Backport adjustments (2.6 divergence from master, semantics identical):
- `Proxy.IsDQLQueueFull` added standalone; 2.6 has no `getMetaCache`/`setMetaCache`/`GetMetaCache` refactor, so only the probe method is introduced.
- `HandlersV2` gains only the `dqlQueueFull` probe field; the `metaCache` field / `getProxyMetaCache` wiring do not exist on 2.6 and the admission path does not use them.
- `proxy.http.dqlAdmissionEnabled` param only (the unrelated readHeaderTimeout/readTimeout/writeTimeout/idleTimeout/maxHeaderBytes fields the conflict pulled in belong to other master commits and were dropped); version tagged 2.6.4.
- Test imports rewritten `pkg/v3` → `pkg/v2`.

Verified: gofmt clean, config yaml matches the generator, no conflict markers.

issue: #52985
pr: #52986