### PR TITLE
fix: honor explicit pulsar.webaddress and keep the derived web address a valid url

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -283,6 +283,9 @@ pulsar:
   # Default value applies when Pulsar is running on the same network with Milvus.
   address: localhost
   port: 6650 # Port of Pulsar service.
+  # Web address of the Pulsar admin REST API, used to clean up subscriptions. It must be a full url with scheme, e.g. http://pulsar-web:8080.
+  # Empty by default, in which case http://<host of pulsar.address>:<pulsar.webport> is used. Set it only if the admin API is not reachable there, e.g. behind a proxy or over https.
+  webaddress: 
   webport: 80 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
   # The maximum size of each message in Pulsar. Unit: Byte.
   # By default, Pulsar can transmit at most 2MB of data in a single message. When streaming.splitChunkSN is enabled, the StreamingNode WAL layer splits larger payloads into multiple records that fit this limit.

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1362,8 +1362,11 @@ Default value applies when Pulsar is running on the same network with Milvus.`,
 			}
 			if hostOnly, _, err := net.SplitHostPort(host); err == nil {
 				host = hostOnly
+			} else {
+				// no port in the host; strip IPv6 brackets so that JoinHostPort adds them back
+				host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
 			}
-			return "http://" + host + ":" + p.WebPort.GetValue()
+			return "http://" + net.JoinHostPort(host, p.WebPort.GetValue())
 		},
 	}
 	p.WebAddress.Init(base.mgr)

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -19,6 +19,7 @@ package paramtable
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -1343,12 +1344,26 @@ Default value applies when Pulsar is running on the same network with Milvus.`,
 		Version:      "2.0.0",
 		DefaultValue: "",
 		Formatter: func(add string) string {
+			if add != "" {
+				// honor an explicitly configured web address
+				return add
+			}
 			pulsarURL, err := url.ParseRequestURI(p.Address.GetValue())
 			if err != nil {
 				mlog.Info(context.TODO(), "failed to parse pulsar config, assume pulsar not used", mlog.Err(err))
 				return ""
 			}
-			return "http://" + pulsarURL.Hostname() + ":" + p.WebPort.GetValue()
+			// pulsar.address may be a multi-host service url such as
+			// pulsar://host1:6650,host2:6650, which url.Hostname() cannot handle.
+			// Derive the web address from the first host.
+			host := pulsarURL.Host
+			if idx := strings.Index(host, ","); idx >= 0 {
+				host = host[:idx]
+			}
+			if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+				host = hostOnly
+			}
+			return "http://" + host + ":" + p.WebPort.GetValue()
 		},
 	}
 	p.WebAddress.Init(base.mgr)

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1343,10 +1343,20 @@ Default value applies when Pulsar is running on the same network with Milvus.`,
 		Key:          "pulsar.webaddress",
 		Version:      "2.0.0",
 		DefaultValue: "",
+		Doc: `Web address of the Pulsar admin REST API, used to clean up subscriptions. It must be a full url with scheme, e.g. http://pulsar-web:8080.
+Empty by default, in which case http://<host of pulsar.address>:<pulsar.webport> is used. Set it only if the admin API is not reachable there, e.g. behind a proxy or over https.`,
+		Export: true,
 		Formatter: func(add string) string {
+			add = strings.TrimSpace(add)
 			if add != "" {
-				// honor an explicitly configured web address
-				return add
+				// An explicit web address is used as is, but unlike pulsar.address it has to carry
+				// its scheme: the admin API may be served over https, so it cannot be guessed here.
+				u, err := url.Parse(add)
+				if err == nil && u.Host != "" && (u.Scheme == "http" || u.Scheme == "https") {
+					return add
+				}
+				mlog.Warn(context.TODO(), "pulsar.webaddress is not an http(s) url, using the address derived from pulsar.address",
+					mlog.String("configured", add))
 			}
 			pulsarURL, err := url.ParseRequestURI(p.Address.GetValue())
 			if err != nil {

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -302,16 +302,40 @@ func TestServiceParam(t *testing.T) {
 		}
 
 		{
-			// a multi-host service url derives the web address from the first host
-			bt.Save(SParams.PulsarCfg.Address.Key, "pulsar://broker-0.example.com:6650,broker-1.example.com:6650")
-			assert.Equal(t, "http://broker-0.example.com:"+SParams.PulsarCfg.WebPort.GetValue(), SParams.PulsarCfg.WebAddress.GetValue())
+			// derived from pulsar.address: single host is unchanged, a multi-host
+			// service url uses the first host, and IPv6 hosts are bracketed
+			webPort := SParams.PulsarCfg.WebPort.GetValue()
+			for _, c := range []struct {
+				address  string
+				expected string
+			}{
+				{"pulsar://localhost:6650", "http://localhost:" + webPort},
+				{"pulsar://10.1.2.3:6650", "http://10.1.2.3:" + webPort},
+				{"pulsar+ssl://broker.example.com:6651", "http://broker.example.com:" + webPort},
+				{"pulsar://broker.example.com", "http://broker.example.com:" + webPort},
+				{"broker.example.com", "http://broker.example.com:" + webPort},
+				{"pulsar://user:pw@broker.example.com:6650", "http://broker.example.com:" + webPort},
+				{"pulsar://[::1]:6650", "http://[::1]:" + webPort},
+				{"pulsar://[fd00::1]", "http://[fd00::1]:" + webPort},
+				{"pulsar://broker-0.example.com:6650,broker-1.example.com:6650", "http://broker-0.example.com:" + webPort},
+				{"broker-0.example.com,broker-1.example.com", "http://broker-0.example.com:" + webPort},
+			} {
+				bt.Save(SParams.PulsarCfg.Address.Key, c.address)
+				assert.Equal(t, c.expected, SParams.PulsarCfg.WebAddress.GetValue(), c.address)
+			}
 		}
 
 		{
-			// an explicitly configured web address is honored as is
+			// an explicitly configured web address is honored as is, whatever pulsar.address is
 			bt.Save(SParams.PulsarCfg.WebAddress.Key, "http://pulsar-web.example.com:8080")
-			assert.Equal(t, "http://pulsar-web.example.com:8080", SParams.PulsarCfg.WebAddress.GetValue())
+			for _, address := range []string{"pulsar://localhost:6650", "pulsar://broker-0.example.com:6650,broker-1.example.com:6650", ""} {
+				bt.Save(SParams.PulsarCfg.Address.Key, address)
+				assert.Equal(t, "http://pulsar-web.example.com:8080", SParams.PulsarCfg.WebAddress.GetValue(), address)
+			}
+			bt.Remove(SParams.PulsarCfg.WebAddress.Key)
 		}
+
+		bt.Save(SParams.PulsarCfg.Address.Key, "")
 	})
 
 	t.Run("test pulsar auth config", func(t *testing.T) {

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -300,6 +300,18 @@ func TestServiceParam(t *testing.T) {
 			bt.Save(SParams.PulsarCfg.Address.Key, "")
 			assert.Equal(t, SParams.PulsarCfg.WebAddress.GetValue(), "")
 		}
+
+		{
+			// a multi-host service url derives the web address from the first host
+			bt.Save(SParams.PulsarCfg.Address.Key, "pulsar://broker-0.example.com:6650,broker-1.example.com:6650")
+			assert.Equal(t, "http://broker-0.example.com:"+SParams.PulsarCfg.WebPort.GetValue(), SParams.PulsarCfg.WebAddress.GetValue())
+		}
+
+		{
+			// an explicitly configured web address is honored as is
+			bt.Save(SParams.PulsarCfg.WebAddress.Key, "http://pulsar-web.example.com:8080")
+			assert.Equal(t, "http://pulsar-web.example.com:8080", SParams.PulsarCfg.WebAddress.GetValue())
+		}
 	})
 
 	t.Run("test pulsar auth config", func(t *testing.T) {

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -335,6 +335,27 @@ func TestServiceParam(t *testing.T) {
 			bt.Remove(SParams.PulsarCfg.WebAddress.Key)
 		}
 
+		{
+			// an explicit web address must be an http(s) url, otherwise it is ignored in favor of the derived one
+			bt.Save(SParams.PulsarCfg.Address.Key, "pulsar://localhost:6650")
+			derived := "http://localhost:" + SParams.PulsarCfg.WebPort.GetValue()
+			for _, c := range []struct {
+				webAddress string
+				expected   string
+			}{
+				{"https://pulsar-admin.example.com", "https://pulsar-admin.example.com"},
+				{" http://pulsar-web.example.com:8080 ", "http://pulsar-web.example.com:8080"},
+				{"   ", derived},                                  // blank
+				{"pulsar-web.example.com:8080", derived},          // no scheme
+				{"pulsar://pulsar-web.example.com:6650", derived}, // not http(s)
+				{"http://", derived},                              // no host
+			} {
+				bt.Save(SParams.PulsarCfg.WebAddress.Key, c.webAddress)
+				assert.Equal(t, c.expected, SParams.PulsarCfg.WebAddress.GetValue(), c.webAddress)
+			}
+			bt.Remove(SParams.PulsarCfg.WebAddress.Key)
+		}
+
 		bt.Save(SParams.PulsarCfg.Address.Key, "")
 	})
 


