### PR TITLE
fix: handle unavailable compaction result payloads

### DIFF
--- a/internal/datacoord/compaction_result_retry_test.go
+++ b/internal/datacoord/compaction_result_retry_test.go
@@ -1,0 +1,134 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestCompactionUnavailableResult(t *testing.T) {
+	for _, typ := range []datapb.CompactionType{
+		datapb.CompactionType_MixCompaction,
+		datapb.CompactionType_SortCompaction,
+		datapb.CompactionType_Level0DeleteCompaction,
+		datapb.CompactionType_ClusteringCompaction,
+		datapb.CompactionType_BumpSchemaVersionCompaction,
+	} {
+		t.Run(typ.String(), func(t *testing.T) {
+			newTask := func(meta CompactionMeta) CompactionTask {
+				p := &datapb.CompactionTask{
+					PlanID: 10, NodeID: 20, Type: typ,
+					State:      datapb.CompactionTaskState_executing,
+					RetryTimes: 1, FailReason: "previous reason",
+				}
+				switch typ {
+				case datapb.CompactionType_Level0DeleteCompaction:
+					return newL0CompactionTask(p, nil, meta)
+				case datapb.CompactionType_ClusteringCompaction:
+					return newClusteringCompactionTask(p, nil, meta, nil, nil, nil)
+				case datapb.CompactionType_BumpSchemaVersionCompaction:
+					return newBumpSchemaVersionTask(p, nil, meta, nil)
+				default:
+					return newMixCompactionTask(p, nil, meta, nil)
+				}
+			}
+			query := &datapb.CompactionStateRequest{PlanID: 10}
+			lostResult := merr.WrapErrCompactionResultNotFound("terminal task has no payload")
+
+			t.Run("drop then reset without changing retry metadata", func(t *testing.T) {
+				meta := NewMockCompactionMeta(t)
+				cluster := session.NewMockCluster(t)
+				task := newTask(meta)
+				dropped := false
+				cluster.EXPECT().QueryCompaction(int64(20), query).Return(nil, lostResult).Once()
+				cluster.EXPECT().DropCompaction(int64(20), int64(10)).Run(func(int64, int64) {
+					dropped = true
+				}).Return(nil).Once()
+				expected := task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
+				meta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).
+					Run(func(_ context.Context, saved *datapb.CompactionTask) {
+						require.True(t, dropped)
+						require.True(t, proto.Equal(expected, saved))
+					}).Return(nil).Once()
+
+				task.QueryTaskOnWorker(cluster)
+				require.True(t, proto.Equal(expected, task.GetTaskProto()))
+				require.Equal(t, taskcommon.Init, task.GetTaskState())
+			})
+
+			t.Run("drop failure keeps original task", func(t *testing.T) {
+				meta := NewMockCompactionMeta(t)
+				cluster := session.NewMockCluster(t)
+				task := newTask(meta)
+				original := task.ShadowClone()
+				cluster.EXPECT().QueryCompaction(int64(20), query).Return(nil, lostResult).Once()
+				// Even a non-retriable drop error must not fail a clustering task.
+				cluster.EXPECT().DropCompaction(int64(20), int64(10)).
+					Return(merr.WrapErrServiceInternalMsg("drop failed")).Once()
+
+				task.QueryTaskOnWorker(cluster)
+				require.True(t, proto.Equal(original, task.GetTaskProto()))
+				meta.AssertNotCalled(t, "SaveCompactionTask", mock.Anything, mock.Anything)
+			})
+		})
+	}
+}
+
+func TestMixCompactionDeletedErrorAfterSaveFailure(t *testing.T) {
+	meta := NewMockCompactionMeta(t)
+	cluster := session.NewMockCluster(t)
+	task := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID: 10, NodeID: 20, Type: datapb.CompactionType_MixCompaction,
+		State:      datapb.CompactionTaskState_executing,
+		RetryTimes: 1, FailReason: "previous reason",
+	}, nil, meta, nil)
+	original := task.ShadowClone()
+	expected := task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
+	query := &datapb.CompactionStateRequest{PlanID: 10}
+	cluster.EXPECT().QueryCompaction(int64(20), query).
+		Return(nil, merr.WrapErrCompactionResultNotFound("terminal task has no payload")).Once()
+	cluster.EXPECT().DropCompaction(int64(20), int64(10)).Return(nil).Once()
+	meta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).
+		Return(merr.WrapErrServiceUnavailableMsg("meta unavailable")).Once()
+
+	task.QueryTaskOnWorker(cluster)
+	require.True(t, proto.Equal(original, task.GetTaskProto()))
+
+	// Model Hummer's reported deleted response as a generic query error.
+	// This does not assert a particular Hummer error code or the DataNode protocol.
+	cluster.EXPECT().QueryCompaction(int64(20), query).
+		Return(nil, merr.WrapErrServiceInternalMsg("task 10 deleted")).Once()
+	meta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, saved *datapb.CompactionTask) {
+			require.True(t, proto.Equal(expected, saved))
+		}).Return(nil).Once()
+
+	task.QueryTaskOnWorker(cluster)
+	require.True(t, proto.Equal(expected, task.GetTaskProto()))
+	require.Equal(t, taskcommon.Init, task.GetTaskState())
+	cluster.AssertNumberOfCalls(t, "DropCompaction", 1)
+}

