### PR TITLE
fix: keep installed C++ debug info self-contained

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -84,19 +84,6 @@ endif ()
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( Utils )
 
-# ---- Split DWARF (Linux only) ----
-# Moves debug info into .dwo files, dramatically reducing .o file sizes
-# and link time. Requires GCC 4.8+ or Clang 3.7+.
-if (LINUX AND NOT USE_ASAN STREQUAL "ON")
-    check_cxx_compiler_flag("-gsplit-dwarf" HAS_SPLIT_DWARF)
-    if (HAS_SPLIT_DWARF)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gsplit-dwarf")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gsplit-dwarf")
-        message(STATUS "Using -gsplit-dwarf for faster linking")
-    endif ()
-endif ()
-
-
 # **************************** Build time, type and code version ****************************
 get_current_time( BUILD_TIME )
 message( STATUS "Build time = ${BUILD_TIME}" )
@@ -201,6 +188,18 @@ find_package(Azure REQUIRED)
 include( CTest )
 include( BuildUtils )
 include( DefineOptions )
+
+# ---- Split DWARF (Linux only) ----
+# Keep this opt-in: .dwo files stay in the build tree and are not included in
+# installed artifacts or the published debug image by default.
+if (LINUX AND MILVUS_USE_SPLIT_DWARF AND NOT USE_ASAN STREQUAL "ON")
+    check_cxx_compiler_flag("-gsplit-dwarf" HAS_SPLIT_DWARF)
+    if (HAS_SPLIT_DWARF)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gsplit-dwarf")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gsplit-dwarf")
+        message(STATUS "Using -gsplit-dwarf for faster linking")
+    endif ()
+endif ()
 
 include( ExternalProject )
 include( GNUInstallDirs )

--- a/internal/core/cmake/DefineOptions.cmake
+++ b/internal/core/cmake/DefineOptions.cmake
@@ -63,6 +63,9 @@ define_option(MILVUS_USE_PCH "Use precompiled headers to speed up compilation" O
 
 define_option(MILVUS_UNITY_BUILD "Use CMake unity (jumbo) build to speed up compilation" OFF)
 
+define_option(MILVUS_USE_SPLIT_DWARF
+        "Split DWARF debug info into external .dwo files" OFF)
+
 define_option(MILVUS_VERBOSE_THIRDPARTY_BUILD
         "Show output from ExternalProjects rather than just logging to files" ON)
 

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -110,6 +110,7 @@ fi
 # Build acceleration options (override via env vars)
 : "${USE_PCH:="ON"}"
 : "${USE_UNITY_BUILD:="OFF"}"
+: "${USE_SPLIT_DWARF:="OFF"}"
 
 while getopts "p:t:s:n:a:y:x:f:S:ulcgbZh" arg; do
   case $arg in
@@ -255,7 +256,8 @@ ${CMAKE_EXTRA_ARGS} \
 -DENABLE_GCP_NATIVE=${ENABLE_GCP_NATIVE} \
 -DENABLE_AZURE_FS=${ENABLE_AZURE_FS} \
 -DMILVUS_USE_PCH=${USE_PCH} \
--DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} "
+-DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} \
+-DMILVUS_USE_SPLIT_DWARF=${USE_SPLIT_DWARF} "
 # Azure build variables removed as we now use Arrow with Azure support directly
 CMAKE_CMD=${CMAKE_CMD}"${CPP_SRC_DIR}"
 


### PR DESCRIPTION
## What this fixes

Linux builds currently enable split DWARF by default, but Milvus installation and published debug images do not include the generated `.dwo` files. The installed ELF files therefore contain dangling DWO references and GDB cannot load the expected debug information.

## Changes

- make split DWARF an explicit CMake opt-in, defaulting to OFF
- expose `USE_SPLIT_DWARF=ON` through `scripts/core_build.sh` for build-only workflows that preserve `.dwo` files
- keep the existing release image, tag, multi-arch manifest, and strip pipeline unchanged

With the default build, debug information remains self-contained in the installed ELF files. The existing release pipeline can continue publishing the unstripped build as `-debug` and stripping the same build for the regular image without copying sidecar debug files into production images.

## Release impact

- regular stripped images should retain their current layout and strip behavior
- debug images can grow because debug sections are embedded instead of being left behind in the build tree
- Release builds still use the existing `-g1`; changing the debug level or publishing `.dwp` artifacts is intentionally out of scope
- the first C++ build after this flag change may have lower cache reuse

## Validation

- `bash -n scripts/core_build.sh`
- parsed `DefineOptions.cmake` with CMake
- verified `MILVUS_USE_SPLIT_DWARF` defaults to OFF and accepts explicit ON
- `git diff --check`

Fixes #53182