### PR TITLE
test: align boost-ranker invalid-filter assertion

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
@@ -809,5 +809,5 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
+            check_items={"err_code": 1100, "err_msg": "parse scorer filter failed"},
         )


### PR DESCRIPTION
## What does this PR do?

Update the boost-ranker invalid-filter test to match the scorer-specific error wording currently returned by the server.

issue: #53083