### PR TITLE
test: align boost-ranker invalid-filter assertion with server wording

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
@@ -809,5 +809,5 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
+            check_items={"err_code": 1100, "err_msg": "parse scorer filter failed"},
         )


### PR DESCRIPTION
The boost-ranker invalid-filter test asserts an outdated server error message. Update it to match the current `parse scorer filter failed` wording while preserving the expected error code.

issue: #53083