### PR TITLE
fix: rename misspelled local helper getLimitSwicher to getLimitSwitcher

### DIFF
--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -236,7 +236,7 @@ to reduce unnecessary proxy updates. Range: (0, 1]`,
 	}
 	p.DDLLimitEnabled.Init(base.mgr)
 
-	getLimitSwicher := func() (string, bool) {
+	getLimitSwitcher := func() (string, bool) {
 		if p.ForceDenyAllDDL.GetAsBool() {
 			return min, true
 		}
@@ -251,7 +251,7 @@ to reduce unnecessary proxy updates. Range: (0, 1]`,
 		Version:      "2.2.0",
 		DefaultValue: max,
 		Formatter: func(v string) string {
-			switcher, ok := getLimitSwicher()
+			switcher, ok := getLimitSwitcher()
 			if ok {
 				return switcher
 			}
@@ -273,7 +273,7 @@ To use this setting, set quotaAndLimits.ddl.enabled to true at the same time.`,
 		Version:      "2.4.1",
 		DefaultValue: max,
 		Formatter: func(v string) string {
-			switcher, ok := getLimitSwicher()
+			switcher, ok := getLimitSwitcher()
 			if ok {
 				return switcher
 			}
@@ -293,7 +293,7 @@ To use this setting, set quotaAndLimits.ddl.enabled to true at the same time.`,
 		Version:      "2.2.0",
 		DefaultValue: max,
 		Formatter: func(v string) string {
-			switcher, ok := getLimitSwicher()
+			switcher, ok := getLimitSwitcher()
 			if ok {
 				return switcher
 			}
@@ -315,7 +315,7 @@ To use this setting, set quotaAndLimits.ddl.enabled to true at the same time.`,
 		Version:      "2.4.1",
 		DefaultValue: max,
 		Formatter: func(v string) string {
-			switcher, ok := getLimitSwicher()
+			switcher, ok := getLimitSwitcher()
 			if ok {
 				return switcher
 			}


### PR DESCRIPTION
/kind improvement

Renames the misspelled local helper `getLimitSwicher` → `getLimitSwitcher` in `pkg/util/paramtable/quota_param.go` (definition + 4 call sites, all inside the same function; repo-wide grep shows zero other occurrences). Pure identifier rename, no behavior change.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>
