### PR TITLE
fix: avoid duplicate chown layers in runtime images

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -39,8 +39,8 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
-    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
+USER milvus:milvus
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
 
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.

--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -13,6 +13,7 @@ FROM amazonlinux:2023
 
 ARG TARGETARCH
 ARG MILVUS_ASAN_LIB
+ARG MILVUS_RUNTIME_USER=milvus:milvus
 
 RUN yum install -y wget libgomp libaio libatomic tzdata && \
     yum upgrade -y openssl openssl-libs && \
@@ -22,12 +23,13 @@ RUN yum install -y wget libgomp libaio libatomic tzdata && \
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
     chmod +x /tini
 
-RUN mkdir -p /milvus/bin
-COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus --chmod=774 ./bin/milvus /milvus/bin/milvus
 
-COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus --chmod=774 ./configs/ /milvus/configs/
 
-COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
+COPY --chown=milvus:milvus --chmod=774 ./lib/ /milvus/lib/
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
@@ -37,17 +39,15 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
+    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
 
-# Change user to milvus
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
-ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -12,17 +12,20 @@ ARG MILVUS_BASE_IMAGE_REPO="milvusdb/milvus-base"
 ARG MILVUS_BASE_IMAGE_TAG="gpu-20230822-34f9067"
 FROM ${MILVUS_BASE_IMAGE_REPO}:${MILVUS_BASE_IMAGE_TAG}
 
+ARG MILVUS_RUNTIME_USER=milvus:milvus
+
 # Upgrade openssl to fix CVE-2026-45447 (base image is a pinned/legacy ubuntu20.04 build)
 RUN apt-get update && \
     apt-get upgrade -y openssl libssl1.1 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /milvus/bin
-COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus --chmod=774 ./bin/milvus /milvus/bin/milvus
 
-COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus --chmod=774 ./configs/ /milvus/configs/
 
-COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
+COPY --chown=milvus:milvus --chmod=774 ./lib/ /milvus/lib/
 
 
 ENV PATH=/milvus/bin:$PATH
@@ -30,8 +33,5 @@ ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
 
-# Change user to milvus
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04
 
 ARG TARGETARCH
+ARG MILVUS_RUNTIME_USER=milvus:milvus
 
 # Install ca-certificates first, then switch to HTTPS and install other packages
 RUN apt-get update && \
@@ -19,10 +20,11 @@ RUN apt-get update && \
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
     chmod +x /tini
 
-RUN mkdir -p /milvus/bin
-COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus 
-COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
-COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus --chmod=774 ./bin/milvus /milvus/bin/milvus
+COPY --chown=milvus:milvus --chmod=774 ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus --chmod=774 ./lib/ /milvus/lib/
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
@@ -32,15 +34,12 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
+    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
 
-# Change user to milvus
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
-USER milvus:milvus
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}
 
 ENTRYPOINT ["/tini", "--"]
 
 WORKDIR /milvus
-

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -34,8 +34,8 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
-    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
+USER milvus:milvus
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
 
 # Run as milvus by default; downstream images may select another user at build time.
 USER ${MILVUS_RUNTIME_USER}

--- a/build/docker/milvus/rockylinux9/Dockerfile
+++ b/build/docker/milvus/rockylinux9/Dockerfile
@@ -41,8 +41,8 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
-    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
+USER milvus:milvus
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
 
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.

--- a/build/docker/milvus/rockylinux9/Dockerfile
+++ b/build/docker/milvus/rockylinux9/Dockerfile
@@ -13,6 +13,7 @@ FROM rockylinux/rockylinux:9
 
 ARG TARGETARCH
 ARG MILVUS_ASAN_LIB
+ARG MILVUS_RUNTIME_USER=milvus:milvus
 
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
@@ -24,12 +25,13 @@ RUN dnf install -y dnf-plugins-core && \
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
     chmod +x /tini
 
-RUN mkdir -p /milvus/bin
-COPY ./bin/milvus /milvus/bin/milvus
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus ./bin/milvus /milvus/bin/milvus
 
-COPY ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus ./configs/ /milvus/configs/
 
