### PR TITLE
test: fix external refresh and oversized insert expectations

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -3631,9 +3631,9 @@ class TestMilvusClientExternalTableRefresh(ExternalTableTestBase):
         self, minio_env, external_prefix
     ):
         """
-        target: test MilvusClient external table refresh second concurrent returns existing or rejects (milvus#49231)
-        method: milvus#49231: duplicate refresh must not return a dropped new job_id
-        expected: behavior matches the case assertion.
+        target: verify duplicate external table refresh behavior (milvus#49231)
+        method: submit two back-to-back refreshes and inspect the first job if the second creates a new job
+        expected: reject/reuse while active, or create a new job only after the first job is terminal
         """
         minio_client, cfg = minio_env
         client = self._client()
@@ -3649,12 +3649,26 @@ class TestMilvusClientExternalTableRefresh(ExternalTableTestBase):
         schema = _build_basic_schema(self, client, ext_url)
         self.create_collection(client, collection_name=coll, schema=schema)
         job_first = self.refresh_external_collection(client, collection_name=coll)[0]
-        self.refresh_external_collection(
+        second_result, second_succeeded = self.refresh_external_collection(
             client,
             collection_name=coll,
-            check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100, ct.err_msg: "in progress"},
+            check_task=CheckTasks.check_nothing,
         )
+
+        if second_succeeded:
+            if second_result != job_first:
+                first_progress = self.get_refresh_external_collection_progress(client, job_id=job_first)[0]
+                assert first_progress.state in ("RefreshCompleted", "RefreshFailed"), (
+                    "duplicate refresh returned a different job id while the first job is still active: "
+                    f"first={job_first} (state={first_progress.state}), second={second_result}"
+                )
+                second_progress = self.wait_refresh_progress(client, second_result)
+                assert second_progress.state == "RefreshCompleted", (
+                    f"second refresh job {second_result} ended in {second_progress.state}: {second_progress.reason}"
+                )
+        else:
+            assert "in progress" in second_result.message, second_result
+
         first_progress = self.wait_refresh_progress(client, job_first)
         assert first_progress.state == "RefreshCompleted"
 

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -3655,22 +3655,24 @@ class TestMilvusClientExternalTableRefresh(ExternalTableTestBase):
             check_task=CheckTasks.check_nothing,
         )
 
+        first_progress = self.wait_refresh_progress(client, job_first)
+        assert first_progress.state == "RefreshCompleted"
+
         if second_succeeded:
             if second_result != job_first:
-                first_progress = self.get_refresh_external_collection_progress(client, job_id=job_first)[0]
-                assert first_progress.state in ("RefreshCompleted", "RefreshFailed"), (
-                    "duplicate refresh returned a different job id while the first job is still active: "
-                    f"first={job_first} (state={first_progress.state}), second={second_result}"
-                )
                 second_progress = self.wait_refresh_progress(client, second_result)
                 assert second_progress.state == "RefreshCompleted", (
                     f"second refresh job {second_result} ended in {second_progress.state}: {second_progress.reason}"
                 )
+                assert first_progress.end_time <= second_progress.start_time, (
+                    "duplicate refresh jobs overlapped: "
+                    f"first={job_first} (end_time={first_progress.end_time}), "
+                    f"second={second_result} (start_time={second_progress.start_time})"
+                )
         else:
+            assert second_result.code == 703, second_result
             assert "in progress" in second_result.message, second_result
-
-        first_progress = self.wait_refresh_progress(client, job_first)
-        assert first_progress.state == "RefreshCompleted"
+            assert str(job_first) in second_result.message, second_result
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_external_table_list_refresh_jobs(self, minio_env, external_prefix):

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -714,9 +714,9 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_insert_over_resource_limit(self):
         """
-        target: test insert over RPC limitation 64MB (67108864)
-        method: insert excessive data
-        expected: raise exception
+        target: test insert over the materialized message size limit
+        method: insert data whose Proxy-side materialized message exceeds maxInsertSize
+        expected: reject the insert with a parameter-too-large error
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -725,7 +725,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 1. Create collection
         self.create_collection(client, collection_name, default_dim, auto_id=False)
 
-        # 2. Generate row data (150000 rows, which exceeds 64MB RPC limit)
+        # 2. Generate row data whose materialized message exceeds the default 64 MiB maxInsertSize
         rng = np.random.default_rng(seed=19530)
         rows = [
             {
@@ -738,8 +738,10 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         ]
 
         # 3. Verify error on insert
-        error = {ct.err_code: 999, ct.err_msg: "message larger than max"}
-        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
+        error, succeeded = self.insert(client, collection_name, data=rows, check_task=CheckTasks.check_nothing)
+        assert not succeeded, "insert unexpectedly accepted a message larger than maxInsertSize"
+        assert error.code == 1102, error
+        assert "exceeds maxInsertSize" in error.message, error
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -738,10 +738,14 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         ]
 
         # 3. Verify error on insert
-        error, succeeded = self.insert(client, collection_name, data=rows, check_task=CheckTasks.check_nothing)
-        assert not succeeded, "insert unexpectedly accepted a message larger than maxInsertSize"
+        error = self.insert(
+            client,
+            collection_name,
+            data=rows,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1102, ct.err_msg: "exceeds maxInsertSize"},
+        )[0]
         assert error.code == 1102, error
-        assert "exceeds maxInsertSize" in error.message, error
 
         self.drop_collection(client, collection_name)
 


### PR DESCRIPTION
issue: #53133
issue: #52648

## What was changed

- Handle both valid outcomes of two back-to-back external collection refresh requests:
  - reject or reuse the request while the first job is active;
  - allow a new job only after the first job reaches a terminal state.
- Update the oversized insert test to verify the current application-level
  `maxInsertSize` rejection.
- Assert error code `1102` and the stable `exceeds maxInsertSize` message instead
  of the obsolete gRPC `message larger than max` error.

## Why

The external refresh test assumed that the first job would always remain active
until the second request arrived. On faster environments, the first job can
complete before the second request, making a new refresh job valid.

The oversized insert test assumed a 64 MiB gRPC receive limit. The Proxy receive
limit is now 128 MiB, while oversized materialized inserts are rejected by the
64 MiB `quotaAndLimits.limits.maxInsertSize` guard.

## Verification

- `ruff check` passed for both changed files.
- `ruff format --check` passed for both changed files.
- Python compilation checks passed.
- External refresh regression E2E: passed.
- Oversized insert regression E2E: passed with error code `1102`.
