### PR TITLE
enhance: [2.6] isolate online-write cgo pool from segment loading (#50812)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -532,6 +532,9 @@ queryNode:
       cacheTtl: 0
       storageUsageTrackingEnabled: false # Enable storage usage tracking for Tiered Storage. Defaults to false.
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
+    mutatePoolSizeFactor: 2 # size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes
+    dynamicPoolSizeFactor: 1 # size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info
+    deletePoolSizeFactor: 1 # size factor (CPUNum * factor) of the DeleteBatch dispatch pool
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index

--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -57,6 +57,13 @@ var (
 	warmupPool atomic.Pointer[conc.Pool[any]]
 	warmupOnce sync.Once
 
+	// mutatePool serves the online write CGO path (segment Insert/Delete).
+	// It is isolated from the load/management work on DynamicPool so that a
+	// burst of segment loading (e.g. delta-log replay after compaction) cannot
+	// starve online insert/delete, which would otherwise stall tSafe advancement.
+	mutatePool     atomic.Pointer[conc.Pool[any]]
+	mutatePoolOnce sync.Once
+
 	deletePool     atomic.Pointer[conc.Pool[struct{}]]
 	deletePoolOnce sync.Once
 
@@ -70,6 +77,7 @@ var (
 	cgoTagSQ      = C.CString("CGO_SQ")
 	cgoTagLoad    = C.CString("CGO_LOAD")
 	cgoTagDynamic = C.CString("CGO_DYN")
+	cgoTagMutate  = C.CString("CGO_MUTATE")
 	cgoTagWarmup  = C.CString("CGO_WARMUP")
 )
 
@@ -95,9 +103,18 @@ func initSQPool() {
 	})
 }
 
+func dynamicPoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.DynamicPoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
+}
+
 func initDynamicPool() {
 	dynOnce.Do(func() {
-		size := hardware.GetCPUNum()
+		pt := paramtable.Get()
+		size := dynamicPoolSize()
 		pool := conc.NewPool[any](
 			size,
 			conc.WithPreAlloc(false),
@@ -109,7 +126,40 @@ func initDynamicPool() {
 		)
 
 		dp.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, config.NewHandler("qn.dynamicpool.sizefactor", ResizeDynamicPool))
 		log.Info("init dynamicPool done", zap.Int("size", size))
+	})
+}
+
+func mutatePoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.MutatePoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
+}
+
+// initMutatePool initializes the dedicated pool for the online-write CGO path
+// (segment Insert/Delete), isolated from segment loading on DynamicPool/LoadPool
+// so a post-compaction delta-replay burst cannot starve online writes and freeze
+// tSafe advancement (#49435).
+func initMutatePool() {
+	mutatePoolOnce.Do(func() {
+		pt := paramtable.Get()
+		size := mutatePoolSize()
+		pool := conc.NewPool[any](
+			size,
+			conc.WithPreAlloc(false),
+			conc.WithDisablePurge(false),
+			conc.WithPreHandler(func() {
+				runtime.LockOSThread()
+				C.SetThreadName(cgoTagMutate)
+			}), // lock os thread for cgo thread disposal
+		)
+
+		mutatePool.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, config.NewHandler("qn.mutatepool.sizefactor", ResizeMutatePool))
+		log.Info("init mutatePool done", zap.Int("size", size))
 	})
 }
 
@@ -179,10 +229,22 @@ func initBFApplyPool() {
 	})
 }
 
+func deletePoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.DeletePoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
+}
+
 func initDeletePool() {
 	deletePoolOnce.Do(func() {
-		pool := conc.NewPool[struct{}](runtime.GOMAXPROCS(0))
+		pt := paramtable.Get()
+		size := deletePoolSize()
+		pool := conc.NewPool[struct{}](size)
 		deletePool.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, config.NewHandler("qn.deletepool.sizefactor", ResizeDeletePool))
+		log.Info("init deletePool done", zap.Int("size", size))
 	})
 }
 
