### PR TITLE
fix: guard compaction publication (#51649)

### DIFF
--- a/internal/datacoord/compaction_task_bump_schema_version.go
+++ b/internal/datacoord/compaction_task_bump_schema_version.go
@@ -499,8 +499,9 @@ func (t *bumpSchemaVersionTask) commitBumpV3Materialization(ctx context.Context,
 	// pre-lock read here would only spuriously abort after a benign concurrent
 	// commit (e.g. a stats publication) advanced the pointer.
 	if err := manifestMeta.CommitSegmentManifest(ctx, SegmentManifestCommit{
-		SegmentID:     segmentID,
-		StorageConfig: compaction.CreateStorageConfig(),
+		SegmentID:      segmentID,
+		StorageConfig:  compaction.CreateStorageConfig(),
+		CompactionTask: t.GetTaskProto(),
 		Mutation: ManifestMutation{
 			Type: ManifestMutationCommitUpdates,
 			Updates: &packed.ManifestUpdates{

--- a/internal/datacoord/compaction_task_bump_schema_version_materialization_test.go
+++ b/internal/datacoord/compaction_task_bump_schema_version_materialization_test.go
@@ -160,6 +160,51 @@ func TestCommitBumpV3MaterializationHappyPath(t *testing.T) {
 	assert.EqualValues(t, 64, updated.GetStats().GetStatsBinlogSize())
 }
 
+func TestCommitBumpV3MaterializationRechecksSnapshotProtectionBeforePublication(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/500"
+	currentManifest := packed.MarshalManifestPath(basePath, 5)
+	newManifest := packed.MarshalManifestPath(basePath, 6)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	addMaterializationSegment(t, meta, currentManifest, 3)
+	sm := createTestSnapshotMetaLoaded(t)
+	meta.snapshotMeta = sm
+
+	task := newMaterializationTask(meta, 7)
+	require.NoError(t, meta.ValidateSegmentStateBeforeCompleteCompactionMutation(task.GetTaskProto()))
+
+	commit := mockey.Mock(packed.CommitManifestUpdates).To(
+		func(string, int64, *indexpb.StorageConfig, *packed.ManifestUpdates) (string, error) {
+			// Reproduce the seam: snapshot creation begins after the task's initial
+			// validation but before the prepared manifest is published under segMu.
+			sm.SetSnapshotPending(1)
+			return newManifest, nil
+		},
+	).Build()
+	defer commit.UnPatch()
+
+	_, err = task.commitBumpV3Materialization(context.Background(), materializationResult(nil))
+	require.ErrorIs(t, err, merr.ErrCompactionBlocked)
+
+	updated := meta.GetSegment(context.Background(), materializationSegmentID)
+	require.Equal(t, currentManifest, updated.GetManifestPath())
+	require.EqualValues(t, 3, updated.GetSchemaVersion())
+	require.Empty(t, updated.GetBinlogs())
+
+	// Snapshot protection is a compaction admission gate, so ordinary manifest
+	// writers that do not opt into the precondition remain unaffected.
+	require.NoError(t, meta.CommitSegmentManifest(context.Background(), SegmentManifestCommit{
+		SegmentID:     materializationSegmentID,
+		StorageConfig: &indexpb.StorageConfig{},
+		Mutation: ManifestMutation{
+			Type:    ManifestMutationCommitUpdates,
+			Updates: &packed.ManifestUpdates{},
+		},
+	}))
+	require.Equal(t, newManifest, meta.GetSegment(context.Background(), materializationSegmentID).GetManifestPath())
+}
+
 func TestCommitBumpV3MaterializationReplayShortCircuits(t *testing.T) {
 	basePath := "/tmp/milvus/insert_log/1/10/500"
 	currentManifest := packed.MarshalManifestPath(basePath, 5)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -2794,7 +2794,34 @@ func (m *meta) completeMixCompactionMutation(
 func (m *meta) ValidateSegmentStateBeforeCompleteCompactionMutation(t *datapb.CompactionTask) error {
 	m.segMu.RLock()
 	defer m.segMu.RUnlock()
+	if err := m.validateCompactionProtectionLocked(t); err != nil {
+		return err
+	}
 
+	for _, segmentID := range t.GetInputSegments() {
+		segment := m.segments.GetSegment(segmentID)
+		if !isSegmentHealthy(segment) {
+			// SHOULD NOT HAPPEN: input segment was dropped.
+			// This indicates that compaction tasks, which should be mutually exclusive,
+			// may have executed concurrently.
+			mlog.Warn(m.ctx, "should not happen! input segment was dropped",
+				mlog.Int64("planID", t.GetPlanID()),
+				mlog.String("type", t.GetType().String()),
+				mlog.String("channel", t.GetChannel()),
+				mlog.Int64("partitionID", t.GetPartitionID()),
+				mlog.Int64("segmentID", segmentID),
+			)
+			return merr.WrapErrSegmentNotFound(segmentID, "input segment was dropped")
+		}
+	}
+	return nil
+}
+
+// validateCompactionProtectionLocked checks the snapshot admission gates at a
+// metadata serialization boundary. The caller must hold segMu for reading or
+// writing so snapshot creation either observes the pre- or post-compaction
+// segment set after this check.
+func (m *meta) validateCompactionProtectionLocked(t *datapb.CompactionTask) error {
 	// Snapshot compaction protection exists to keep the sealed-segment list stable during
 	// backfill — if an L1/L2 segment gets merged away mid-backfill, the backfill breaks.
 	// L0 segments are transient delete-log carriers, not part of that stable list, and
@@ -2831,29 +2858,15 @@ func (m *meta) ValidateSegmentStateBeforeCompleteCompactionMutation(t *datapb.Co
 			}
 		}
 	}
-
-	for _, segmentID := range t.GetInputSegments() {
-		segment := m.segments.GetSegment(segmentID)
-		if !isSegmentHealthy(segment) {
-			// SHOULD NOT HAPPEN: input segment was dropped.
-			// This indicates that compaction tasks, which should be mutually exclusive,
-			// may have executed concurrently.
-			mlog.Warn(m.ctx, "should not happen! input segment was dropped",
-				mlog.Int64("planID", t.GetPlanID()),
-				mlog.String("type", t.GetType().String()),
-				mlog.String("channel", t.GetChannel()),
-				mlog.Int64("partitionID", t.GetPartitionID()),
-				mlog.Int64("segmentID", segmentID),
-			)
-			return merr.WrapErrSegmentNotFound(segmentID, "input segment was dropped")
-		}
-	}
 	return nil
 }
 
 func (m *meta) CompleteCompactionMutation(ctx context.Context, t *datapb.CompactionTask, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error) {
 	m.segMu.Lock()
 	defer m.segMu.Unlock()
+	if err := m.validateCompactionProtectionLocked(t); err != nil {
+		return nil, nil, err
+	}
 	switch t.GetType() {
 	case datapb.CompactionType_MixCompaction:
 		return m.completeMixCompactionMutation(t, result)

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -1296,6 +1296,21 @@ func (suite *MetaBasicSuite) TestValidateSegmentState_BlockedBySnapshot() {
 		suite.NoError(err)
 	})
 
+	suite.Run("complete mutation rechecks protection after initial validation", func() {
+		sm := createTestSnapshotMetaLoaded(suite.T())
+		m := &meta{
+			segments:     latestSegments,
+			snapshotMeta: sm,
+		}
+
+		suite.NoError(m.ValidateSegmentStateBeforeCompleteCompactionMutation(task))
+		sm.SetSnapshotPending(100)
+
+		_, _, err := m.CompleteCompactionMutation(context.Background(), task, &datapb.CompactionPlanResult{})
+		suite.ErrorIs(err, merr.ErrCompactionBlocked)
+		suite.Equal(commonpb.SegmentState_Flushed, m.segments.GetSegment(1).GetState())
+	})
+
 	suite.Run("rejected when only middle segment is protected in multi-segment task", func() {
 		multiSegments := NewSegmentsInfo()
 		for segID, segment := range map[UniqueID]*SegmentInfo{

--- a/internal/datacoord/segment_manifest_commit.go
+++ b/internal/datacoord/segment_manifest_commit.go
@@ -99,6 +99,9 @@ type SegmentManifestCommit struct {
 	StorageConfig    *indexpb.StorageConfig
 	Mutation         ManifestMutation
 	CatalogMutation  SegmentCatalogMutation
+	// CompactionTask opts this commit into a final snapshot-protection check
+	// while segMu is held. Ordinary manifest writers leave it nil.
+	CompactionTask *datapb.CompactionTask
 }
 
 // CommitSegmentManifest is the only DataCoord primitive that both creates a
@@ -184,6 +187,11 @@ func (m *meta) CommitSegmentManifest(ctx context.Context, commit SegmentManifest
 	// apply the catalog mutation to the latest clone rather than the I/O input.
 	m.segMu.Lock()
 	defer m.segMu.Unlock()
+	if commit.CompactionTask != nil {
+		if err := m.validateCompactionProtectionLocked(commit.CompactionTask); err != nil {
+			return err
+		}
+	}
 	latest := m.segments.GetSegment(commit.SegmentID)
 	if isNewSegment {
 		if latest != nil {


### PR DESCRIPTION
Related to #51649.

## Summary

- Recheck snapshot compaction protection inside the final metadata publication critical section.
- Apply the same opt-in guard to Storage V3 bump-schema materialization commits.
- Add deterministic regression coverage for both publication seams.