### PR TITLE
docs: fix typos in contributor doc and godoc comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ We highly recommend you refer to and comply to the following style guides when y
 
 ### Golang coding style
 
-- Coding style: refer to the [Effictive Go Style Guide](https://golang.org/doc/effective_go)
+- Coding style: refer to the [Effective Go Style Guide](https://golang.org/doc/effective_go)
 
 We also use `golangci-lint` to perform code check. Run the following command before submitting your pull request and make sure there is no issue reported:
 

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -568,7 +568,7 @@ func isEmbeddingFunctionOutputField(field *schemapb.FieldSchema, collSchema *sch
 // This function checks whether all fields are provided in the collSchema.Fields and not function output.
 // If any field is missing in the msg, an error will be returned.
 //
-// This funcion also checks the length of each column. All columns shall have the same length.
+// This function also checks the length of each column. All columns shall have the same length.
 // Also, the InsertData.Infos shall have BlobInfo with this length returned.
 // When the length is not aligned, an error will be returned.
 func validateColumnBasedNullableVectorFieldData(field *schemapb.FieldSchema, srcField *schemapb.FieldData, logicalRows int) error {


### PR DESCRIPTION
/kind documentation

Two one-word typo fixes:

1. `CONTRIBUTING.md:179` — "Effictive Go Style Guide" → "Effective Go Style Guide" (anchor text of the coding-style link).
2. `internal/storage/utils.go:571` — "This funcion also checks the length of each column" → "This function also checks..." in the doc comment of the exported `ColumnBasedInsertMsgToInsertData` (godoc-rendered).

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>