@@ -196,6 +258,13 @@ func GetSQPool() *conc.Pool[any] {
 func GetDynamicPool() *conc.Pool[any] {
 	initDynamicPool()
 	return dp.Load()
+}
+
+// GetMutatePool returns the singleton pool for online write cgo operations
+// (segment Insert/Delete).
+func GetMutatePool() *conc.Pool[any] {
+	initMutatePool()
+	return mutatePool.Load()
 }
 
 func GetLoadPool() *conc.Pool[any] {
@@ -265,6 +334,24 @@ func ResizeBM25LoadPool(evt *config.Event) {
 	}
 }
 
+func ResizeMutatePool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetMutatePool(), mutatePoolSize(), "MutatePool")
+	}
+}
+
+func ResizeDynamicPool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetDynamicPool(), dynamicPoolSize(), "DynamicPool")
+	}
+}
+
+func ResizeDeletePool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetDeletePool(), deletePoolSize(), "DeletePool")
+	}
+}
+
 // CollectPoolStats returns current stats for all goroutine pools.
 // Called by PoolMetricsCollector at Prometheus scrape time (pull model).
 func CollectPoolStats() []metrics.PoolStats {
@@ -280,6 +367,7 @@ func CollectPoolStats() []metrics.PoolStats {
 	refs := []poolRef{
 		{"SQPool", GetSQPool()},
 		{"DynamicPool", GetDynamicPool()},
+		{"MutatePool", GetMutatePool()},
 		{"LoadPool", GetLoadPool()},
 		{"WarmupPool", GetWarmupPool()},
 		{"BFApplyPool", GetBFApplyPool()},
@@ -299,7 +387,7 @@ func CollectPoolStats() []metrics.PoolStats {
 	return stats
 }
 
-func resizePool(pool *conc.Pool[any], newSize int, tag string) {
+func resizePool[T any](pool *conc.Pool[T], newSize int, tag string) {
 	log := log.Ctx(context.Background()).
 		With(
 			zap.String("poolTag", tag),

--- a/internal/querynodev2/segments/pool_test.go
+++ b/internal/querynodev2/segments/pool_test.go
@@ -104,6 +104,63 @@ func TestResizePools(t *testing.T) {
 		assert.Equal(t, expectedCap, GetWarmupPool().Cap())
 	})
 
+	t.Run("MutatePool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "2")
+
+		expectedCap := hardware.GetCPUNum() * pt.QueryNodeCfg.MutatePoolSizeFactor.GetAsInt()
+		ResizeMutatePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, expectedCap, GetMutatePool().Cap())
+
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "4")
+		ResizeMutatePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*4, GetMutatePool().Cap())
+
+		// factor <= 0 clamps to CPUNum so the mutate pool is never zero-sized.
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "0")
+		ResizeMutatePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetMutatePool().Cap())
+	})
+
+	t.Run("DynamicPool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "1")
+
+		pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "3")
+		ResizeDynamicPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*3, GetDynamicPool().Cap())
+
+		// factor <= 0 clamps to CPUNum.
+		pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "0")
+		ResizeDynamicPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetDynamicPool().Cap())
+	})
+
+	t.Run("DeletePool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "1")
+
+		pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "3")
+		ResizeDeletePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*3, GetDeletePool().Cap())
+
+		// factor <= 0 clamps to CPUNum.
+		pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "0")
+		ResizeDeletePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetDeletePool().Cap())
+	})
+
 	t.Run("BfApplyPool", func(t *testing.T) {
 		expectedCap := hardware.GetCPUNum() * pt.QueryNodeCfg.BloomFilterApplyParallelFactor.GetAsInt()
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -784,7 +784,7 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 
 	var result *segcore.InsertResult
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	GetMutatePool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -839,7 +839,7 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	// been applied to this segment, and skipping them causes silent data loss.
 
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	GetMutatePool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -1009,7 +1009,10 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 		LoadDeletedRecord(CSegmentInterface c_segment, CLoadDeletedRecordInfo deleted_record_info)
 	*/
 	var status C.CStatus
-	GetDynamicPool().Submit(func() (any, error) {
+	// Delta-log replay during segment load runs on the load pool, not the
+	// online-write mutate pool, so a large post-compaction replay cannot starve
+	// online insert/delete (and thus tSafe advancement).
+	GetLoadPool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3576,6 +3576,19 @@ type queryNodeConfig struct {
 	// CGOPoolSize ratio to MaxReadConcurrency
 	CGOPoolSizeRatio ParamItem `refreshable:"true"`
 
+	// MutatePoolSizeFactor controls the size of the online-write CGO pool
+	// (segment Insert/Delete) as CPUNum * factor. The mutate pool is isolated
+	// from load/management work so segment loading cannot starve online writes.
+	MutatePoolSizeFactor ParamItem `refreshable:"true"`
+
+	// DynamicPoolSizeFactor controls the size of the dynamic CGO pool
+	// (segment create/release/statistics/index-info) as CPUNum * factor.
+	DynamicPoolSizeFactor ParamItem `refreshable:"true"`
+
+	// DeletePoolSizeFactor controls the size of the DeleteBatch dispatch pool
+	// as CPUNum * factor.
+	DeletePoolSizeFactor ParamItem `refreshable:"true"`
+
 	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 
 	ExprEvalBatchSize ParamItem `refreshable:"false"`
@@ -4812,6 +4825,33 @@ user-task-polling:
 		Doc:          "cgo pool size ratio to max read concurrency",
 	}
 	p.CGOPoolSizeRatio.Init(base.mgr)
+
+	p.MutatePoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.mutatePoolSizeFactor",
+		Version:      "2.6.20",
+		DefaultValue: "2",
+		Doc:          "size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes",
+		Export:       true,
+	}
+	p.MutatePoolSizeFactor.Init(base.mgr)
+
+	p.DynamicPoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.dynamicPoolSizeFactor",
+		Version:      "2.6.20",
+		DefaultValue: "1",
+		Doc:          "size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info",
+		Export:       true,
+	}
+	p.DynamicPoolSizeFactor.Init(base.mgr)
+
+	p.DeletePoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.deletePoolSizeFactor",
+		Version:      "2.6.20",
+		DefaultValue: "1",
+		Doc:          "size factor (CPUNum * factor) of the DeleteBatch dispatch pool",
+		Export:       true,
+	}
+	p.DeletePoolSizeFactor.Init(base.mgr)
 
 	p.EnableWorkerSQCostMetrics = ParamItem{
 		Key:          "queryNode.enableWorkerSQCostMetrics",


### PR DESCRIPTION
pr: #50812

## What

Backport of #50812 to **2.6**. #50812 is the fix for #49435 (`code=505 channel tsafe stalled` under heavy upsert + concurrent Strong-consistency query on a CPU-constrained standalone); it landed on **master / 3.0** but was never cherry-picked to 2.6, so 2.6 users are still hitting this (e.g. issues/49435#issuecomment-5419836160).

## Problem

On the QueryNode, load-time delta-log replay (`LoadDeltaData` / `LoadDeletedRecord`) and the online forward `Insert` / `Delete` both submit their CGO onto the same `DynamicPool` (size = `CPUNum`). After a compaction, the multi-partition delta-replay burst saturates the pool and starves the online `Insert` / `Delete`. Because `deleteNode.Operate` runs `ProcessDelete` **before** `UpdateTSafe`, channel tSafe freezes for tens of seconds and Strong queries fail with `channel tsafe stalled`.

## Changes (querynode pool isolation)

- Add a dedicated **`MutatePool`** for the online-write CGO path (`segment.Insert` / `segment.Delete`), isolated from load/management work on `DynamicPool`.
- Route load-time `LoadDeltaData` delta-replay onto **`LoadPool`**.
- Make `DynamicPool` / `DeletePool` size-configurable + hot-reloadable (`CPUNum * factor`); add `MutatePoolSizeFactor` / `DynamicPoolSizeFactor` / `DeletePoolSizeFactor` (defaults `2` / `1` / `1`).
- Export `MutatePool` in the existing querynode pool metrics.

**Scope:** this backports the querynode pool-isolation half of #50812 (the part that fixes #49435). #50812's datanode pool-metrics observability bundle is orthogonal to this stall and left for a separate parity change; 2.6's `warmupPool` / `bm25LoadPool` are kept (their removal in #50812 is unrelated cleanup that 2.6 still depends on).

## Validation

Re-ran the repro on 2.6 across **8 standalone instances** (heavy upsert + concurrent Strong `count(*)` / query, 8-core node each):

| | |
|---|---|
| `channel tsafe stalled` / 505 | **0** (8/8) |
| Search/query requests | **≈417,503 — 100% success** |

All stall preconditions were present, so this is a genuine stress test: CPU throttle peak **0.50–0.78**, delete buffer **8.45–9.24 M rows**, `LoadDeletedRecord` **~12 s**. `DynamicPool` — the old contention point, previously pegged **8/8** — stayed near-idle at **2–7/8**, while the isolated `MutatePool` kept `Insert` / `Delete` at **~1–2 ms / ~7–11 ms** under throttle. Full per-instance data: https://github.com/milvus-io/milvus/issues/49435#issuecomment-5277165559

issue: #49435
related: #50812

/cc @xiaofan-luan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011coeCLfVcwLKqkgaLfp6Ci
