### PR TITLE
enhance: avoid widening narrow roaring filter inputs

### DIFF
--- a/client/membership/roaringfilter/roaring_filter.go
+++ b/client/membership/roaringfilter/roaring_filter.go
@@ -93,15 +93,25 @@ const (
 	EstimatedLowContainerOverheadBytes = 64
 )
 
-// Build deduplicates members into a portable Roaring64 bitmap and wraps it in
-// an MRB1 envelope.
+// Build deduplicates int64 members into a portable Roaring64 bitmap and wraps
+// it in an MRB1 envelope. It retains the original []int64 API; callers with a
+// narrower signed slice can use BuildSigned to avoid widening the whole input.
 func Build(members []int64) ([]byte, error) {
+	return BuildSigned(members)
+}
+
+// BuildSigned deduplicates signed integer members into a portable Roaring64
+// bitmap and wraps it in an MRB1 envelope. Narrow signed values are extended to
+// int64 before their two's-complement bits become Roaring keys. The conversion
+// happens as each value is consumed, so callers do not need an intermediate
+// []int64 allocation.
+func BuildSigned[T ~int | ~int8 | ~int16 | ~int32 | ~int64](members []T) ([]byte, error) {
 	var sortedKeys []uint64
 	ascending, highContainerCount, lowContainerCount := memberContainerCounts(members)
 	if !ascending {
 		sortedKeys = make([]uint64, len(members))
 		for i, member := range members {
-			sortedKeys[i] = uint64(member)
+			sortedKeys[i] = uint64(int64(member))
 		}
 		slices.Sort(sortedKeys)
 		highContainerCount, lowContainerCount = sortedKeyContainerCounts(sortedKeys)
@@ -128,7 +138,7 @@ func Build(members []int64) ([]byte, error) {
 			// Add extends the last container or appends a new one, so this is
 			// linear and, unlike the sort path, allocates nothing per member.
 			for _, member := range members {
-				bitmap.Add(uint64(member))
+				bitmap.Add(uint64(int64(member)))
 			}
 		} else {
 			bitmap.AddMany(sortedKeys)
@@ -178,15 +188,15 @@ func Build(members []int64) ([]byte, error) {
 // memberContainerCounts reports whether members is already non-decreasing in
 // the unsigned key space and, when it is, counts distinct high-32 children and
 // Roaring32 low containers without allocating. Equal keys are duplicates.
-func memberContainerCounts(members []int64) (bool, uint64, uint64) {
+func memberContainerCounts[T ~int | ~int8 | ~int16 | ~int32 | ~int64](members []T) (bool, uint64, uint64) {
 	if len(members) == 0 {
 		return true, 0, 0
 	}
-	previous := uint64(members[0])
+	previous := uint64(int64(members[0]))
 	highContainerCount := uint64(1)
 	lowContainerCount := uint64(1)
 	for i := 1; i < len(members); i++ {
-		key := uint64(members[i])
+		key := uint64(int64(members[i]))
 		if key < previous {
 			return false, 0, 0
 		}

--- a/client/membership/roaringfilter/roaring_filter_test.go
+++ b/client/membership/roaringfilter/roaring_filter_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var _ func([]int64) ([]byte, error) = Build
+
 // The structural rejection suite for this format lives with the validator, in
 // pkg/util/roaringfilter, and the cross-check that a blob built here is one the
 // proxy accepts lives in internal/parser/planparserv2 (it needs both modules).
@@ -97,6 +99,40 @@ func TestBuildPreservesSignedBitPattern(t *testing.T) {
 		require.Truef(t, bitmap.Contains(c.key),
 			"member %d must map to key %#016x", c.member, c.key)
 	}
+}
+
+type namedSignedInt16 int16
+
+func requireBuildSignedMatchesBuild[T ~int | ~int8 | ~int16 | ~int32 | ~int64](
+	t *testing.T,
+	members []T,
+) {
+	t.Helper()
+	widened := make([]int64, len(members))
+	for i, member := range members {
+		widened[i] = int64(member)
+	}
+
+	want, err := Build(widened)
+	require.NoError(t, err)
+	got, err := BuildSigned(members)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestBuildSignedMatchesInt64API(t *testing.T) {
+	requireBuildSignedMatchesBuild(t, []int{-1, 0, 1, 42})
+	requireBuildSignedMatchesBuild(t, []int8{math.MinInt8, -1, 0, math.MaxInt8})
+	requireBuildSignedMatchesBuild(t, []int16{math.MinInt16, -1, 0, math.MaxInt16})
+	requireBuildSignedMatchesBuild(t, []int32{math.MinInt32, -1, 0, math.MaxInt32})
+	requireBuildSignedMatchesBuild(t, []int64{math.MinInt64, -1, 0, math.MaxInt64})
+	requireBuildSignedMatchesBuild(t, []namedSignedInt16{-1, 0, 42})
+
+	members := []int16{9, 3, -5, 1}
+	original := append([]int16(nil), members...)
+	_, err := BuildSigned(members)
+	require.NoError(t, err)
+	require.Equal(t, original, members, "BuildSigned must not reorder the caller's slice")
 }
 
 func TestBuildEmptySet(t *testing.T) {

--- a/client/milvusclient/roaring_filter.go
+++ b/client/milvusclient/roaring_filter.go
@@ -27,39 +27,29 @@ import (
 // template value and contains an MRB1 envelope around portable Roaring64 data.
 type RoaringBitmapBlob []byte
 
-type signedInteger interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64
-}
-
-func widenSignedIntegers[T signedInteger](members []T) []int64 {
-	values := make([]int64, len(members))
-	for i, member := range members {
-		values[i] = int64(member)
-	}
-	return values
-}
-
 // NewRoaringBitmapBlob builds an exact membership bitmap from a slice of
 // signed integers. Supported input types are []int, []int8, []int16, []int32,
 // and []int64; values are sign-extended to int64 before serialization.
 func NewRoaringBitmapBlob(members any) (RoaringBitmapBlob, error) {
-	var values []int64
+	var (
+		blob []byte
+		err  error
+	)
 	switch typed := members.(type) {
 	case []int:
-		values = widenSignedIntegers(typed)
+		blob, err = roaringfilter.BuildSigned(typed)
 	case []int8:
-		values = widenSignedIntegers(typed)
+		blob, err = roaringfilter.BuildSigned(typed)
 	case []int16:
-		values = widenSignedIntegers(typed)
+		blob, err = roaringfilter.BuildSigned(typed)
 	case []int32:
-		values = widenSignedIntegers(typed)
+		blob, err = roaringfilter.BuildSigned(typed)
 	case []int64:
-		values = typed
+		blob, err = roaringfilter.Build(typed)
 	default:
 		return nil, errors.Errorf(
 			"roaring bitmap members must be []int, []int8, []int16, []int32, or []int64, got %T", members)
 	}
-	blob, err := roaringfilter.Build(values)
 	if err != nil {
 		return nil, err
 	}

--- a/client/milvusclient/roaring_filter_test.go
+++ b/client/milvusclient/roaring_filter_test.go
@@ -106,3 +106,72 @@ func TestRoaringBitmapBlobTemplateMarshaling(t *testing.T) {
 	require.True(t, ok, "RoaringBitmapBlob must marshal as native protobuf bytes")
 	require.Equal(t, []byte(blob), bytesValue.BytesVal)
 }
+
+var benchmarkRoaringBitmapBlobSink RoaringBitmapBlob
+
+func makeSignedMembers[T ~int32 | ~int64](n int, shuffled bool) []T {
+	members := make([]T, n)
+	for i := range members {
+		value := i
+		if shuffled {
+			value = (i*2053)%n - n/2
+		}
+		members[i] = T(value)
+	}
+	return members
+}
+
+func roaringBitmapBlobAllocsPerRun(members any) (float64, error) {
+	var err error
+	allocs := testing.AllocsPerRun(20, func() {
+		benchmarkRoaringBitmapBlobSink, err = NewRoaringBitmapBlob(members)
+	})
+	return allocs, err
+}
+
+func TestNewRoaringBitmapBlobNarrowAllocationParity(t *testing.T) {
+	for _, shuffled := range []bool{false, true} {
+		name := "ordered"
+		if shuffled {
+			name = "shuffled"
+		}
+		t.Run(name, func(t *testing.T) {
+			int32Members := makeSignedMembers[int32](4096, shuffled)
+			int64Members := makeSignedMembers[int64](4096, shuffled)
+			int32Allocs, err := roaringBitmapBlobAllocsPerRun(int32Members)
+			require.NoError(t, err)
+			int64Allocs, err := roaringBitmapBlobAllocsPerRun(int64Members)
+			require.NoError(t, err)
+			require.Equal(t, int64Allocs, int32Allocs,
+				"a narrow input must not allocate an intermediate []int64")
+		})
+	}
+}
+
+func benchmarkNewRoaringBitmapBlob(b *testing.B, members any) {
+	b.Helper()
+	blob, err := NewRoaringBitmapBlob(members)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkRoaringBitmapBlobSink = blob
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		blob, err := NewRoaringBitmapBlob(members)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkRoaringBitmapBlobSink = blob
+	}
+}
+
+func BenchmarkNewRoaringBitmapBlobInt32Shuffled(b *testing.B) {
+	members := makeSignedMembers[int32](64*1024, true)
+	benchmarkNewRoaringBitmapBlob(b, members)
+}
+
+func BenchmarkNewRoaringBitmapBlobInt64Shuffled(b *testing.B) {
+	members := makeSignedMembers[int64](64*1024, true)
+	benchmarkNewRoaringBitmapBlob(b, members)
+}


### PR DESCRIPTION
Follow-up to #52778. The equivalent fix is also included in #53019 for the `3.0` branch.

issue: #52777

## What this PR does

`NewRoaringBitmapBlob` previously widened every `[]int`, `[]int8`, `[]int16`, and `[]int32` into a full `[]int64`. For unordered input, the lower-level builder then allocated another full `[]uint64` sorting buffer.

This change adds an additive generic `BuildSigned` path that sign-extends values while consuming them. Ordered narrow inputs need no input-sized conversion buffer; unordered inputs allocate only the required `[]uint64` sorting buffer.

The existing `Build([]int64) ([]byte, error)` API remains unchanged and delegates to the generic implementation.

## Compatibility

- Preserves byte-identical MRB1 output for every supported signed width.
- Preserves two-complement signed-key mapping.
- Preserves the caller slice without reordering it.
- Retains the exact existing `Build` function signature.

## Design document

This is a focused resource-usage correction to the existing [membership_match design](https://github.com/milvus-io/milvus/blob/master/docs/design-docs/design_docs/20260822-membership-match-expression.md).

## Test plan

- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./membership/roaringfilter ./milvusclient`
- [x] Byte-equivalence coverage for `int`, `int8`, `int16`, `int32`, `int64`, and named signed types.
- [x] Ordered and shuffled narrow-vs-int64 allocation-parity coverage.
- [x] Paired benchmark: both int32 and int64 paths stabilize at 58 allocs/op and about 853 KB/op for 65,536 shuffled members; the previous extra `8*N` allocation is gone.
- [x] `git diff --check`