### PR TITLE
fix: [3.0] normalize StructArray nullable in Go and RESTful SDKs

### DIFF
--- a/client/entity/schema.go
+++ b/client/entity/schema.go
@@ -224,8 +224,14 @@ func (s *Schema) ReadProto(p *schemapb.CollectionSchema) *Schema {
 func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 	structSchema := NewStructSchema()
 	typeParams := KvPairsMap(p.GetTypeParams())
+	nullable := p.GetNullable()
 	for _, sf := range p.GetFields() {
 		field := NewField().ReadProto(sf)
+		// The server propagates struct-level nullable to every stored sub-field. Keep
+		// that physical projection out of the user-facing schema and recover the
+		// parent flag for clients that lost it while retaining the sub-field flags.
+		nullable = nullable || field.Nullable
+		field.Nullable = false
 		// unwrap Array/ArrayOfVector wrapper added by ProtoMessage()
 		switch sf.GetDataType() {
 		case schemapb.DataType_Array, schemapb.DataType_ArrayOfVector:
@@ -246,7 +252,7 @@ func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 		DataType:     FieldTypeArray,
 		ElementType:  FieldTypeStruct,
 		TypeParams:   typeParams,
-		Nullable:     p.GetNullable(),
+		Nullable:     nullable,
 		StructSchema: structSchema,
 	}
 }

--- a/client/entity/schema.go
+++ b/client/entity/schema.go
@@ -224,13 +224,9 @@ func (s *Schema) ReadProto(p *schemapb.CollectionSchema) *Schema {
 func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 	structSchema := NewStructSchema()
 	typeParams := KvPairsMap(p.GetTypeParams())
-	nullable := p.GetNullable()
 	for _, sf := range p.GetFields() {
 		field := NewField().ReadProto(sf)
-		// The server propagates struct-level nullable to every stored sub-field. Keep
-		// that physical projection out of the user-facing schema and recover the
-		// parent flag for clients that lost it while retaining the sub-field flags.
-		nullable = nullable || field.Nullable
+		// Like PyMilvus, expose nullable only on the parent struct field.
 		field.Nullable = false
 		// unwrap Array/ArrayOfVector wrapper added by ProtoMessage()
 		switch sf.GetDataType() {
@@ -252,7 +248,7 @@ func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 		DataType:     FieldTypeArray,
 		ElementType:  FieldTypeStruct,
 		TypeParams:   typeParams,
-		Nullable:     nullable,
+		Nullable:     p.GetNullable(),
 		StructSchema: structSchema,
 	}
 }

--- a/client/entity/schema_test.go
+++ b/client/entity/schema_test.go
@@ -17,12 +17,14 @@
 package entity
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 func TestCL_CommonCL(t *testing.T) {
@@ -251,6 +253,42 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 	dim, err := clips.StructSchema.Fields[1].GetDim()
 	s.NoError(err)
 	s.EqualValues(8, dim)
+}
+
+func (s *SchemaSuite) TestStructArrayFieldReadProtoNormalizesNullable() {
+	for _, parentNullable := range []bool{false, true} {
+		s.Run(fmt.Sprintf("parent_nullable_%t", parentNullable), func() {
+			protoSchema := &schemapb.CollectionSchema{
+				StructArrayFields: []*schemapb.StructArrayFieldSchema{
+					{
+						Name:     "clips",
+						Nullable: parentNullable,
+						Fields: []*schemapb.FieldSchema{
+							{Name: "score", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float, Nullable: true},
+							{Name: "embedding", DataType: schemapb.DataType_ArrayOfVector, ElementType: schemapb.DataType_FloatVector, Nullable: true},
+						},
+					},
+				},
+			}
+
+			got := NewSchema().ReadProto(protoSchema)
+			s.Require().Len(got.Fields, 1)
+			clips := got.Fields[0]
+			s.True(clips.Nullable)
+			s.Require().NotNil(clips.StructSchema)
+			for _, subField := range clips.StructSchema.Fields {
+				s.False(subField.Nullable)
+			}
+			s.NoError(got.Validate())
+
+			roundTrip := got.ProtoMessage()
+			s.Require().Len(roundTrip.GetStructArrayFields(), 1)
+			s.True(roundTrip.GetStructArrayFields()[0].GetNullable())
+			for _, subField := range roundTrip.GetStructArrayFields()[0].GetFields() {
+				s.False(subField.GetNullable())
+			}
+		})
+	}
 }
 
 func TestSchema(t *testing.T) {

--- a/client/entity/schema_test.go
+++ b/client/entity/schema_test.go
@@ -257,37 +257,42 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 
 func (s *SchemaSuite) TestStructArrayFieldReadProtoNormalizesNullable() {
 	for _, parentNullable := range []bool{false, true} {
-		s.Run(fmt.Sprintf("parent_nullable_%t", parentNullable), func() {
-			protoSchema := &schemapb.CollectionSchema{
-				StructArrayFields: []*schemapb.StructArrayFieldSchema{
-					{
-						Name:     "clips",
-						Nullable: parentNullable,
-						Fields: []*schemapb.FieldSchema{
-							{Name: "score", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float, Nullable: true},
-							{Name: "embedding", DataType: schemapb.DataType_ArrayOfVector, ElementType: schemapb.DataType_FloatVector, Nullable: true},
+		for _, subNullable := range []bool{false, true} {
+			s.Run(fmt.Sprintf("parent_nullable_%t/sub_nullable_%t", parentNullable, subNullable), func() {
+				protoSchema := &schemapb.CollectionSchema{
+					StructArrayFields: []*schemapb.StructArrayFieldSchema{
+						{
+							Name:     "clips",
+							Nullable: parentNullable,
+							Fields: []*schemapb.FieldSchema{
+								{Name: "score", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float, Nullable: subNullable},
+								{Name: "embedding", DataType: schemapb.DataType_ArrayOfVector, ElementType: schemapb.DataType_FloatVector, Nullable: subNullable},
+							},
 						},
 					},
-				},
-			}
+				}
 
-			got := NewSchema().ReadProto(protoSchema)
-			s.Require().Len(got.Fields, 1)
-			clips := got.Fields[0]
-			s.True(clips.Nullable)
-			s.Require().NotNil(clips.StructSchema)
-			for _, subField := range clips.StructSchema.Fields {
-				s.False(subField.Nullable)
-			}
-			s.NoError(got.Validate())
+				got := NewSchema().ReadProto(protoSchema)
+				s.Require().Len(got.Fields, 1)
+				clips := got.Fields[0]
+				s.Equal(parentNullable, clips.Nullable)
+				s.Require().NotNil(clips.StructSchema)
+				for _, subField := range clips.StructSchema.Fields {
+					s.False(subField.Nullable)
+				}
+				s.NoError(got.Validate())
 
-			roundTrip := got.ProtoMessage()
-			s.Require().Len(roundTrip.GetStructArrayFields(), 1)
-			s.True(roundTrip.GetStructArrayFields()[0].GetNullable())
-			for _, subField := range roundTrip.GetStructArrayFields()[0].GetFields() {
-				s.False(subField.GetNullable())
-			}
-		})
+				roundTrip := got.ProtoMessage()
+				s.Require().Len(roundTrip.GetStructArrayFields(), 1)
+				s.Equal(parentNullable, roundTrip.GetStructArrayFields()[0].GetNullable())
+				for _, subField := range roundTrip.GetStructArrayFields()[0].GetFields() {
+					s.False(subField.GetNullable())
+				}
+				for _, subField := range protoSchema.GetStructArrayFields()[0].GetFields() {
+					s.Equal(subNullable, subField.GetNullable(), "decoding must not mutate the input schema")
+				}
+			})
+		}
 	}
 }
 

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -398,9 +398,15 @@ func printFieldDetail(field *schemapb.FieldSchema, oldVersion bool) gin.H {
 func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) []gin.H {
 	res := make([]gin.H, 0, len(structFields))
 	for _, sf := range structFields {
+		nullable := sf.GetNullable()
 		subs := make([]gin.H, 0, len(sf.GetFields()))
 		for _, sub := range sf.GetFields() {
+			// The server stores the parent nullable state on every sub-field. REST
+			// exposes nullable at the struct level, so hide the physical projection
+			// and recover the parent flag when an older client dropped it.
+			nullable = nullable || sub.GetNullable()
 			detail := printFieldDetail(sub, false)
+			detail[HTTPReturnFieldNullable] = false
 			if short, err := typeutil.ExtractStructFieldName(sub.GetName()); err == nil && short != "" {
 				detail[HTTPReturnFieldName] = short
 			}
@@ -410,7 +416,7 @@ func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) [
 			HTTPReturnFieldName:     sf.GetName(),
 			HTTPReturnFieldID:       sf.GetFieldID(),
 			HTTPReturnDescription:   sf.GetDescription(),
-			HTTPReturnFieldNullable: sf.GetNullable(),
+			HTTPReturnFieldNullable: nullable,
 			HTTPReturnFieldType:     schemapb.DataType_ArrayOfStruct.String(),
 			"fields":                subs,
 		}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -398,14 +398,10 @@ func printFieldDetail(field *schemapb.FieldSchema, oldVersion bool) gin.H {
 func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) []gin.H {
 	res := make([]gin.H, 0, len(structFields))
 	for _, sf := range structFields {
-		nullable := sf.GetNullable()
 		subs := make([]gin.H, 0, len(sf.GetFields()))
 		for _, sub := range sf.GetFields() {
-			// The server stores the parent nullable state on every sub-field. REST
-			// exposes nullable at the struct level, so hide the physical projection
-			// and recover the parent flag when an older client dropped it.
-			nullable = nullable || sub.GetNullable()
 			detail := printFieldDetail(sub, false)
+			// Like PyMilvus, expose nullable only on the parent struct field.
 			detail[HTTPReturnFieldNullable] = false
 			if short, err := typeutil.ExtractStructFieldName(sub.GetName()); err == nil && short != "" {
 				detail[HTTPReturnFieldName] = short
@@ -416,7 +412,7 @@ func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) [
 			HTTPReturnFieldName:     sf.GetName(),
 			HTTPReturnFieldID:       sf.GetFieldID(),
 			HTTPReturnDescription:   sf.GetDescription(),
-			HTTPReturnFieldNullable: nullable,
+			HTTPReturnFieldNullable: sf.GetNullable(),
 			HTTPReturnFieldType:     schemapb.DataType_ArrayOfStruct.String(),
 			"fields":                subs,
 		}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4428,7 +4428,9 @@ func TestIsEmbeddingListData(t *testing.T) {
 
 func TestPrintStructArrayFieldsV2(t *testing.T) {
 	schema := buildStructArrayTestSchema()
-	schema.GetStructArrayFields()[0].Nullable = true
+	for _, subField := range schema.GetStructArrayFields()[0].GetFields() {
+		subField.Nullable = true
+	}
 	printed := printStructArrayFieldsV2(schema.GetStructArrayFields())
 	require.Len(t, printed, 1)
 	entry := printed[0]
@@ -4439,9 +4441,11 @@ func TestPrintStructArrayFieldsV2(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, subs, 2)
 	assert.Equal(t, "sub_int", subs[0][HTTPReturnFieldName])
+	assert.Equal(t, false, subs[0][HTTPReturnFieldNullable])
 	assert.Equal(t, schemapb.DataType_Array.String(), subs[0][HTTPReturnFieldType])
 	assert.Equal(t, schemapb.DataType_Int32.String(), subs[0][HTTPReturnFieldElementType])
 	assert.Equal(t, "sub_vec", subs[1][HTTPReturnFieldName])
+	assert.Equal(t, false, subs[1][HTTPReturnFieldNullable])
 	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
 }
 

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4427,26 +4427,36 @@ func TestIsEmbeddingListData(t *testing.T) {
 }
 
 func TestPrintStructArrayFieldsV2(t *testing.T) {
-	schema := buildStructArrayTestSchema()
-	for _, subField := range schema.GetStructArrayFields()[0].GetFields() {
-		subField.Nullable = true
+	for _, parentNullable := range []bool{false, true} {
+		for _, subNullable := range []bool{false, true} {
+			t.Run(fmt.Sprintf("parent_nullable_%t/sub_nullable_%t", parentNullable, subNullable), func(t *testing.T) {
+				schema := buildStructArrayTestSchema()
+				schema.GetStructArrayFields()[0].Nullable = parentNullable
+				for _, subField := range schema.GetStructArrayFields()[0].GetFields() {
+					subField.Nullable = subNullable
+				}
+				printed := printStructArrayFieldsV2(schema.GetStructArrayFields())
+				require.Len(t, printed, 1)
+				entry := printed[0]
+				assert.Equal(t, "my_struct", entry[HTTPReturnFieldName])
+				assert.Equal(t, schemapb.DataType_ArrayOfStruct.String(), entry[HTTPReturnFieldType])
+				assert.Equal(t, parentNullable, entry[HTTPReturnFieldNullable])
+				subs, ok := entry["fields"].([]gin.H)
+				require.True(t, ok)
+				require.Len(t, subs, 2)
+				assert.Equal(t, "sub_int", subs[0][HTTPReturnFieldName])
+				assert.Equal(t, false, subs[0][HTTPReturnFieldNullable])
+				assert.Equal(t, schemapb.DataType_Array.String(), subs[0][HTTPReturnFieldType])
+				assert.Equal(t, schemapb.DataType_Int32.String(), subs[0][HTTPReturnFieldElementType])
+				assert.Equal(t, "sub_vec", subs[1][HTTPReturnFieldName])
+				assert.Equal(t, false, subs[1][HTTPReturnFieldNullable])
+				assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
+				for _, subField := range schema.GetStructArrayFields()[0].GetFields() {
+					assert.Equal(t, subNullable, subField.GetNullable(), "printing must not mutate the input schema")
+				}
+			})
+		}
 	}
-	printed := printStructArrayFieldsV2(schema.GetStructArrayFields())
-	require.Len(t, printed, 1)
-	entry := printed[0]
-	assert.Equal(t, "my_struct", entry[HTTPReturnFieldName])
-	assert.Equal(t, schemapb.DataType_ArrayOfStruct.String(), entry[HTTPReturnFieldType])
-	assert.Equal(t, true, entry[HTTPReturnFieldNullable])
-	subs, ok := entry["fields"].([]gin.H)
-	require.True(t, ok)
-	require.Len(t, subs, 2)
-	assert.Equal(t, "sub_int", subs[0][HTTPReturnFieldName])
-	assert.Equal(t, false, subs[0][HTTPReturnFieldNullable])
-	assert.Equal(t, schemapb.DataType_Array.String(), subs[0][HTTPReturnFieldType])
-	assert.Equal(t, schemapb.DataType_Int32.String(), subs[0][HTTPReturnFieldElementType])
-	assert.Equal(t, "sub_vec", subs[1][HTTPReturnFieldName])
-	assert.Equal(t, false, subs[1][HTTPReturnFieldNullable])
-	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
 }
 
 func TestStructArrayScalarSubFieldTypes(t *testing.T) {

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -139,6 +139,73 @@ func TestStructArrayCreateWithScalarFields(t *testing.T) {
 	require.True(t, has)
 }
 
+func TestStructArrayNullableSchemaDescribeCreateRoundTrip(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	sourceName := common.GenRandomString(hp.StructArrayPrefix+"_nullable_source", 6)
+	schema, _ := hp.CreateStructArraySchema(hp.DefaultStructArraySchemaOption(sourceName))
+	var clips *entity.Field
+	for _, field := range schema.Fields {
+		if field.Name == "clips" {
+			clips = field
+			break
+		}
+	}
+	require.NotNil(t, clips)
+	clips.WithNullable(true)
+
+	common.CheckErr(t, mc.CreateCollection(ctx,
+		client.NewCreateCollectionOption(sourceName, schema)), true)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		_ = mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(sourceName))
+	})
+
+	described, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(sourceName))
+	common.CheckErr(t, err, true)
+	var describedClips *entity.Field
+	for _, field := range described.Schema.Fields {
+		if field.Name == "clips" {
+			describedClips = field
+			break
+		}
+	}
+	require.NotNil(t, describedClips)
+	require.True(t, describedClips.Nullable)
+	require.NotNil(t, describedClips.StructSchema)
+	for _, subField := range describedClips.StructSchema.Fields {
+		require.False(t, subField.Nullable)
+	}
+	require.NoError(t, described.Schema.Validate())
+
+	replayedName := common.GenRandomString(hp.StructArrayPrefix+"_nullable_replay", 6)
+	common.CheckErr(t, mc.CreateCollection(ctx,
+		client.NewCreateCollectionOption(replayedName, described.Schema)), true)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		_ = mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(replayedName))
+	})
+
+	replayed, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(replayedName))
+	common.CheckErr(t, err, true)
+	var replayedClips *entity.Field
+	for _, field := range replayed.Schema.Fields {
+		if field.Name == "clips" {
+			replayedClips = field
+			break
+		}
+	}
+	require.NotNil(t, replayedClips)
+	require.True(t, replayedClips.Nullable)
+	require.NotNil(t, replayedClips.StructSchema)
+	for _, subField := range replayedClips.StructSchema.Fields {
+		require.False(t, subField.Nullable)
+	}
+}
+
 // TestStructArrayInsertBasic ports test_insert_struct_array_basic.
 func TestStructArrayInsertBasic(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)

--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -25,25 +25,28 @@ def assert_profile_equal(actual, expected):
 class TestRestfulStructArrayNullable(TestBase):
     dim = REST_VECTOR_DIM
 
-    def _create_struct_array_collection(self, name: str, struct_nullable: bool | None = None):
-        struct_field = {
-            "fieldName": "profile",
-            "typeParams": {"max_capacity": "4"},
-            "fields": [
-                {
-                    "fieldName": "p_int",
-                    "dataType": "Array",
-                    "elementDataType": "Int64",
-                    "elementTypeParams": {"max_capacity": "4"},
-                },
-                {
-                    "fieldName": "p_tag",
-                    "dataType": "Array",
-                    "elementDataType": "VarChar",
-                    "elementTypeParams": {"max_capacity": "4", "max_length": "128"},
-                },
-            ],
-        }
+    def _create_struct_array_collection(
+        self, name: str, struct_nullable: bool | None = None, struct_field: dict | None = None
+    ):
+        if struct_field is None:
+            struct_field = {
+                "fieldName": "profile",
+                "typeParams": {"max_capacity": "4"},
+                "fields": [
+                    {
+                        "fieldName": "p_int",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "4"},
+                    },
+                    {
+                        "fieldName": "p_tag",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "4", "max_length": "128"},
+                    },
+                ],
+            }
         if struct_nullable is not None:
             struct_field["nullable"] = struct_nullable
 
@@ -322,7 +325,7 @@ class TestRestfulStructArrayNullable(TestBase):
         """
         target: test REST v2 nullable propagation for Struct Array
         method: create schema.structFields with nullable=true and inspect REST describe output
-        expected: REST either preserves nullable=true on Struct Array in describe output, or rejects unsupported nullable explicitly
+        expected: REST preserves nullable=true on the parent and hides the stored nullable flags on sub-fields
         """
         name = gen_collection_name()
         self.name = name
@@ -332,3 +335,48 @@ class TestRestfulStructArrayNullable(TestBase):
         assert rsp["code"] == 0
         profile = next(field for field in rsp["data"].get("structFields", []) if field["name"] == "profile")
         assert profile["nullable"] is True
+        assert all(sub_field["nullable"] is False for sub_field in profile["fields"])
+
+    def test_rest_v2_nullable_struct_array_schema_describe_create_round_trip(self):
+        """
+        target: test REST v2 nullable Struct Array schema round trip
+        method: create a nullable Struct Array, describe it, map the response back to create format,
+            and create another collection
+        expected: nullable remains on the parent and the described schema can be reused successfully
+        """
+        source_name = gen_collection_name()
+        self.name = source_name
+        self._create_struct_array_collection(source_name, struct_nullable=True)
+
+        rsp = self.collection_client.collection_describe(source_name)
+        assert rsp["code"] == 0
+        profile = next(field for field in rsp["data"].get("structFields", []) if field["name"] == "profile")
+        assert profile["nullable"] is True
+        assert all(sub_field["nullable"] is False for sub_field in profile["fields"])
+
+        replayed_struct_field = {
+            "fieldName": profile["name"],
+            "description": profile.get("description", ""),
+            "nullable": profile["nullable"],
+            "typeParams": {param["key"]: param["value"] for param in profile.get("params", [])},
+            "fields": [
+                {
+                    "fieldName": sub_field["name"],
+                    "description": sub_field.get("description", ""),
+                    "dataType": sub_field["type"],
+                    "elementDataType": sub_field["elementType"],
+                    "elementTypeParams": {param["key"]: param["value"] for param in sub_field.get("params", [])},
+                    "nullable": sub_field["nullable"],
+                }
+                for sub_field in profile["fields"]
+            ],
+        }
+
+        replayed_name = gen_collection_name()
+        self._create_struct_array_collection(replayed_name, struct_field=replayed_struct_field)
+
+        rsp = self.collection_client.collection_describe(replayed_name)
+        assert rsp["code"] == 0
+        replayed_profile = next(field for field in rsp["data"].get("structFields", []) if field["name"] == "profile")
+        assert replayed_profile["nullable"] is True
+        assert all(sub_field["nullable"] is False for sub_field in replayed_profile["fields"])


### PR DESCRIPTION
pr: #52974
issue: #52924

## What was changed

- Backport StructArray nullable schema normalization to the 3.0 branch.
- Preserve the parent nullable flag directly, matching PyMilvus.
- Clear nullable from user-facing StructArray sub-fields in Go SDK v3 and REST v2.
- Backport unit and E2E regression coverage.

## Tests

- CI
