### PR TITLE
fix: [3.0] skip file resource sync before first add (#52707)

### DIFF
--- a/internal/coordinator/file_resource_observer.go
+++ b/internal/coordinator/file_resource_observer.go
@@ -131,7 +131,9 @@ func (m *FileResourceObserver) Start() {
 		m.startonce.Do(func() {
 			m.wg.Add(1)
 			go m.syncLoop()
-			m.Notify()
+			if !m.IsEmpty() {
+				m.Notify()
+			}
 		})
 	}
 }
@@ -148,6 +150,13 @@ func (m *FileResourceObserver) Notify() {
 	case m.notifyCh <- struct{}{}:
 	default:
 	}
+}
+
+func (m *FileResourceObserver) IsEmpty() bool {
+	if m.meta == nil {
+		return true
+	}
+	return !m.meta.HasFileResource(m.ctx)
 }
 
 // if node sync at least once, it will be a valid node.
@@ -196,6 +205,10 @@ func (m *FileResourceObserver) Sync() error {
 	var syncErr error
 	activeNodes := make(map[int64]struct{})
 	resources, targetVersion := m.meta.ListFileResource(m.ctx)
+	// Version 0 means no file resource has ever been added successfully.
+	if targetVersion == 0 {
+		return nil
+	}
 
 	// sync file resource to query node if file resource mode was Sync
 	if m.qnMode == fileresource.SyncMode {
@@ -317,10 +330,7 @@ func (m *FileResourceObserver) Sync() error {
 		return true
 	})
 
-	if syncErr != nil {
-		return syncErr
-	}
-	return nil
+	return syncErr
 }
 
 func (m *FileResourceObserver) InitMeta(meta rootcoord.IMetaTable) {

--- a/internal/coordinator/file_resource_observer_test.go
+++ b/internal/coordinator/file_resource_observer_test.go
@@ -70,7 +70,10 @@ func (s *FileResourceObserverSuite) TestNewFileResourceObserver() {
 }
 
 func (s *FileResourceObserverSuite) TestStartStop() {
-	s.Run("start_with_sync_mode", func() {
+	s.Run("start_with_sync_mode_and_no_resources", func() {
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+		mockCluster := qcsession.NewMockCluster(s.T())
 		observer := &FileResourceObserver{
 			ctx:          s.ctx,
 			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
@@ -78,24 +81,91 @@ func (s *FileResourceObserverSuite) TestStartStop() {
 			closeCh:      make(chan struct{}),
 			qnMode:       fileresource.SyncMode,
 			dnMode:       fileresource.CloseMode,
-
-			qnManager: qcsession.NewNodeManager(),
+			qnManager:    qnManager,
+			cluster:      mockCluster,
 		}
 
-		// Mock meta to avoid nil pointer
+		// A non-zero version with no current resources represents a restart after
+		// all resources were removed. Startup should not issue an empty sync RPC.
 		mockMeta := mockrootcoord.NewIMetaTable(s.T())
-		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(0)).Maybe()
+		mockMeta.EXPECT().HasFileResource(mock.Anything).Return(false).Twice()
 		observer.meta = mockMeta
 
+		// Simulate a node registration notification during coordinator startup.
+		if !observer.IsEmpty() {
+			observer.Notify()
+		}
 		observer.Start()
 		// Start should be idempotent
 		observer.Start()
-
-		// Give syncLoop time to start
-		time.Sleep(50 * time.Millisecond)
+		s.Empty(observer.notifyCh)
 
 		observer.Stop()
 		// Stop should be idempotent
+		observer.Stop()
+	})
+
+	s.Run("start_preserves_pending_mutation_retry", func() {
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+		mockCluster := qcsession.NewMockCluster(s.T())
+		mockCluster.EXPECT().SyncFileResource(mock.Anything, int64(1), mock.MatchedBy(func(req *internalpb.SyncFileResourceRequest) bool {
+			return len(req.GetResources()) == 0 && req.GetVersion() == 2
+		})).Return(merr.Success(), nil).Once()
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			notifyCh:     make(chan struct{}, 1),
+			closeCh:      make(chan struct{}),
+			qnMode:       fileresource.SyncMode,
+			dnMode:       fileresource.CloseMode,
+			qnManager:    qnManager,
+			cluster:      mockCluster,
+		}
+
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().HasFileResource(mock.Anything).Return(false).Once()
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(2)).Once()
+		observer.meta = mockMeta
+
+		// Mutation retries use the unconditional notification path and must not be
+		// discarded just because the observer starts with an empty resource list.
+		observer.Notify()
+		observer.Start()
+		s.Eventually(func() bool {
+			info, ok := observer.distribution.Get(1)
+			return ok && info.Version == 2
+		}, time.Second, 10*time.Millisecond)
+		observer.Stop()
+	})
+
+	s.Run("start_with_sync_mode_and_resources", func() {
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+		mockCluster := qcsession.NewMockCluster(s.T())
+		mockCluster.EXPECT().SyncFileResource(mock.Anything, int64(1), mock.Anything).Return(merr.Success(), nil).Once()
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			notifyCh:     make(chan struct{}, 1),
+			closeCh:      make(chan struct{}),
+			qnMode:       fileresource.SyncMode,
+			dnMode:       fileresource.CloseMode,
+			qnManager:    qnManager,
+			cluster:      mockCluster,
+		}
+
+		resources := []*internalpb.FileResourceInfo{{Name: "test"}}
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().HasFileResource(mock.Anything).Return(true).Once()
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(resources, uint64(1)).Once()
+		observer.meta = mockMeta
+
+		observer.Start()
+		s.Eventually(func() bool {
+			info, ok := observer.distribution.Get(1)
+			return ok && info.Version == 1
+		}, time.Second, 10*time.Millisecond)
 		observer.Stop()
 	})
 
@@ -131,6 +201,18 @@ func (s *FileResourceObserverSuite) TestNotify() {
 	s.Len(observer.notifyCh, 1)
 }
 
+func (s *FileResourceObserverSuite) TestIsEmpty() {
+	observer := &FileResourceObserver{ctx: s.ctx}
+	s.True(observer.IsEmpty())
+
+	mockMeta := mockrootcoord.NewIMetaTable(s.T())
+	mockMeta.EXPECT().HasFileResource(mock.Anything).Return(false).Once()
+	mockMeta.EXPECT().HasFileResource(mock.Anything).Return(true).Once()
+	observer.meta = mockMeta
+	s.True(observer.IsEmpty())
+	s.False(observer.IsEmpty())
+}
+
 func (s *FileResourceObserverSuite) TestCheckNodeSynced() {
 	s.Run("meta_not_ready", func() {
 		observer := &FileResourceObserver{
@@ -141,9 +223,21 @@ func (s *FileResourceObserverSuite) TestCheckNodeSynced() {
 		s.False(observer.CheckNodeSynced(1))
 	})
 
-	s.Run("no_resources", func() {
+	s.Run("no_resource_ever_added", func() {
 		mockMeta := mockrootcoord.NewIMetaTable(s.T())
 		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(0))
+
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			meta:         mockMeta,
+		}
+		s.True(observer.CheckNodeSynced(1))
+	})
+
+	s.Run("empty_resources_after_removal", func() {
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(2))
 
 		observer := &FileResourceObserver{
 			ctx:          s.ctx,
@@ -194,9 +288,22 @@ func (s *FileResourceObserverSuite) TestCheckAllQnReady() {
 		s.Error(err)
 	})
 
-	s.Run("no_resources", func() {
+	s.Run("no_resource_ever_added", func() {
 		mockMeta := mockrootcoord.NewIMetaTable(s.T())
 		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(0))
+
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			meta:         mockMeta,
+		}
+		err := observer.CheckAllQnReady()
+		s.NoError(err)
+	})
+
+	s.Run("empty_resources_after_removal", func() {
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(2))
 
 		observer := &FileResourceObserver{
 			ctx:          s.ctx,
@@ -263,6 +370,84 @@ func (s *FileResourceObserverSuite) TestCheckAllQnReady() {
 }
 
 func (s *FileResourceObserverSuite) TestSync() {
+	s.Run("skip_initial_sync_before_any_resource_is_added", func() {
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(0))
+
+		mockCluster := qcsession.NewMockCluster(s.T())
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+		mockDNManager := dcsession.NewMockNodeManager(s.T())
+		proxyManager := proxyutil.NewProxyClientManager(nil)
+		proxyManager.GetProxyClients().Insert(200, mocks.NewMockProxyClient(s.T()))
+
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			meta:         mockMeta,
+			qnManager:    qnManager,
+			dnManager:    mockDNManager,
+			cluster:      mockCluster,
+			proxyManager: proxyManager,
+			qnMode:       fileresource.SyncMode,
+			dnMode:       fileresource.SyncMode,
+			proxyMode:    fileresource.SyncMode,
+		}
+
+		err := observer.Sync()
+		s.NoError(err)
+		s.Equal(0, observer.distribution.Len())
+	})
+
+	s.Run("sync_empty_resources_after_last_resource_is_removed", func() {
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(2))
+
+		mockCluster := qcsession.NewMockCluster(s.T())
+		mockCluster.EXPECT().SyncFileResource(mock.Anything, int64(1), mock.MatchedBy(func(req *internalpb.SyncFileResourceRequest) bool {
+			return req.GetVersion() == 2 && len(req.GetResources()) == 0
+		})).Return(merr.Success(), nil)
+
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			meta:         mockMeta,
+			qnManager:    qnManager,
+			cluster:      mockCluster,
+			qnMode:       fileresource.SyncMode,
+			dnMode:       fileresource.CloseMode,
+		}
+		err := observer.Sync()
+		s.NoError(err)
+	})
+
+	s.Run("sync_empty_resources_failure", func() {
+		mockMeta := mockrootcoord.NewIMetaTable(s.T())
+		mockMeta.EXPECT().ListFileResource(mock.Anything).Return(nil, uint64(2))
+
+		mockCluster := qcsession.NewMockCluster(s.T())
+		mockCluster.EXPECT().SyncFileResource(mock.Anything, int64(1), mock.Anything).Return(nil, errors.New("rpc error"))
+
+		qnManager := qcsession.NewNodeManager()
+		qnManager.Add(qcsession.NewNodeInfo(qcsession.ImmutableNodeInfo{NodeID: 1}))
+
+		observer := &FileResourceObserver{
+			ctx:          s.ctx,
+			distribution: typeutil.NewConcurrentMap[int64, *NodeInfo](),
+			meta:         mockMeta,
+			qnManager:    qnManager,
+			cluster:      mockCluster,
+			qnMode:       fileresource.SyncMode,
+			dnMode:       fileresource.CloseMode,
+		}
+
+		err := observer.Sync()
+		s.Error(err)
+	})
+
 	s.Run("sync_query_nodes_success", func() {
 		mockMeta := mockrootcoord.NewIMetaTable(s.T())
 		resources := []*internalpb.FileResourceInfo{{Name: "test"}}
@@ -597,7 +782,6 @@ func (s *FileResourceObserverSuite) TestRetryNotify() {
 		notifyCh:     make(chan struct{}, 1),
 		closeCh:      make(chan struct{}),
 	}
-
 	// Clear channel first
 	select {
 	case <-observer.notifyCh:

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -171,6 +171,7 @@ type Server struct {
 
 type FileResourceObserver interface {
 	InitDataCoord(manager session.NodeManager)
+	IsEmpty() bool
 	Notify()
 }
 
@@ -877,7 +878,7 @@ func (s *Server) handleSessionEvent(ctx context.Context, role string, event *ses
 			}
 
 			// notify file manager sync file resource to new node
-			if s.fileResourceObserver != nil {
+			if s.fileResourceObserver != nil && !s.fileResourceObserver.IsEmpty() {
 				s.fileResourceObserver.Notify()
 			}
 		case sessionutil.SessionDelEvent:

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -137,6 +137,7 @@ type Server struct {
 
 type FileResourceObserver interface {
 	InitQueryCoord(manager *session.NodeManager, cluster session.Cluster)
+	IsEmpty() bool
 	Notify()
 }
 
@@ -677,7 +678,7 @@ func (s *Server) watchNodes(revision int64) {
 					Labels:   event.Session.GetServerLabel(),
 				}))
 				s.handleNodeUp(nodeID)
-				if s.fileResourceObserver != nil {
+				if s.fileResourceObserver != nil && !s.fileResourceObserver.IsEmpty() {
 					s.fileResourceObserver.Notify()
 				}
 

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -154,6 +154,7 @@ type IMetaTable interface {
 
 	AddFileResource(ctx context.Context, resource *internalpb.FileResourceInfo) error
 	RemoveFileResource(ctx context.Context, name string) (error, bool)
+	HasFileResource(ctx context.Context) bool
 	ListFileResource(ctx context.Context) ([]*internalpb.FileResourceInfo, uint64)
 	GetFileResources(ctx context.Context, resourceIDs ...int64) ([]*internalpb.FileResourceInfo, error)
 	IncFileResourceRefCnt(ids []int64) error
@@ -2496,6 +2497,13 @@ func (mt *MetaTable) GetFileResources(ctx context.Context, resourceIDs ...int64)
 		resources = append(resources, proto.Clone(resource).(*internalpb.FileResourceInfo))
 	}
 	return resources, nil
+}
+
+func (mt *MetaTable) HasFileResource(ctx context.Context) bool {
+	mt.ddLock.RLock()
+	defer mt.ddLock.RUnlock()
+
+	return len(mt.fileResourceID2Meta) > 0
 }
 
 // IncFileResourceRefCnt increments refCnt for file resources, reserving them for

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1863,6 +1863,14 @@ func TestMetaTableGetFileResources(t *testing.T) {
 	})
 }
 
+func TestMetaTableHasFileResource(t *testing.T) {
+	meta := &MetaTable{fileResourceID2Meta: make(map[int64]*internalpb.FileResourceInfo)}
+	require.False(t, meta.HasFileResource(context.Background()))
+
+	meta.fileResourceID2Meta[1] = &internalpb.FileResourceInfo{Id: 1}
+	require.True(t, meta.HasFileResource(context.Background()))
+}
+
 func TestMetaTable_DropPartition_CopyOnWrite(t *testing.T) {
 	catalog := mocks.NewRootCoordCatalog(t)
 	originalPart := &model.Partition{

--- a/internal/rootcoord/mock_file_resource_observer.go
+++ b/internal/rootcoord/mock_file_resource_observer.go
@@ -95,6 +95,51 @@ func (_c *MockFileResourceObserver_InitMeta_Call) RunAndReturn(run func(IMetaTab
 	return _c
 }
 
+// IsEmpty provides a mock function with no fields
+func (_m *MockFileResourceObserver) IsEmpty() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsEmpty")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockFileResourceObserver_IsEmpty_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsEmpty'
+type MockFileResourceObserver_IsEmpty_Call struct {
+	*mock.Call
+}
+
+// IsEmpty is a helper method to define mock.On call
+func (_e *MockFileResourceObserver_Expecter) IsEmpty() *MockFileResourceObserver_IsEmpty_Call {
+	return &MockFileResourceObserver_IsEmpty_Call{Call: _e.mock.On("IsEmpty")}
+}
+
+func (_c *MockFileResourceObserver_IsEmpty_Call) Run(run func()) *MockFileResourceObserver_IsEmpty_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockFileResourceObserver_IsEmpty_Call) Return(_a0 bool) *MockFileResourceObserver_IsEmpty_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockFileResourceObserver_IsEmpty_Call) RunAndReturn(run func() bool) *MockFileResourceObserver_IsEmpty_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Notify provides a mock function with no fields
 func (_m *MockFileResourceObserver) Notify() {
 	_m.Called()

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -2679,6 +2679,52 @@ func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// HasFileResource provides a mock function with given fields: ctx
+func (_m *IMetaTable) HasFileResource(ctx context.Context) bool {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasFileResource")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// IMetaTable_HasFileResource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasFileResource'
+type IMetaTable_HasFileResource_Call struct {
+	*mock.Call
+}
+
+// HasFileResource is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *IMetaTable_Expecter) HasFileResource(ctx interface{}) *IMetaTable_HasFileResource_Call {
+	return &IMetaTable_HasFileResource_Call{Call: _e.mock.On("HasFileResource", ctx)}
+}
+
+func (_c *IMetaTable_HasFileResource_Call) Run(run func(ctx context.Context)) *IMetaTable_HasFileResource_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_HasFileResource_Call) Return(_a0 bool) *IMetaTable_HasFileResource_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *IMetaTable_HasFileResource_Call) RunAndReturn(run func(context.Context) bool) *IMetaTable_HasFileResource_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IncFileResourceRefCnt provides a mock function with given fields: ids
 func (_m *IMetaTable) IncFileResourceRefCnt(ids []int64) error {
 	ret := _m.Called(ids)

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -181,6 +181,7 @@ type Core struct {
 type FileResourceObserver interface {
 	CheckAllQnReady() error
 	InitMeta(meta IMetaTable)
+	IsEmpty() bool
 	Notify()
 	Sync() error
 }
@@ -245,14 +246,14 @@ func (c *Core) ServerExist(serverID int64) bool {
 
 func (c *Core) setProxyClients(sessions []*sessionutil.Session) {
 	c.proxyClientManager.SetProxyClients(sessions)
-	if c.fileResourceObserver != nil {
+	if c.fileResourceObserver != nil && !c.fileResourceObserver.IsEmpty() {
 		c.fileResourceObserver.Notify()
 	}
 }
 
 func (c *Core) addProxyClient(session *sessionutil.Session) {
 	c.proxyClientManager.AddProxyClient(session)
-	if c.fileResourceObserver != nil {
+	if c.fileResourceObserver != nil && !c.fileResourceObserver.IsEmpty() {
 		c.fileResourceObserver.Notify()
 	}
 }

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -2272,6 +2272,7 @@ func TestCore_NotifyFileResourceObserverOnProxySession(t *testing.T) {
 		proxyManager.EXPECT().AddProxyClient(session).Run(func(*sessionutil.Session) {
 			clientAdded = true
 		})
+		observer.EXPECT().IsEmpty().Return(false)
 		observer.EXPECT().Notify().Run(func() {
 			assert.True(t, clientAdded)
 		})
@@ -2290,6 +2291,7 @@ func TestCore_NotifyFileResourceObserverOnProxySession(t *testing.T) {
 		proxyManager.EXPECT().SetProxyClients(sessions).Run(func([]*sessionutil.Session) {
 			clientsSet = true
 		})
+		observer.EXPECT().IsEmpty().Return(false)
 		observer.EXPECT().Notify().Run(func() {
 			assert.True(t, clientsSet)
 		})
@@ -2307,6 +2309,19 @@ func TestCore_NotifyFileResourceObserverOnProxySession(t *testing.T) {
 
 		c := newTestCore()
 		c.proxyClientManager = proxyManager
+		c.addProxyClient(session)
+	})
+
+	t.Run("empty resources", func(t *testing.T) {
+		proxyManager := proxyutil.NewMockProxyClientManager(t)
+		observer := NewMockFileResourceObserver(t)
+		session := &sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: TestProxyID}}
+		proxyManager.EXPECT().AddProxyClient(session)
+		observer.EXPECT().IsEmpty().Return(true)
+
+		c := newTestCore()
+		c.proxyClientManager = proxyManager
+		c.SetFileResourceObserver(observer)
 		c.addProxyClient(session)
 	})
 }


### PR DESCRIPTION
issue: #52216
pr: https://github.com/milvus-io/milvus/pull/52707

## Summary
Skip FileResource synchronization while the metadata version is zero, and avoid startup or node-registration notifications when the active resource set is empty. Preserve direct empty-list synchronization after the last resource is removed so node-local files are still cleared.