### PR TITLE
fix: [hotfix] assign all lacking channels of a replica in one AssignChannel call (#53089)

### DIFF
--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -18,6 +18,9 @@ package checkers
 
 import (
 	"context"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -272,7 +275,16 @@ func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int
 }
 
 func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*meta.DmChannel, replica *meta.Replica) []task.Task {
-	plans := make([]assign.ChannelAssignPlan, 0)
+	// Group channels by their candidate node set and hand each group to the
+	// assign policy in one call. Assigning channel by channel lets every call
+	// observe the same node scores (the tasks of this round are not in the
+	// scheduler yet), so all channels of a replica end up on the same node.
+	type channelGroup struct {
+		nodes    []int64
+		channels []*meta.DmChannel
+	}
+	groups := make(map[string]*channelGroup)
+	groupKeys := make([]string, 0)
 	for _, ch := range channels {
 		var rwNodes []int64
 		if streamingutil.IsStreamingServiceEnabled() {
@@ -282,8 +294,20 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 				rwNodes = replica.GetRWNodes()
 			}
 		}
-		plan := c.assignPolicy.AssignChannel(ctx, replica.GetCollectionID(), []*meta.DmChannel{ch}, rwNodes, true)
-		plans = append(plans, plan...)
+		key := nodesGroupKey(rwNodes)
+		group, ok := groups[key]
+		if !ok {
+			group = &channelGroup{nodes: rwNodes}
+			groups[key] = group
+			groupKeys = append(groupKeys, key)
+		}
+		group.channels = append(group.channels, ch)
+	}
+
+	plans := make([]assign.ChannelAssignPlan, 0, len(channels))
+	for _, key := range groupKeys {
+		group := groups[key]
+		plans = append(plans, c.assignPolicy.AssignChannel(ctx, replica.GetCollectionID(), group.channels, group.nodes, true)...)
 	}
 
 	for i := range plans {
@@ -291,6 +315,19 @@ func (c *ChannelChecker) createChannelLoadTask(ctx context.Context, channels []*
 	}
 
 	return balance.CreateChannelTasksFromPlans(ctx, c.ID(), Params.QueryCoordCfg.ChannelTaskTimeout.GetAsDuration(time.Millisecond), plans)
+}
+
+// nodesGroupKey returns an order-insensitive key of a node set.
+func nodesGroupKey(nodes []int64) string {
+	sorted := make([]int64, len(nodes))
+	copy(sorted, nodes)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	var sb strings.Builder
+	for _, node := range sorted {
+		sb.WriteString(strconv.FormatInt(node, 10))
+		sb.WriteByte(',')
+	}
+	return sb.String()
 }
 
 func (c *ChannelChecker) createChannelReduceTasks(ctx context.Context, channels []*meta.DmChannel, replica *meta.Replica) []task.Task {

--- a/internal/querycoordv2/checkers/channel_checker_test.go
+++ b/internal/querycoordv2/checkers/channel_checker_test.go
@@ -18,6 +18,8 @@ package checkers
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -27,17 +29,24 @@ import (
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/kv/querycoord"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
 	"github.com/milvus-io/milvus/internal/querycoordv2/assign"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
+	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 type ChannelCheckerTestSuite struct {
@@ -362,4 +371,86 @@ func (suite *ChannelCheckerTestSuite) TestReleaseDirtyChannels() {
 
 func TestChannelCheckerSuite(t *testing.T) {
 	suite.Run(t, new(ChannelCheckerTestSuite))
+}
+
+// TestLoadChannelsSpreadAcrossSQNodes reproduces the case that a new replica gets
+// all its channels at once while none of the candidate streaming query nodes
+// hosts the channels' WAL (e.g. the replica lives in a resource group whose
+// streaming nodes own no pchannel). Every channel task generated in one check
+// round must not target the same node.
+func (suite *ChannelCheckerTestSuite) TestLoadChannelsSpreadAcrossSQNodes() {
+	streamingutil.SetStreamingServiceEnabled()
+	defer os.Unsetenv(streamingutil.MilvusStreamingServiceEnabled)
+
+	const channelNum = 12
+	sqNodes := []int64{1051, 1053, 1054, 1056, 1057, 1058}
+	walNode := int64(1007) // WAL owner, not a candidate of the replica
+
+	// feed pchannel -> WAL node assignments, otherwise GetWALLocated blocks forever
+	snmanager.ResetStreamingNodeManager()
+	b := mock_balancer.NewMockBalancer(suite.T())
+	b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
+		relations := make([]types.PChannelInfoAssigned, 0, channelNum)
+		for i := 0; i < channelNum; i++ {
+			relations = append(relations, types.PChannelInfoAssigned{
+				Channel: types.PChannelInfo{Name: fmt.Sprintf("pchannel%d", i), Term: 1},
+				Node:    types.StreamingNodeInfo{ServerID: walNode, Address: "localhost:1"},
+			})
+		}
+		cb(balancer.WatchChannelAssignmentsCallbackParam{
+			Version:            typeutil.VersionInt64Pair{Global: 1, Local: 1},
+			CChannelAssignment: &streamingpb.CChannelAssignment{Meta: &streamingpb.CChannelMeta{Pchannel: "pchannel0"}},
+			Relations:          relations,
+		})
+		<-ctx.Done()
+		return context.Cause(ctx)
+	}).Maybe()
+	// register the candidates (and the WAL owner) as streaming query nodes
+	streamingNodes := make(map[int64]*types.StreamingNodeInfoWithResourceGroup)
+	for _, node := range append([]int64{walNode}, sqNodes...) {
+		streamingNodes[node] = &types.StreamingNodeInfoWithResourceGroup{
+			StreamingNodeInfo: types.StreamingNodeInfo{ServerID: node, Address: "localhost:1"},
+		}
+	}
+	b.EXPECT().GetAllStreamingNodes(mock.Anything).Return(streamingNodes, nil).Maybe()
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(streamingNodes, nil).Maybe()
+	b.EXPECT().Close().Return().Maybe()
+	balance.Register(b)
+
+	ctx := context.Background()
+	checker := suite.checker
+	checker.scheduler.(*task.MockScheduler).EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(1, 1))
+	suite.meta.PutPartition(ctx, utils.CreateTestPartition(1, 1))
+	checker.meta.Put(ctx, meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  1,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		RwSqNodes:     sqNodes,
+	}))
+	suite.setNodeAvailable(sqNodes...)
+
+	channels := make([]*datapb.VchannelInfo, 0, channelNum)
+	for i := 0; i < channelNum; i++ {
+		channels = append(channels, &datapb.VchannelInfo{
+			CollectionID: 1,
+			ChannelName:  fmt.Sprintf("pchannel%d_1v0", i),
+		})
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, nil, nil)
+	checker.targetMgr.UpdateCollectionNextTarget(ctx, int64(1))
+
+	tasks := checker.Check(ctx)
+	suite.Len(tasks, channelNum)
+	perNode := make(map[int64]int)
+	for _, t := range tasks {
+		suite.Len(t.Actions(), 1)
+		action := t.Actions()[0].(*task.ChannelAction)
+		suite.Equal(task.ActionTypeGrow, action.Type())
+		perNode[action.Node()]++
+	}
+	suite.Len(perNode, len(sqNodes), "channels should be spread over all sq nodes, got %v", perNode)
+	for node, cnt := range perNode {
+		suite.Equal(channelNum/len(sqNodes), cnt, "node %d got %d channels, distribution %v", node, cnt, perNode)
+	}
 }


