### PR TITLE
enhance: [3.0] match REST access log formatters by URL path (#53143)

### DIFF
--- a/internal/proxy/accesslog/global.go
+++ b/internal/proxy/accesslog/global.go
@@ -121,7 +121,7 @@ func (l *AccessLogger) Write(info info.AccessInfo) bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
-	method := info.MethodName()
+	method := info.MethodNameForFormatter()
 	formatter, ok := l.formatters.GetByMethod(method)
 	if !ok {
 		return false

--- a/internal/proxy/accesslog/global_test.go
+++ b/internal/proxy/accesslog/global_test.go
@@ -17,13 +17,17 @@
 package accesslog
 
 import (
+	"bytes"
 	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -183,6 +187,76 @@ func TestAccessLogger_Basic(t *testing.T) {
 
 	ok := _globalL.Write(accessInfo)
 	assert.True(t, ok)
+}
+
+func TestAccessLogger_RestfulMethodUsesURLPath(t *testing.T) {
+	newLogger := func(writer *bytes.Buffer) *AccessLogger {
+		formatters := NewFormatterManger()
+		formatters.Add(BaseFormatterKey, "base: $method_name")
+		formatters.Add("search", "search: $method_name")
+		formatters.SetMethod("search", "/v2/search")
+
+		logger := NewAccessLogger()
+		logger.enable.Store(true)
+		logger.writer = writer
+		logger.formatters = formatters
+		return logger
+	}
+
+	tests := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{
+			name:     "exact path matches",
+			target:   "/v2/search",
+			expected: "search: /v2/search\n",
+		},
+		{
+			name:     "query does not change restful method",
+			target:   "/v2/search?cluster_id=123",
+			expected: "search: /v2/search?cluster_id=123\n",
+		},
+		{
+			name:     "different prefix does not match",
+			target:   "/search?cluster_id=123",
+			expected: "base: /search?cluster_id=123\n",
+		},
+		{
+			name:     "different path does not match",
+			target:   "/v2/searching?cluster_id=123",
+			expected: "base: /v2/searching?cluster_id=123\n",
+		},
+		{
+			name:     "child path does not match",
+			target:   "/v2/search/result?cluster_id=123",
+			expected: "base: /v2/search/result?cluster_id=123\n",
+		},
+		{
+			name:     "escaped question mark remains part of path",
+			target:   "/v2/search%3Fcluster_id=123",
+			expected: "base: /v2/search%3Fcluster_id=123\n",
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			ctx.Request = httptest.NewRequest(http.MethodPost, test.target, nil)
+			accessInfo := info.NewRestfulInfo(ctx)
+			accessInfo.SetParams(&gin.LogFormatterParams{
+				Request: ctx.Request,
+				Path:    ctx.Request.URL.RequestURI(),
+			})
+
+			var writer bytes.Buffer
+			logger := newLogger(&writer)
+			require.True(t, logger.Write(accessInfo))
+			assert.Equal(t, test.expected, writer.String())
+		})
+	}
 }
 
 func TestAccessLogger_WriteFailed(t *testing.T) {

--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -122,6 +122,10 @@ func (i *GrpcAccessInfo) MethodName() string {
 	return methodName
 }
 
+func (i *GrpcAccessInfo) MethodNameForFormatter() string {
+	return i.MethodName()
+}
+
 func (i *GrpcAccessInfo) Address() string {
 	ip, ok := peer.FromContext(i.ctx)
 	if !ok {

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -80,6 +80,12 @@ func (s *GrpcAccessInfoSuite) SetupTest() {
 	}
 }
 
+func (s *GrpcAccessInfoSuite) TestMethodName() {
+	s.info.grpcInfo.FullMethod = "/milvus.proto.milvus.MilvusService/Search"
+	s.Equal("Search", s.info.MethodName())
+	s.Equal("Search", s.info.MethodNameForFormatter())
+}
+
 func (s *GrpcAccessInfoSuite) TestErrorCode() {
 	s.info.resp = &milvuspb.QueryResults{
 		Status: merr.Status(nil),

--- a/internal/proxy/accesslog/info/info.go
+++ b/internal/proxy/accesslog/info/info.go
@@ -64,7 +64,10 @@ type AccessInfo interface {
 	TimeNow() string
 	TimeStart() string
 	TimeEnd() string
+	// MethodName returns the method value written to the access log.
 	MethodName() string
+	// MethodNameForFormatter returns the stable key used to select a formatter.
+	MethodNameForFormatter() string
 	Address() string
 	TraceID() string
 	MethodStatus() string

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -103,6 +103,13 @@ func (i *RestfulInfo) MethodName() string {
 	return i.params.Path
 }
 
+func (i *RestfulInfo) MethodNameForFormatter() string {
+	if i.ctx == nil || i.ctx.Request == nil || i.ctx.Request.URL == nil {
+		return i.MethodName()
+	}
+	return i.ctx.Request.URL.Path
+}
+
 func (i *RestfulInfo) Address() string {
 	return i.params.ClientIP
 }

--- a/internal/proxy/accesslog/info/restful_info_test.go
+++ b/internal/proxy/accesslog/info/restful_info_test.go
@@ -85,9 +85,13 @@ func (s *RestfulAccessInfoSuite) TestTimeEnd() {
 }
 
 func (s *RestfulAccessInfoSuite) TestMethodName() {
-	s.info.params.Path = "/restful/test"
+	req, err := http.NewRequest(http.MethodPost, "/restful/test?cluster_id=123", nil)
+	s.NoError(err)
+	s.ctx.Request = req
+	s.info.params.Path = req.URL.RequestURI()
 	result := Get(s.info, "$method_name")
 	s.Equal(s.info.params.Path, result[0])
+	s.Equal("/restful/test", s.info.MethodNameForFormatter())
 }
 
 func (s *RestfulAccessInfoSuite) TestAddress() {

--- a/internal/proxy/membership_filter_plan_size_test.go
+++ b/internal/proxy/membership_filter_plan_size_test.go
@@ -372,7 +372,7 @@ func TestQueryTaskMembershipFilterPlanSizeLimit(t *testing.T) {
 	// An unexpected GetPartitions call will still fail this strict mock.
 
 	task := &queryTask{
-		baseTask: baseTask{metaCache: cache},
+		baseTask: baseTask{MetaCache: cache},
 		ctx:      ctx,
 		RetrieveRequest: &internalpb.RetrieveRequest{
 			Base:       &commonpb.MsgBase{},


### PR DESCRIPTION
issue: #53150
pr: https://github.com/milvus-io/milvus/pull/53143

## Summary
Match REST access log formatters using the parsed URL path so configured methods also apply when requests include query parameters. Preserve the full request target, including query parameters, in `$method_name` output.