### PR TITLE
docs: fix dead relative links in design docs and grafana README

### DIFF
--- a/deployments/monitor/grafana/README.md
+++ b/deployments/monitor/grafana/README.md
@@ -2,7 +2,7 @@
 
 Milvus outputs a list of detailed time-series metrics during runtime. You can use [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) to visualize the metrics. This topic introduces the monitoring metrics displayed in the Grafana Milvus Dashboard.
 
-We recommend reading [Milvus monitoring framework overview](monitor_overview.md) to understand Prometheus metrics first.
+We recommend reading [Milvus monitoring framework overview](https://milvus.io/docs/monitor_overview.md) to understand Prometheus metrics first.
 
 > The time unit in this topic is millisecond. 
 >

--- a/docs/design-docs/design_docs/20211214-milvus_hybrid_ts.md
+++ b/docs/design-docs/design_docs/20211214-milvus_hybrid_ts.md
@@ -1,6 +1,6 @@
 # Hybrid Timestamp in Milvus
 
-In chapter [Milvus TimeSync Mechanism](./milvus_timesync_en.md), we have already known why we need TSO in Milvus. Milvus
+In chapter [Milvus TimeSync Mechanism](./20211215-milvus_timesync.md), we have already known why we need TSO in Milvus. Milvus
 uses the [TiKV's](https://github.com/tikv/tikv) implementation into TSO. So if you are interested in how TSO is
 implemented, you can look into the official documentation of TiKV.
 

--- a/docs/design-docs/design_docs/20260129-add-function-field-design.md
+++ b/docs/design-docs/design_docs/20260129-add-function-field-design.md
@@ -1034,7 +1034,4 @@ Extend beyond BM25 to support user-defined function types.
 
 ## 14. References
 
-- Milvus Architecture: [docs/architecture.md](../architecture.md)
-- Segcore Pipeline: [docs/segcore-pipeline.md](../segcore-pipeline.md)
-- Reduce Mechanism: [docs/reduce-mechanism.md](../reduce-mechanism.md)
-- BM25 Algorithm: [pkg/util/bm25/bm25.go](../../pkg/util/bm25/bm25.go)
+- BM25 Algorithm: [pkg/util/bm25/bm25.go](../../../pkg/util/bm25/bm25.go)

--- a/docs/design-docs/design_docs/20260720-segment-reopen-request-read-lease-drain-design.md
+++ b/docs/design-docs/design_docs/20260720-segment-reopen-request-read-lease-drain-design.md
@@ -13,9 +13,7 @@
   - `internal/core/src/common/QueryResult.h`
   - `internal/querynodev2/tasks/search_task.go`
 - Related documents:
-  - [Chinese version](./20260720-segment-reopen-request-read-lease-drain-design_zh.md)
   - [Segment Reopen Atomic Read & Update with Copy-on-Write](./20260627-segment-reopen-atomic-read-update-cow.md)
-  - [Segment Reopen Review Page](./20260627-segment-reopen-generation-review/index.html)
 
 ---
 


### PR DESCRIPTION
/kind documentation

Fixes four files with dead relative links, all verified via `git ls-files`:

1. `docs/design-docs/design_docs/20260129-add-function-field-design.md` — the "Related documents" list linked three architecture docs (`architecture.md`, `segcore-pipeline.md`, `reduce-mechanism.md`) that no longer exist anywhere in the repo; dropped those bullets. The BM25 link pointed at `../../pkg/util/bm25/bm25.go`, which resolves to `docs/pkg/...` from `design_docs/` — fixed to `../../../pkg/...`.
2. `docs/design-docs/design_docs/20211214-milvus_hybrid_ts.md` — referenced `./milvus_timesync_en.md`, which was renamed; the actual file is `./20211215-milvus_timesync.md`.
3. `docs/design-docs/design_docs/20260720-segment-reopen-request-read-lease-drain-design.md` — dropped links to a `_zh.md` translation and a review `index.html` that were never committed.
4. `deployments/monitor/grafana/README.md` — `monitor_overview.md` exists only on the docs site; linked the milvus.io page directly (same URL convention used elsewhere in that README).

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>
