### PR TITLE
fix: clear stale StructArray offset aliases on reopen [3.0]

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -7119,7 +7119,8 @@ ChunkedSegmentSealedImpl::InvalidateStaleStructArrayOffsets(
     const SchemaPtr& current_schema,
     const SchemaPtr& target_schema,
     RuntimeResourceState& runtime) {
-    if (runtime.struct_to_array_offsets.empty()) {
+    if (runtime.struct_to_array_offsets.empty() &&
+        runtime.array_offsets_map.empty()) {
         return;
     }
 
@@ -7149,6 +7150,18 @@ ChunkedSegmentSealedImpl::InvalidateStaleStructArrayOffsets(
          it != runtime.struct_to_array_offsets.end();) {
         if (surviving_structs.find(it->first) == surviving_structs.end()) {
             it = runtime.struct_to_array_offsets.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Remove aliases for child fields that no longer exist in the target
+    // schema. Otherwise their shared_ptrs keep retired StructArray offsets
+    // reachable through GetArrayOffsets().
+    for (auto it = runtime.array_offsets_map.begin();
+         it != runtime.array_offsets_map.end();) {
+        if (!target_schema->has_field(it->first)) {
+            it = runtime.array_offsets_map.erase(it);
         } else {
             ++it;
         }

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -594,7 +594,11 @@ TEST(test_chunk_segment,
     auto old_offsets = segment->GetArrayOffsets(old_label);
     ASSERT_NE(old_offsets, nullptr);
     ASSERT_EQ(old_offsets.get(), segment->GetArrayOffsets(old_score).get());
-    ASSERT_EQ(old_offsets->GetTotalElementCount(), row_count * array_len);
+    // DataGen marks alternating rows valid for nullable scalar fields, starting
+    // with row 0. Sealed binlog serialization drops payloads from null rows, so
+    // only the three valid rows contribute elements to the shared offsets.
+    constexpr int64_t valid_row_count = (row_count + 1) / 2;
+    ASSERT_EQ(old_offsets->GetTotalElementCount(), valid_row_count * array_len);
 
     auto new_schema = std::make_shared<Schema>();
     new_schema->set_schema_version(2);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/52877
pr: https://github.com/milvus-io/milvus/pull/53153