### PR TITLE
fix: stop logging encryption key and storage credentials in compaction logs

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -20,9 +20,37 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+var _ mlog.ObjectMarshaler = Params{}
+
+// MarshalLogObject logs every tunable under the lowerCamel form of its json
+// tag, plus the non-secret locator fields of StorageConfig. The credentials in
+// StorageConfig are never logged.
+func (p Params) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddInt64("storageVersion", p.StorageVersion)
+	enc.AddString("storageFormat", p.StorageFormat)
+	enc.AddUint64("binlogMaxSize", p.BinLogMaxSize)
+	enc.AddBool("useMergeSort", p.UseMergeSort)
+	enc.AddInt("maxSegmentMergeSort", p.MaxSegmentMergeSort)
+	enc.AddFloat64("preferSegmentSizeRatio", p.PreferSegmentSizeRatio)
+	enc.AddInt("bloomFilterApplyBatchSize", p.BloomFilterApplyBatchSize)
+	enc.AddBool("useLoonFfi", p.UseLoonFFI)
+	enc.AddFloat64("lobHoleRatioThreshold", p.LOBHoleRatioThreshold)
+	enc.AddInt64("textInlineThreshold", p.TextInlineThreshold)
+	enc.AddInt64("textMaxLobFileBytes", p.TextMaxLobFileBytes)
+	enc.AddInt64("textFlushThresholdBytes", p.TextFlushThresholdBytes)
+	if cfg := p.StorageConfig; cfg != nil {
+		enc.AddString("storageType", cfg.GetStorageType())
+		enc.AddString("storageAddress", cfg.GetAddress())
+		enc.AddString("storageBucket", cfg.GetBucketName())
+		enc.AddString("storageRootPath", cfg.GetRootPath())
+	}
+	return nil
+}
 
 type Params struct {
 	StorageVersion            int64                  `json:"storage_version,omitempty"`

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -17,14 +17,82 @@
 package compaction
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+// logKeyOfJSONTag turns a json tag such as "binlog_max_size" into the log key
+// MarshalLogObject uses for it ("binlogMaxSize").
+func logKeyOfJSONTag(tag string) string {
+	parts := strings.Split(strings.Split(tag, ",")[0], "_")
+	for i := 1; i < len(parts); i++ {
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func TestParamsMarshalLogObject(t *testing.T) {
+	params := Params{
+		StorageVersion:            storage.StorageV2,
+		StorageFormat:             "parquet",
+		BinLogMaxSize:             1,
+		UseMergeSort:              true,
+		MaxSegmentMergeSort:       2,
+		PreferSegmentSizeRatio:    0.5,
+		BloomFilterApplyBatchSize: 3,
+		UseLoonFFI:                true,
+		LOBHoleRatioThreshold:     0.25,
+		TextInlineThreshold:       4,
+		TextMaxLobFileBytes:       5,
+		TextFlushThresholdBytes:   6,
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType:       "remote",
+			Address:           "minio:9000",
+			BucketName:        "a-bucket",
+			RootPath:          "files",
+			AccessKeyID:       "ak-secret",
+			SecretAccessKey:   "sk-secret",
+			SslCACert:         "ca-secret",
+			GcpCredentialJSON: "gcp-secret",
+		},
+	}
+
+	sink := mlog.CaptureGlobalLogs(t, &mlog.Config{Level: "info", DisableTimestamp: true})
+	mlog.Info(context.Background(), "compact start", mlog.Any("compactionParams", params))
+	logged := sink.String()
+
+	// Every field of Params except StorageConfig must show up under the log key
+	// derived from its json tag, so a field added later cannot silently vanish
+	// from the logs.
+	typ := reflect.TypeOf(params)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Name == "StorageConfig" {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		require.NotEmptyf(t, tag, "field %s must carry a json tag", field.Name)
+		assert.Contains(t, logged, logKeyOfJSONTag(tag)+"=", "field %s is missing from the log", field.Name)
+	}
+
+	for _, locator := range []string{"storageType=remote", "storageAddress=minio:9000", "storageBucket=a-bucket", "storageRootPath=files"} {
+		assert.Contains(t, logged, locator)
+	}
+	for _, secret := range []string{"ak-secret", "sk-secret", "ca-secret", "gcp-secret"} {
+		assert.NotContains(t, logged, secret)
+	}
+}
 
 func TestGetJSONParams(t *testing.T) {
 	paramtable.Init()

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -448,8 +448,13 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	defer span.End()
 	compactStart := time.Now()
 
-	mlog.Info(context.TODO(), "compact start", mlog.Any("compactionParams", t.compactionParams),
-		mlog.Any("plan", t.plan))
+	mlog.Info(ctx, "compact start",
+		mlog.Int64("planID", t.plan.GetPlanID()),
+		mlog.String("type", t.plan.GetType().String()),
+		mlog.String("channel", t.plan.GetChannel()),
+		mlog.Int("segmentNum", len(t.plan.GetSegmentBinlogs())),
+		mlog.Int64("totalRows", t.plan.GetTotalRows()),
+		mlog.Any("compactionParams", t.compactionParams))
 
 	if err := t.preCompact(); err != nil {
 		mlog.Warn(context.TODO(), "compact wrong, failed to preCompact", mlog.Err(err))

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -40,8 +40,10 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -135,6 +137,25 @@ func (s *MixCompactionTaskStorageV1Suite) prepareMissingBM25OutputSegments(isSor
 			IsSorted:     isSorted,
 		})
 	}
+}
+
+func TestMixCompactionDoesNotLogPluginContext(t *testing.T) {
+	s := newMixCompactionStorageV1SuiteForDirectTest(t)
+	s.prepareMissingBM25OutputSegments(false)
+	s.task.plan.PluginContext = []*commonpb.KeyValuePair{
+		{Key: hookutil.CipherConfigUnsafeEZK, Value: "sentinel-ezk"},
+	}
+	s.task.plan.JsonParams = `{"storage_config":{"secret_access_key":"sentinel-sk"}}`
+
+	sink := mlog.CaptureGlobalLogs(t, &mlog.Config{Level: "debug", DisableTimestamp: true})
+	_, err := s.task.Compact()
+	s.NoError(err)
+
+	logged := sink.String()
+	// segmentNum is emitted only by the rewritten "compact start" line.
+	s.Contains(logged, "segmentNum=3")
+	s.NotContains(logged, "sentinel-ezk")
+	s.NotContains(logged, "sentinel-sk")
 }
 
 func TestMixCompactionMaterializesMissingBM25OutputNoDelete(t *testing.T) {


### PR DESCRIPTION
issue: #53190

## What

The mix compactor logged the whole `CompactionPlan` at compaction start. DataCoord attaches the encryption zone key (`cipher.ezk`, the plaintext key returned by `Cipher.GetUnsafeKey`) to the plan's `PluginContext`, and the object storage credentials to its `JsonParams`, so both ended up in DataNode Info logs. The `compaction.Params` logged next to it carried the same `StorageConfig` credentials, and the sort compactor logs the same params.

## How

- `mix_compactor.go`: log plan identifiers (planID, type, channel, segmentNum, totalRows) instead of the whole plan.
- `compaction.Params` implements `MarshalLogObject` and emits the tunables only. Every `mlog.Any("compactionParams", ...)` site (mix and sort compactor) now goes through it automatically, so `StorageConfig` never reaches the log.

## Verification

- `TestParamsMarshalLogObject`: logs the params through the global logger and asserts the output carries the tunables and none of the credential values.
- `internal/compaction` and `internal/datanode/compactor` unit tests pass; `make static-check` passes.
- Grepped all other whole-object log sites for messages carrying `PluginContext` (CreateJobRequest, AnalyzeRequest, CreateStatsRequest, ImportRequest, PreImportRequest) and the other compactors: none log the request or plan.
- Out of scope: on the import path the encryption zone key travels as a plain `ezk` request option before any `PluginContext` is derived from it, and DataCoord logs the import options verbatim (`internal/datacoord/services.go`). That is a pre-existing issue and will be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Rb15SK6orWBQuE4euYC2n