-COPY ./lib/ /milvus/lib/
+COPY --chown=milvus:milvus ./lib/ /milvus/lib/
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
@@ -39,17 +41,15 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
+    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
 
-# Change user to milvus
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
-ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:focal-20240530
 
 ARG TARGETARCH
 ARG MILVUS_ASAN_LIB
+ARG MILVUS_RUNTIME_USER=milvus:milvus
 
 # Install ca-certificates first, then switch to HTTPS and install other packages
 RUN apt-get update && \
@@ -31,27 +32,25 @@ RUN apt-get update && \
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
     chmod +x /tini
 
-RUN mkdir -p /milvus/bin
-COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus --chmod=774 ./bin/milvus /milvus/bin/milvus
 
-COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus --chmod=774 ./configs/ /milvus/configs/
 
-COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
+COPY --chown=milvus:milvus --chmod=774 ./lib/ /milvus/lib/
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
 
-# Change user to milvus
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
-ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:jammy-20240530
 
 ARG TARGETARCH
 ARG MILVUS_ASAN_LIB
+ARG MILVUS_RUNTIME_USER=milvus:milvus
 
 # Install ca-certificates first, then switch to HTTPS and install other packages
 RUN apt-get update && \
@@ -31,12 +32,13 @@ RUN apt-get update && \
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
     chmod +x /tini
 
-RUN mkdir -p /milvus/bin
-COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
+RUN groupadd -r milvus && useradd -r -g milvus milvus && \
+    install -d -o milvus -g milvus /milvus /milvus/bin /var/lib/milvus
+COPY --chown=milvus:milvus --chmod=774 ./bin/milvus /milvus/bin/milvus
 
-COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
+COPY --chown=milvus:milvus --chmod=774 ./configs/ /milvus/configs/
 
-COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
+COPY --chown=milvus:milvus --chmod=774 ./lib/ /milvus/lib/
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
@@ -46,17 +48,15 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
+    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
 
-# Change user to milvus
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.
-ENV ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
-RUN groupadd -r milvus && useradd -r -g milvus milvus && \
-    mkdir -p /var/lib/milvus && \
-    chown -R milvus:milvus /milvus /var/lib/milvus
 ENV ASAN_OPTIONS=detect_leaks=1:detect_container_overflow=0
-USER milvus:milvus
+
+# Run as milvus by default; downstream images may select another user at build time.
+USER ${MILVUS_RUNTIME_USER}
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -48,8 +48,8 @@ ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 # Generate fipsmodule.cnf for FIPS module integrity self-test.
 # FIPS activation is handled programmatically at startup — no OPENSSL_CONF needed.
-RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so && \
-    chown milvus:milvus /milvus/configs/ssl/fipsmodule.cnf
+USER milvus:milvus
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
 
 # protobuf 5.x RepeatedField adds container annotations that trigger ASAN
 # container-overflow false positives during static initialization, disable it.


### PR DESCRIPTION
## What

Fix the duplicated multi-gigabyte ownership layer in Milvus runtime images.

- create the `milvus` user and writable runtime directories before copying artifacts
- copy binaries, configs, and libraries with their final `milvus:milvus` ownership
- remove recursive `chown -R` over `/milvus`
- only chown the small generated FIPS config file
- preserve `milvus:milvus` as the default runtime user
- add `MILVUS_RUNTIME_USER` as an explicit build-time override for downstream images that require another runtime user

This is applied consistently to Ubuntu 20.04/22.04, Amazon Linux 2023, Rocky Linux 9, and GPU runtime Dockerfiles.

Fixes #53172

## Why

The current Dockerfiles copy large artifacts as `root:root` and recursively change ownership in a later layer. OCI image layering materializes the changed files again, which can add multiple gigabytes to the published image.

## Verification

- `git diff --check`
- contract check across all six runtime Dockerfiles:
  - user creation precedes artifact copies
  - all artifact copies use `--chown=milvus:milvus`
  - no recursive Milvus ownership change remains
  - default runtime user remains `milvus:milvus`
- local BuildKit parser check was unavailable because the local Docker daemon is not running; remote image build and runtime smoke checks are expected from PR CI