### PR DESCRIPTION
Cherry-pick from master
pr: #53089

issue: #53088

`ChannelChecker.createChannelLoadTask` now groups the lacking channels of a replica by their candidate node set and hands each group to `AssignChannel` in **one** call, instead of calling it once per channel.

`ChannelChecker` hard-codes the RoundRobin assign policy (#45858). `RoundRobinAssignPolicy.AssignChannel` sorts the candidates by `channelCnt + pendingTaskDelta` (ties broken by node ID) and returns `nodes[i%len(nodes)]`. With one channel per call `i` is always 0, and inside a single check round the scheduler delta is still 0 (tasks are added after `Check` returns) and the heartbeat channel count is still 0, so every channel of a new replica lands on the smallest node ID.

Production impact (2.6.23, 12 vchannels, replica scaled 1 -> 2 into a second resource group): all 12 delegators were placed on one streaming node, which OOMKilled at the 128 GiB limit; the next round repeated on the next node. Three streaming nodes were OOMKilled in a row while the other nodes of the resource group stayed idle, and the replica never became serviceable (details in the issue).

Handing the whole batch to the policy lets `nodes[i%len(nodes)]` actually rotate. In streaming mode all channels share the replica's RW SQ nodes, so this is a single call; in the channel-exclusive (non-streaming) mode channels with different node sets are assigned per group.

`TestChannelCheckerSuite/TestLoadChannelsSpreadAcrossSQNodes`: 6 RW SQ nodes, 12 lacking channels, WAL owner outside the candidate set.

Before:
```
Error:    "map[1051:12]" should have 6 item(s), but has 1
Messages: channels should be spread over all sq nodes, got map[1051:12]
```
After: 2 channels per node, `internal/querycoordv2/checkers` and `internal/querycoordv2/assign` pass with `-gcflags="all=-N -l" -tags test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwUqDq36KvDWrAKW1GtGAj

---------