--- a/internal/datacoord/compaction_task_bump_schema_version.go
+++ b/internal/datacoord/compaction_task_bump_schema_version.go
@@ -259,7 +259,13 @@ func (t *bumpSchemaVersionTask) QueryTaskOnWorker(cluster session.Cluster) {
 		PlanID: t.GetTaskProto().GetPlanID(),
 	})
 	if err != nil || result == nil {
-		if errors.Is(err, merr.ErrNodeNotFound) {
+		if errors.Is(err, merr.ErrCompactionResultNotFound) {
+			if dropErr := cluster.DropCompaction(t.GetTaskProto().GetNodeID(), t.GetTaskProto().GetPlanID()); dropErr != nil {
+				log.Warn(context.TODO(), "bumpSchemaVersionTask failed to drop task with unavailable result", mlog.Err(dropErr))
+				return
+			}
+		}
+		if errors.Is(err, merr.ErrNodeNotFound) || errors.Is(err, merr.ErrCompactionResultNotFound) {
 			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
 				log.Warn(context.TODO(), "bumpSchemaVersionTask failed to updateAndSaveTaskMeta", mlog.Err(err))
 			}

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
@@ -152,6 +153,14 @@ func (t *clusteringCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 		PlanID: t.GetTaskProto().GetPlanID(),
 	})
 	if err != nil || result == nil {
+		if errors.Is(err, merr.ErrCompactionResultNotFound) {
+			if dropErr := cluster.DropCompaction(t.GetTaskProto().GetNodeID(), t.GetTaskProto().GetPlanID()); dropErr != nil {
+				mlog.Warn(context.TODO(), "clusteringCompactionTask failed to drop task with unavailable result", mlog.Err(dropErr))
+				// Keep querying this worker; retryOnError must not fail the task.
+				err = nil
+				return
+			}
+		}
 		mlog.Warn(context.TODO(), "clusteringCompactionTask failed to get compaction result", mlog.Err(err))
 		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
 		if err != nil {

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
@@ -152,6 +153,12 @@ func (t *l0CompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 		PlanID: t.GetTaskProto().GetPlanID(),
 	})
 	if err != nil || result == nil {
+		if errors.Is(err, merr.ErrCompactionResultNotFound) {
+			if dropErr := cluster.DropCompaction(t.GetTaskProto().GetNodeID(), t.GetTaskProto().GetPlanID()); dropErr != nil {
+				log.Warn(context.TODO(), "l0CompactionTask failed to drop task with unavailable result", mlog.Err(dropErr))
+				return
+			}
+		}
 		log.Warn(context.TODO(), "l0CompactionTask failed to get compaction result", mlog.Err(err))
 		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
 		if err != nil {

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -118,10 +118,21 @@ func (t *mixCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clu
 }
 
 func (t *mixCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
-	result, err := cluster.QueryCompaction(t.GetTaskProto().GetNodeID(), &datapb.CompactionStateRequest{
-		PlanID: t.GetTaskProto().GetPlanID(),
+	task := t.GetTaskProto()
+	result, err := cluster.QueryCompaction(task.GetNodeID(), &datapb.CompactionStateRequest{
+		PlanID: task.GetPlanID(),
 	})
 	if err != nil || result == nil {
+		if errors.Is(err, merr.ErrCompactionResultNotFound) {
+			if dropErr := cluster.DropCompaction(task.GetNodeID(), task.GetPlanID()); dropErr != nil {
+				mlog.Warn(context.TODO(), "mixCompactionTask failed to drop task with unavailable result",
+					mlog.Int64("planID", task.GetPlanID()),
+					mlog.Int64("nodeID", task.GetNodeID()),
+					mlog.Err(dropErr))
+				return
+			}
+		}
+
 		mlog.Warn(context.TODO(), "mixCompactionTask failed to get compaction result", mlog.Err(err))
 		if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
 			mlog.Warn(context.TODO(), "mixCompactionTask failed to updateAndSaveTaskMeta", mlog.Err(err))

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -250,22 +251,31 @@ func (c *cluster) QueryCompaction(nodeID int64, in *datapb.CompactionStateReques
 			ret = rst
 			break
 		}
-		return ret, err
+		if ret == nil {
+			return nil, nil
+		}
+		return ret, nil
 	}
 
 	switch state {
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if len(resp.GetPayload()) > 0 {
 			return payloadResultF()
 		}
 		return defaultResult, nil
-	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+	case taskcommon.Finished:
+		if len(resp.GetPayload()) > 0 {
 			return payloadResultF()
 		}
-		panic("the compaction result payload must not be empty with Finished/Failed state")
+		return nil, merr.WrapErrCompactionResultNotFound(fmt.Sprintf(
+			"compaction task %d on node %d finished without result payload", in.GetPlanID(), nodeID))
+	case taskcommon.Failed:
+		if len(resp.GetPayload()) > 0 {
+			return payloadResultF()
+		}
+		return defaultResult, nil
 	default:
 		panic("should not happen")
 	}

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -290,6 +290,50 @@ func TestCluster_Compaction(t *testing.T) {
 		assert.Equal(t, "files/insert_log/1/2/3/_delta/not-log-id-suffix", result.GetSegments()[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
 	})
 
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "nil", payload: nil},
+		{name: "empty slice", payload: []byte{}},
+	} {
+		t.Run("query finished compaction without payload/"+tc.name, func(t *testing.T) {
+			mockNodeManager := NewMockNodeManager(t)
+			cluster := NewCluster(mockNodeManager)
+			mockClient := mocks.NewMockDataNodeClient(t)
+			mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+			properties := taskcommon.NewProperties(nil)
+			properties.AppendTaskState(taskcommon.Finished)
+			mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
+				Status:     merr.Success(),
+				Properties: properties,
+				Payload:    tc.payload,
+			}, nil)
+			result, err := cluster.QueryCompaction(1, &datapb.CompactionStateRequest{PlanID: 10})
+			assert.Nil(t, result)
+			assert.ErrorIs(t, err, merr.ErrCompactionResultNotFound)
+			assert.ErrorContains(t, err, "task 10")
+		})
+
+		t.Run("query failed compaction without payload/"+tc.name, func(t *testing.T) {
+			mockNodeManager := NewMockNodeManager(t)
+			cluster := NewCluster(mockNodeManager)
+			mockClient := mocks.NewMockDataNodeClient(t)
+			mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+			properties := taskcommon.NewProperties(nil)
+			properties.AppendTaskState(taskcommon.Failed)
+			mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
+				Status:     merr.Success(),
+				Properties: properties,
+				Payload:    tc.payload,
+			}, nil)
+			result, err := cluster.QueryCompaction(1, &datapb.CompactionStateRequest{PlanID: 10})
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, datapb.CompactionTaskState_failed, result.GetState())
+		})
+	}
+
 	t.Run("drop compaction", func(t *testing.T) {
 		mockNodeManager := NewMockNodeManager(t)
 		cluster := NewCluster(mockNodeManager)


### PR DESCRIPTION
## Summary

Fixes #53179
issue: #53179

- Return `ErrCompactionResultNotFound` instead of panicking when a compaction reports `Finished` without a result payload.
- Treat `Failed` without a payload as a normal terminal failure rather than re-executing the task.
- On the finished-result-loss signal, drop the old worker task first, then reuse each compaction type's existing `pipelining + NullNodeID` reset path.
- Preserve the existing behavior for malformed payloads, payloads without the requested plan, and ordinary query errors.
- Cover nil/empty finished payloads, failed-without-payload behavior, cleanup success/failure for Mix, Sort, L0, Clustering, and BumpSchemaVersion, and the reported deleted-task follow-up path for Mix.

## Verification

On commit `403447685c`:

- Full `make`: passed before this Go-only scope refinement; native build output remains complete.
- `make static-check`: passed for core, pkg, client, and go_client (0 issues).
- Relevant DataCoord/session Go tests: passed with `-tags dynamic,test -gcflags="all=-N -l" -count=1` and macOS native-library rpaths.
- Prior CI Loop on the superseded head passed Build, Code-Check, UT-Integration, UT-GO, and all 8,817 UT-CPP-Cov tests; CI will rerun for this head.

## Scope

The worker-pool restart scenario was reported, not directly reproduced against that backend. The deleted-task regression test models a generic query error and does not assert that backend's precise error code.

This change intentionally retries only `Finished + empty payload`. A `Failed + empty payload` ends the current compaction; later compaction generation remains responsible for future work.