### PR DESCRIPTION
issue: #53192

## What this PR does

`pulsar.webaddress` is the Pulsar admin REST endpoint Milvus uses to clean up subscriptions (`pkg/mq/msgstream`). Today it is always derived from `pulsar.address` as `http://<hostname>:<pulsar.webport>`, and the formatter in `pkg/util/paramtable/service_param.go` discards any value configured under the key itself. Two problems follow:

1. **There is no way to point the admin API anywhere else.** Deployments that expose the admin API through a proxy / load balancer, under a different hostname, or over `https://` cannot express that. This PR honors an explicitly configured `pulsar.webaddress` as-is. When it is not set, the value is derived exactly as before.
2. **The derivation can produce an unparsable url.** `url.Hostname()` mangles a multi-host service url (`pulsar://h1:6650,h2:6650` -> `http://h1:6650,h2:80`, while the pulsar client accepts that form and the `pulsar.address` formatter passes it through) and drops IPv6 brackets (`pulsar://[::1]:6650` -> `http://::1:80`). The web address is now built from the first host with `net.JoinHostPort`, so it is always a valid url (`http://h1:80`, `http://[::1]:80`).

Single-host derivation is byte-for-byte unchanged (`pulsar://localhost:6650` still gives `http://localhost:<webport>`); only inputs that previously produced unusable values change.

## Test

`go test ./util/paramtable/ -run TestServiceParam` in `pkg/`. Added a table of derivation cases (hostname, IP, `pulsar+ssl`, no port, no scheme, userinfo, IPv6 with and without port, multi-host with and without scheme) and the explicit override checked against single-host, multi-host and empty `pulsar.address`.
