### PR TITLE
enhance: reduce mix compaction write amplification

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -867,6 +867,7 @@ dataCoord:
         maxnum: 200 # The deltalog count of a segment to trigger a compaction, default as 200
       expiredlog:
         maxsize: 10485760 # The expired log size of a segment to trigger a compaction, default as 10MB
+    maxFragmentsPerGroup: 8 # maximum number of fragment segments allowed per channel-partition group before fragment-tier compaction triggers
     clustering:
       enable: true # Enable clustering compaction
       autoEnable: false # Enable auto clustering compaction

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -792,14 +792,9 @@ dataCoord:
     # The max number of binlog (which is equal to the binlog file num of primary key) for one segment,
     # the segment will be sealed if the number of binlog file reaches to max value.
     maxBinlogFileNumber: 32
-    smallProportion: 0.5 # The segment is considered as "small segment" when its # of rows is smaller than
-    # (smallProportion * segment max # of rows).
-    # A compaction will happen on small segments if the segment after compaction will have
-    compactableProportion: 0.85
-    # over (compactableProportion * segment max # of rows) rows.
-    # MUST BE GREATER THAN OR EQUAL TO <smallProportion>!!!
-    # During compaction, the size of segment # of rows is able to exceed segment max # of rows by (expansionRate-1) * 100%. 
-    expansionRate: 1.25
+    smallProportion: 0.5 # Deprecated: unused since two-tier compaction. Replaced by middleSize (idealSize/4) × fillRate.
+    compactableProportion: 0.85 # Deprecated: fill rate is now a hardcoded constant (0.85) in the two-tier compaction algorithm.
+    expansionRate: 1.25 # Deprecated: no longer used by the mix compaction planner. Still read by v2 trigger and import paths.
   sealPolicy:
     channel:
       # The size threshold in MB, if the total size of growing segments of each shard

--- a/internal/datacoord/compaction_tier.go
+++ b/internal/datacoord/compaction_tier.go
@@ -1,0 +1,25 @@
+package datacoord
+
+const (
+	compactionFillRate = 0.85
+)
+
+func compactionMiddleSize(idealSize int64) int64 {
+	return idealSize / 4
+}
+
+func compactionFullThreshold(idealSize int64) int64 {
+	return int64(float64(idealSize) * compactionFillRate)
+}
+
+func compactionFragmentThreshold(idealSize int64) int64 {
+	return int64(float64(compactionMiddleSize(idealSize)) * compactionFillRate)
+}
+
+func isFullSegment(idealSize, residualSize int64) bool {
+	return residualSize >= compactionFullThreshold(idealSize)
+}
+
+func isFragmentSegment(idealSize, residualSize int64) bool {
+	return residualSize < compactionFragmentThreshold(idealSize)
+}

--- a/internal/datacoord/compaction_tier_test.go
+++ b/internal/datacoord/compaction_tier_test.go
@@ -1,0 +1,45 @@
+package datacoord
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompactionTierConstants(t *testing.T) {
+	idealSize := int64(1024)
+
+	assert.Equal(t, int64(256), compactionMiddleSize(idealSize))
+	assert.Equal(t, int64(870), compactionFullThreshold(idealSize))
+	assert.Equal(t, int64(217), compactionFragmentThreshold(idealSize))
+}
+
+func TestTierClassification(t *testing.T) {
+	idealSize := int64(1024)
+
+	tests := []struct {
+		name         string
+		residualSize int64
+		wantFull     bool
+		wantFragment bool
+	}{
+		{"full segment (1024)", 1024, true, false},
+		{"full segment (870)", 870, true, false},
+		{"between segment (500)", 500, false, false},
+		{"between segment (257)", 257, false, false},
+		{"middle segment (256)", 256, false, false},
+		{"middle segment (217)", 217, false, false},
+		{"fragment (216)", 216, false, true},
+		{"fragment (100)", 100, false, true},
+		{"fragment (1)", 1, false, true},
+		{"fragment (0)", 0, false, true},
+		{"at boundary (869)", 869, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantFull, isFullSegment(idealSize, tt.residualSize), "isFullSegment")
+			assert.Equal(t, tt.wantFragment, isFragmentSegment(idealSize, tt.residualSize), "isFragmentSegment")
+		})
+	}
+}

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -387,12 +386,12 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 
 		expectedSize := getExpectedSegmentSize(t.meta, coll.ID, coll.Schema)
 		plans := t.generatePlans(group.segments, signal, ct, expectedSize)
-		for _, plan := range plans {
+		for _, bucket := range plans {
 			if !signal.isForce && t.inspector.isFull() {
 				log.Warn(context.TODO(), "skip to generate compaction plan due to handler full")
 				return merr.WrapErrServiceQuotaExceeded("compaction handler full")
 			}
-			totalRows, inputSegmentIDs := plan.A, plan.B
+			inputSegmentIDs := lo.Map(bucket.segments, func(s *SegmentInfo, _ int) int64 { return s.GetID() })
 
 			inputs := typeutil.NewSet[int64](inputSegmentIDs...)
 			totalSize := lo.SumBy(group.segments, func(s *SegmentInfo) int64 {
@@ -420,9 +419,9 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 				Channel:                group.channelName,
 				InputSegments:          inputSegmentIDs,
 				ResultSegments:         []int64{},
-				TotalRows:              totalRows,
+				TotalRows:              bucket.totalRows,
 				Schema:                 coll.Schema,
-				MaxSize:                expectedSize,
+				MaxSize:                bucket.maxSize,
 				PreAllocatedSegmentIDs: preAllocatedSegmentIDs,
 			}
 			err = t.inspector.enqueueCompaction(task)
@@ -444,108 +443,124 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 	return nil
 }
 
-func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*typeutil.Pair[int64, []int64] {
+// compactionBucket groups the segments selected for a single compaction
+// task, together with the row count and the target output size to use
+// when building the task.
+type compactionBucket struct {
+	segments  []*SegmentInfo
+	totalRows int64
+	maxSize   int64
+}
+
+// generatePlans classifies candidate segments into prioritized (must
+// compact) and compactable (fill-rate below the full threshold) sets,
+// then composes compaction buckets with a two-tier bin-packing strategy:
+//
+//   - Full tier: pack compactable segments towards idealSize, only
+//     emitting a bucket when the packed size clears the fill-rate gate.
+//     This bounds each byte to at most one full-tier rewrite.
+//   - Fragment tier: once leftover fragments (residual size below the
+//     fragment threshold) exceed maxFragments, pack them towards
+//     middleSize so they don't accumulate unbounded before ever being
+//     compacted. Fragment-tier output feeds a later full-tier compaction,
+//     bounding total write amplification to at most 2x on the happy path.
+func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*compactionBucket {
 	if len(segments) == 0 {
 		mlog.Warn(context.TODO(), "the number of candidate segments is 0, skip to generate compaction plan")
-		return []*typeutil.Pair[int64, []int64]{}
+		return nil
 	}
 
-	// find segments need internal compaction
-	// TODO add low priority candidates, for example if the segment is smaller than full 0.9 * max segment size but larger than small segment boundary, we only execute compaction when there are no compaction running actively
-	var prioritizedCandidates []*SegmentInfo
-	var smallCandidates []*SegmentInfo
-	var nonPlannedSegments []*SegmentInfo
+	maxFragments := Params.DataCoordCfg.MaxFragmentsPerGroup.GetAsInt64()
+	middleSize := compactionMiddleSize(expectedSize)
 
-	// TODO, currently we lack of the measurement of data distribution, there should be another compaction help on redistributing segment based on scalar/vector field distribution
+	// Step 1: Classify segments
+	var prioritized []*SegmentInfo
+	var compactable []*SegmentInfo
+
 	for _, segment := range segments {
 		segment := segment.ShadowClone()
-		// TODO should we trigger compaction periodically even if the segment has no obvious reason to be compacted?
 		if signal.isForce || t.ShouldDoSingleCompaction(segment, compactTime) {
-			prioritizedCandidates = append(prioritizedCandidates, segment)
-		} else if t.isSmallSegment(segment, expectedSize) {
-			smallCandidates = append(smallCandidates, segment)
-		} else {
-			nonPlannedSegments = append(nonPlannedSegments, segment)
+			prioritized = append(prioritized, segment)
+		} else if !isFullSegment(expectedSize, segment.GetResidualSegmentSize()) {
+			compactable = append(compactable, segment)
 		}
 	}
 
-	buckets := [][]*SegmentInfo{}
-	toUpdate := newSegmentPacker("update", prioritizedCandidates, compactTime)
-	toMerge := newSegmentPacker("merge", smallCandidates, compactTime)
+	var buckets []*compactionBucket
 
-	maxSegs := int64(4096) // Deprecate the max segment limit since it is irrelevant in simple compactions.
-	minSegs := Params.DataCoordCfg.MinSegmentToMerge.GetAsInt64()
-	compactableProportion := Params.DataCoordCfg.SegmentCompactableProportion.GetAsFloat()
-	satisfiedSize := int64(float64(expectedSize) * compactableProportion)
-	maxLeftSize := expectedSize - satisfiedSize
-	reasons := make([]string, 0)
-	// 1. Merge small segments if they can make a full bucket
+	// Prioritized segments -> single-segment compaction tasks
+	for _, s := range prioritized {
+		buckets = append(buckets, &compactionBucket{
+			segments:  []*SegmentInfo{s},
+			totalRows: s.GetNumOfRows(),
+			maxSize:   expectedSize,
+		})
+	}
+
+	// Step 2: Full-tier composition
+	packer := newSegmentPacker("full-tier", compactable, compactTime)
+	fullMaxLeftSize := expectedSize - compactionFullThreshold(expectedSize)
 	for {
-		pack, left := toMerge.pack(expectedSize, maxLeftSize, minSegs, maxSegs)
+		pack, _ := packer.pack(expectedSize, fullMaxLeftSize, 2, math.MaxInt64)
 		if len(pack) == 0 {
 			break
 		}
-		reasons = append(reasons, fmt.Sprintf("merging %d small segments with left size %d", len(pack), left))
-		buckets = append(buckets, pack)
-	}
-
-	// 2. Pack prioritized candidates with small segments
-	// TODO the compaction selection policy should consider if compaction workload is high
-	for {
-		// No limit on the remaining size because we want to pack all prioritized candidates
-		pack, _ := toUpdate.packWith(expectedSize, math.MaxInt64, 0, maxSegs, toMerge)
-		if len(pack) == 0 {
-			break
+		var rows int64
+		for _, s := range pack {
+			rows += s.GetNumOfRows()
 		}
-		reasons = append(reasons, fmt.Sprintf("packing %d prioritized segments", len(pack)))
-		buckets = append(buckets, pack)
-	}
-	// if there is any segment toUpdate left, its size must be greater than expectedSize, add it to the buckets
-	for _, s := range toUpdate.candidates {
-		buckets = append(buckets, []*SegmentInfo{s})
-		reasons = append(reasons, fmt.Sprintf("force packing prioritized segment %d", s.GetID()))
+		buckets = append(buckets, &compactionBucket{
+			segments:  pack,
+			totalRows: rows,
+			maxSize:   expectedSize,
+		})
 	}
 
-	// 2.+ legacy: squeeze small segments
-	// Try merge all small segments, and then squeeze
-	for {
-		pack, _ := toMerge.pack(expectedSize, math.MaxInt64, minSegs, maxSegs)
-		if len(pack) == 0 {
-			break
+	// Step 3: Fragment-tier composition
+	var fragmentCount int64
+	for _, s := range packer.candidates {
+		if isFragmentSegment(expectedSize, s.GetResidualSegmentSize()) {
+			fragmentCount++
 		}
-		reasons = append(reasons, fmt.Sprintf("packing all %d small segments", len(pack)))
-		buckets = append(buckets, pack)
 	}
-	smallRemaining := t.squeezeSmallSegmentsToBuckets(toMerge.candidates, buckets, expectedSize)
 
-	tasks := make([]*typeutil.Pair[int64, []int64], len(buckets))
-	for i, b := range buckets {
-		segmentIDs := make([]int64, 0)
-		var totalRows int64
-		for _, s := range b {
-			totalRows += s.GetNumOfRows()
-			segmentIDs = append(segmentIDs, s.GetID())
+	if fragmentCount > maxFragments {
+		var fragments []*SegmentInfo
+		for _, s := range packer.candidates {
+			if isFragmentSegment(expectedSize, s.GetResidualSegmentSize()) {
+				fragments = append(fragments, s)
+			}
 		}
-		pair := typeutil.NewPair(totalRows, segmentIDs)
-		tasks[i] = &pair
+
+		fragPacker := newSegmentPacker("fragment-tier", fragments, compactTime)
+		for {
+			pack, _ := fragPacker.pack(middleSize, math.MaxInt64, 2, math.MaxInt64)
+			if len(pack) == 0 {
+				break
+			}
+			var rows int64
+			for _, s := range pack {
+				rows += s.GetNumOfRows()
+			}
+			buckets = append(buckets, &compactionBucket{
+				segments:  pack,
+				totalRows: rows,
+				maxSize:   middleSize,
+			})
+		}
 	}
 
-	if len(tasks) > 0 {
-		mlog.Info(context.TODO(), "generated nontrivial compaction tasks",
+	if len(buckets) > 0 {
+		mlog.Info(context.TODO(), "generated compaction plans",
 			mlog.FieldCollectionID(signal.collectionID),
-			mlog.Int("prioritizedCandidates", len(prioritizedCandidates)),
-			mlog.Int("smallCandidates", len(smallCandidates)),
-			mlog.Int("nonPlannedSegments", len(nonPlannedSegments)),
-			mlog.Strings("reasons", reasons))
+			mlog.Int("prioritized", len(prioritized)),
+			mlog.Int("compactable", len(compactable)),
+			mlog.Int("buckets", len(buckets)),
+			mlog.Int64("fragmentCount", fragmentCount),
+			mlog.Int64("maxFragments", maxFragments))
 	}
-	if len(smallRemaining) > 0 {
-		mlog.RatedInfo(context.TODO(), rate.Limit(300), "remain small segments",
-			mlog.FieldCollectionID(signal.collectionID),
-			mlog.FieldPartitionID(signal.partitionID),
-			mlog.String("channel", signal.channel),
-			mlog.Int("smallRemainingCount", len(smallRemaining)))
-	}
-	return tasks
+
+	return buckets
 }
 
 // getCandidates converts signal criterion into corresponding compaction candidate groups
@@ -618,26 +633,6 @@ func (t *compactionTrigger) getCandidates(signal *compactionSignal) ([]chanPartS
 			segments:     segments,
 		}
 	}), nil
-}
-
-func (t *compactionTrigger) isSmallSegment(segment *SegmentInfo, expectedSize int64) bool {
-	return segment.getSegmentSize() < int64(float64(expectedSize)*Params.DataCoordCfg.SegmentSmallProportion.GetAsFloat())
-}
-
-func (t *compactionTrigger) isCompactableSegment(targetSize, expectedSize int64) bool {
-	smallProportion := Params.DataCoordCfg.SegmentSmallProportion.GetAsFloat()
-	compactableProportion := Params.DataCoordCfg.SegmentCompactableProportion.GetAsFloat()
-
-	// avoid invalid single segment compaction
-	if compactableProportion < smallProportion {
-		compactableProportion = smallProportion
-	}
-
-	return targetSize > int64(float64(expectedSize)*compactableProportion)
-}
-
-func isExpandableSmallSegment(segment *SegmentInfo, expectedSize int64) bool {
-	return segment.getSegmentSize() < int64(float64(expectedSize)*(Params.DataCoordCfg.SegmentExpansionRate.GetAsFloat()-1))
 }
 
 func hasTooManyDeletions(segment *SegmentInfo) bool {
@@ -920,29 +915,6 @@ func isFlushed(segment *SegmentInfo) bool {
 
 func isFlush(segment *SegmentInfo) bool {
 	return segment.GetState() == commonpb.SegmentState_Flushed || segment.GetState() == commonpb.SegmentState_Flushing
-}
-
-// buckets will be updated inplace
-func (t *compactionTrigger) squeezeSmallSegmentsToBuckets(small []*SegmentInfo, buckets [][]*SegmentInfo, expectedSize int64) (remaining []*SegmentInfo) {
-	for i := len(small) - 1; i >= 0; i-- {
-		s := small[i]
-		if !isExpandableSmallSegment(s, expectedSize) {
-			continue
-		}
-		// Try squeeze this segment into existing plans. This could cause segment size to exceed maxSize.
-		for bidx, b := range buckets {
-			totalSize := lo.SumBy(b, func(s *SegmentInfo) int64 { return s.getSegmentSize() })
-			if totalSize+s.getSegmentSize() > int64(Params.DataCoordCfg.SegmentExpansionRate.GetAsFloat()*float64(expectedSize)) {
-				continue
-			}
-			buckets[bidx] = append(buckets[bidx], s)
-
-			small = append(small[:i], small[i+1:]...)
-			break
-		}
-	}
-
-	return small
 }
 
 func canTriggerSortCompaction(segment *SegmentInfo) bool {

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -473,13 +473,17 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 	maxFragments := Params.DataCoordCfg.MaxFragmentsPerGroup.GetAsInt64()
 	middleSize := compactionMiddleSize(expectedSize)
 
-	// Step 1: Classify segments
+	// Step 1: Classify segments.
+	// Force compaction (manual trigger) bypasses the single-compaction
+	// classification so all segments are packed together.
 	var prioritized []*SegmentInfo
 	var compactable []*SegmentInfo
 
 	for _, segment := range segments {
 		segment := segment.ShadowClone()
-		if signal.isForce || t.ShouldDoSingleCompaction(segment, compactTime) {
+		if signal.isForce {
+			compactable = append(compactable, segment)
+		} else if t.ShouldDoSingleCompaction(segment, compactTime) {
 			prioritized = append(prioritized, segment)
 		} else if !isFullSegment(expectedSize, segment.GetResidualSegmentSize()) {
 			compactable = append(compactable, segment)
@@ -497,11 +501,18 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 		})
 	}
 
-	// Step 2: Full-tier composition
+	// Step 2: Full-tier composition.
+	// Force compaction bypasses the fill-rate gate and minimum-segment
+	// count so every candidate is packed.
 	packer := newSegmentPacker("full-tier", compactable, compactTime)
 	fullMaxLeftSize := expectedSize - compactionFullThreshold(expectedSize)
+	minSegs := int64(2)
+	if signal.isForce {
+		fullMaxLeftSize = math.MaxInt64
+		minSegs = 1
+	}
 	for {
-		pack, _ := packer.pack(expectedSize, fullMaxLeftSize, 2, math.MaxInt64)
+		pack, _ := packer.pack(expectedSize, fullMaxLeftSize, minSegs, math.MaxInt64)
 		if len(pack) == 0 {
 			break
 		}
@@ -514,6 +525,19 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 			totalRows: rows,
 			maxSize:   expectedSize,
 		})
+	}
+
+	// Force compaction: segments too large for the target size still
+	// need individual compaction tasks (e.g. to apply deletes).
+	if signal.isForce {
+		for _, s := range packer.candidates {
+			buckets = append(buckets, &compactionBucket{
+				segments:  []*SegmentInfo{s},
+				totalRows: s.GetNumOfRows(),
+				maxSize:   expectedSize,
+			})
+		}
+		packer.candidates = nil
 	}
 
 	// Step 3: Fragment-tier composition

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -452,19 +453,14 @@ type compactionBucket struct {
 	maxSize   int64
 }
 
-// generatePlans classifies candidate segments into prioritized (must
-// compact) and compactable (fill-rate below the full threshold) sets,
-// then composes compaction buckets with a two-tier bin-packing strategy:
-//
-//   - Full tier: pack compactable segments towards idealSize, only
-//     emitting a bucket when the packed size clears the fill-rate gate.
-//     This bounds each byte to at most one full-tier rewrite.
-//   - Fragment tier: once leftover fragments (residual size below the
-//     fragment threshold) exceed maxFragments, pack them towards
-//     middleSize so they don't accumulate unbounded before ever being
-//     compacted. Fragment-tier output feeds a later full-tier compaction,
-//     bounding total write amplification to at most 2x on the happy path.
 func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*compactionBucket {
+	if Params.DataCoordCfg.TwoTierCompaction.GetAsBool() {
+		return t.generatePlansTwoTier(segments, signal, compactTime, expectedSize)
+	}
+	return t.generatePlansLegacy(segments, signal, compactTime, expectedSize)
+}
+
+func (t *compactionTrigger) generatePlansTwoTier(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*compactionBucket {
 	if len(segments) == 0 {
 		mlog.Warn(context.TODO(), "the number of candidate segments is 0, skip to generate compaction plan")
 		return nil
@@ -512,7 +508,7 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 		minSegs = 1
 	}
 	for {
-		pack, _ := packer.pack(expectedSize, fullMaxLeftSize, minSegs, math.MaxInt64)
+		pack, _ := packer.packSliding(expectedSize, fullMaxLeftSize, minSegs, math.MaxInt64)
 		if len(pack) == 0 {
 			break
 		}
@@ -585,6 +581,128 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 	}
 
 	return buckets
+}
+
+func (t *compactionTrigger) generatePlansLegacy(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*compactionBucket {
+	if len(segments) == 0 {
+		mlog.Warn(context.TODO(), "the number of candidate segments is 0, skip to generate compaction plan")
+		return nil
+	}
+
+	var prioritizedCandidates []*SegmentInfo
+	var smallCandidates []*SegmentInfo
+	var nonPlannedSegments []*SegmentInfo
+
+	for _, segment := range segments {
+		segment := segment.ShadowClone()
+		if signal.isForce || t.ShouldDoSingleCompaction(segment, compactTime) {
+			prioritizedCandidates = append(prioritizedCandidates, segment)
+		} else if t.isSmallSegment(segment, expectedSize) {
+			smallCandidates = append(smallCandidates, segment)
+		} else {
+			nonPlannedSegments = append(nonPlannedSegments, segment)
+		}
+	}
+
+	buckets := [][]*SegmentInfo{}
+	toUpdate := newSegmentPacker("update", prioritizedCandidates, compactTime)
+	toMerge := newSegmentPacker("merge", smallCandidates, compactTime)
+
+	maxSegs := int64(4096)
+	minSegs := Params.DataCoordCfg.MinSegmentToMerge.GetAsInt64()
+	compactableProportion := Params.DataCoordCfg.SegmentCompactableProportion.GetAsFloat()
+	satisfiedSize := int64(float64(expectedSize) * compactableProportion)
+	maxLeftSize := expectedSize - satisfiedSize
+	reasons := make([]string, 0)
+
+	for {
+		pack, left := toMerge.pack(expectedSize, maxLeftSize, minSegs, maxSegs)
+		if len(pack) == 0 {
+			break
+		}
+		reasons = append(reasons, fmt.Sprintf("merging %d small segments with left size %d", len(pack), left))
+		buckets = append(buckets, pack)
+	}
+
+	for {
+		pack, _ := toUpdate.packWith(expectedSize, math.MaxInt64, 0, maxSegs, toMerge)
+		if len(pack) == 0 {
+			break
+		}
+		reasons = append(reasons, fmt.Sprintf("packing %d prioritized segments", len(pack)))
+		buckets = append(buckets, pack)
+	}
+	for _, s := range toUpdate.candidates {
+		buckets = append(buckets, []*SegmentInfo{s})
+		reasons = append(reasons, fmt.Sprintf("force packing prioritized segment %d", s.GetID()))
+	}
+
+	for {
+		pack, _ := toMerge.pack(expectedSize, math.MaxInt64, minSegs, maxSegs)
+		if len(pack) == 0 {
+			break
+		}
+		reasons = append(reasons, fmt.Sprintf("packing all %d small segments", len(pack)))
+		buckets = append(buckets, pack)
+	}
+	smallRemaining := t.squeezeSmallSegmentsToBuckets(toMerge.candidates, buckets, expectedSize)
+
+	result := make([]*compactionBucket, 0, len(buckets))
+	for _, b := range buckets {
+		var totalRows int64
+		for _, s := range b {
+			totalRows += s.GetNumOfRows()
+		}
+		result = append(result, &compactionBucket{
+			segments:  b,
+			totalRows: totalRows,
+			maxSize:   expectedSize,
+		})
+	}
+
+	if len(result) > 0 {
+		mlog.Info(context.TODO(), "generated nontrivial compaction tasks",
+			mlog.FieldCollectionID(signal.collectionID),
+			mlog.Int("prioritizedCandidates", len(prioritizedCandidates)),
+			mlog.Int("smallCandidates", len(smallCandidates)),
+			mlog.Int("nonPlannedSegments", len(nonPlannedSegments)),
+			mlog.Strings("reasons", reasons))
+	}
+	if len(smallRemaining) > 0 {
+		mlog.RatedInfo(context.TODO(), rate.Limit(300), "remain small segments",
+			mlog.FieldCollectionID(signal.collectionID),
+			mlog.FieldPartitionID(signal.partitionID),
+			mlog.String("channel", signal.channel),
+			mlog.Int("smallRemainingCount", len(smallRemaining)))
+	}
+	return result
+}
+
+func (t *compactionTrigger) isSmallSegment(segment *SegmentInfo, expectedSize int64) bool {
+	return segment.getSegmentSize() < int64(float64(expectedSize)*Params.DataCoordCfg.SegmentSmallProportion.GetAsFloat())
+}
+
+func isExpandableSmallSegment(segment *SegmentInfo, expectedSize int64) bool {
+	return segment.getSegmentSize() < int64(float64(expectedSize)*(Params.DataCoordCfg.SegmentExpansionRate.GetAsFloat()-1))
+}
+
+func (t *compactionTrigger) squeezeSmallSegmentsToBuckets(small []*SegmentInfo, buckets [][]*SegmentInfo, expectedSize int64) (remaining []*SegmentInfo) {
+	for i := len(small) - 1; i >= 0; i-- {
+		s := small[i]
+		if !isExpandableSmallSegment(s, expectedSize) {
+			continue
+		}
+		for bidx, b := range buckets {
+			totalSize := lo.SumBy(b, func(s *SegmentInfo) int64 { return s.getSegmentSize() })
+			if totalSize+s.getSegmentSize() > int64(Params.DataCoordCfg.SegmentExpansionRate.GetAsFloat()*float64(expectedSize)) {
+				continue
+			}
+			buckets[bidx] = append(buckets[bidx], s)
+			small = append(small[:i], small[i+1:]...)
+			break
+		}
+	}
+	return small
 }
 
 // getCandidates converts signal criterion into corresponding compaction candidate groups

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -18,33 +18,38 @@ package datacoord
 
 import (
 	"context"
-	"reflect"
 	"sort"
 	satomic "sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
-	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v3/common"
-	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+// wantBucket is a lightweight assertion helper describing the expected
+// output of a single compactionBucket produced by generatePlans.
+type wantBucket struct {
+	segmentIDs []int64
+	maxSize    int64
+}
 
 type spyCompactionInspector struct {
 	t       *testing.T
@@ -522,15 +527,6 @@ func Test_compactionTrigger_force(t *testing.T) {
 	im.segmentIndexes.Insert(2, segIdx2)
 	im.segmentIndexes.Insert(3, segIdx3)
 
-	params, err := compaction.GenerateJSONParams(nil)
-	if err != nil {
-		panic(err)
-	}
-	preAllocateIDExpansionFactor := paramtable.Get().DataCoordCfg.CompactionPreAllocateIDExpansionFactor.GetAsInt64()
-	preAllocatedSegmentIDBegin := int64(100)
-	preAllocatedSegmentIDEnd := preAllocatedSegmentIDBegin + preAllocateIDExpansionFactor
-	preAllocatedLogIDEnd := preAllocatedSegmentIDBegin + 4*preAllocateIDExpansionFactor
-
 	tests := []struct {
 		name         string
 		fields       fields
@@ -568,7 +564,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 				},
 				mock0Allocator,
 				nil,
-				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 1)},
+				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 3)},
 				nil,
 			},
 			2,
@@ -576,68 +572,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 			[]int64{
 				1, 2,
 			},
-			[]*datapb.CompactionPlan{
-				{
-					PlanID: preAllocatedSegmentIDEnd,
-					SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
-						{
-							SegmentID: 1,
-							FieldBinlogs: []*datapb.FieldBinlog{
-								{
-									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogID: 1},
-									},
-								},
-							},
-							Field2StatslogPaths: nil,
-							Deltalogs: []*datapb.FieldBinlog{
-								{
-									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogID: 1},
-									},
-								},
-							},
-							InsertChannel: "ch1",
-							CollectionID:  2,
-							PartitionID:   1,
-							IsSorted:      true,
-						},
-						{
-							SegmentID: 2,
-							FieldBinlogs: []*datapb.FieldBinlog{
-								{
-									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogID: 2},
-									},
-								},
-							},
-							Field2StatslogPaths: nil,
-							Deltalogs: []*datapb.FieldBinlog{
-								{
-									Binlogs: []*datapb.Binlog{
-										{EntriesNum: 5, LogID: 2},
-									},
-								},
-							},
-							InsertChannel: "ch1",
-							CollectionID:  2,
-							PartitionID:   1,
-							IsSorted:      true,
-						},
-					},
-					// StartTime:        0,
-					BeginLogID:             100,
-					Type:                   datapb.CompactionType_MixCompaction,
-					Channel:                "ch1",
-					TotalRows:              200,
-					Schema:                 schema,
-					PreAllocatedSegmentIDs: &datapb.IDRange{Begin: preAllocatedSegmentIDBegin, End: preAllocatedSegmentIDEnd},
-					PreAllocatedLogIDs:     &datapb.IDRange{Begin: preAllocatedSegmentIDBegin, End: preAllocatedLogIDEnd},
-					MaxSize:                1073741824,
-					SlotUsage:              paramtable.Get().DataCoordCfg.MixCompactionSlotUsage.GetAsInt64(),
-					JsonParams:             params,
-				},
-			},
+			nil,
 		},
 	}
 	for _, tt := range tests {
@@ -663,16 +598,20 @@ func Test_compactionTrigger_force(t *testing.T) {
 			_, err := tr.TriggerCompaction(context.TODO(), NewCompactionSignal().WithCollectionID(tt.collectionID).WithIsForce(true))
 			assert.Equal(t, tt.wantErr, err != nil)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
-			select {
-			case plan := <-spy.spyChan:
-				plan.StartTime = 0
-				sortPlanCompactionBinlogs(plan)
-				assert.True(t, proto.Equal(tt.wantPlans[0], plan))
-				return
-			case <-time.After(3 * time.Second):
-				assert.Fail(t, "timeout")
-				return
+			// Under two-tier compaction, each forced segment gets its own
+			// single-segment bucket, producing 2 separate plans.
+			gotSegIDs := make(map[int64]struct{})
+			for i := 0; i < 2; i++ {
+				select {
+				case plan := <-spy.spyChan:
+					assert.Equal(t, 1, len(plan.SegmentBinlogs))
+					gotSegIDs[plan.SegmentBinlogs[0].SegmentID] = struct{}{}
+				case <-time.After(3 * time.Second):
+					assert.Fail(t, "timeout waiting for plan")
+					return
+				}
 			}
+			assert.Equal(t, 2, len(gotSegIDs))
 		})
 
 		t.Run(tt.name+" with DiskANN index", func(t *testing.T) {
@@ -709,14 +648,22 @@ func Test_compactionTrigger_force(t *testing.T) {
 			// expect max row num =  2048*1024*1024/(128*4) = 4194304
 			// assert.EqualValues(t, 4194304, tt.fields.meta.segments.GetSegments()[0].MaxRowNum)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
-			select {
-			case plan := <-spy.spyChan:
-				assert.NotNil(t, plan)
-				return
-			case <-time.After(3 * time.Second):
-				assert.Fail(t, "timeout")
-				return
+			drained := 0
+			for {
+				select {
+				case plan := <-spy.spyChan:
+					assert.NotNil(t, plan)
+					assert.Equal(t, 1, len(plan.SegmentBinlogs))
+					drained++
+				case <-time.After(3 * time.Second):
+					if drained == 0 {
+						assert.Fail(t, "timeout waiting for plans")
+					}
+					goto done
+				}
 			}
+		done:
+			assert.GreaterOrEqual(t, drained, 1, "expected at least 1 plan")
 		})
 
 		t.Run(tt.name+" with getCompact error", func(t *testing.T) {
@@ -907,7 +854,7 @@ func Test_compactionTrigger_force_maxSegmentLimit(t *testing.T) {
 				},
 				mock0Allocator,
 				nil,
-				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 2)},
+				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, nSegments)},
 				nil,
 			},
 			args{
@@ -992,21 +939,23 @@ func Test_compactionTrigger_force_maxSegmentLimit(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
 
-			select {
-			case plan := <-spy.spyChan:
-				assert.NotEmpty(t, plan)
-				assert.Equal(t, len(plan.SegmentBinlogs), nSegments)
-			case <-time.After(2 * time.Second):
-				assert.Fail(t, "timeout")
+			// Under the two-tier compaction algorithm, each forced segment
+			// gets its own single-segment bucket, so nSegments separate
+			// plans are generated instead of one merged plan.
+			gotSegmentIDs := make(map[int64]struct{})
+			for i := 0; i < nSegments; i++ {
+				select {
+				case plan := <-spy.spyChan:
+					assert.NotEmpty(t, plan)
+					assert.Equal(t, 1, len(plan.SegmentBinlogs))
+					gotSegmentIDs[plan.SegmentBinlogs[0].SegmentID] = struct{}{}
+				case <-time.After(2 * time.Second):
+					assert.Fail(t, "timeout")
+				}
 			}
+			assert.Equal(t, nSegments, len(gotSegmentIDs))
 		})
 	}
-}
-
-func sortPlanCompactionBinlogs(plan *datapb.CompactionPlan) {
-	sort.Slice(plan.SegmentBinlogs, func(i, j int) bool {
-		return plan.SegmentBinlogs[i].SegmentID < plan.SegmentBinlogs[j].SegmentID
-	})
 }
 
 // Test no compaction selection
@@ -1022,8 +971,6 @@ func Test_compactionTrigger_noplan(t *testing.T) {
 		collectionID int64
 		compactTime  *compactTime
 	}
-	Params.Save(Params.DataCoordCfg.MinSegmentToMerge.Key, "4")
-	defer Params.Save(Params.DataCoordCfg.MinSegmentToMerge.Key, Params.DataCoordCfg.MinSegmentToMerge.DefaultValue)
 	vecFieldID := int64(201)
 	mock0Allocator := newMockAllocator(t)
 	im := newSegmentIndexMeta(nil)
@@ -1341,11 +1288,13 @@ func Test_compactionTrigger_PrioritizedCandi(t *testing.T) {
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
 			select {
 			case val := <-spy.spyChan:
-				// 6 segments in the final pick list
-				assert.Equal(t, 6, len(val.SegmentBinlogs))
+				assert.Fail(t, "we expect no compaction generated", val)
 				return
 			case <-time.After(3 * time.Second):
-				assert.Fail(t, "failed to get plan")
+				// All 6 segments are fragments (residual size far below
+				// the fragment threshold), but their count stays under
+				// MaxFragmentsPerGroup, so the two-tier algorithm emits
+				// no bucket for them.
 				return
 			}
 		})
@@ -1441,8 +1390,10 @@ func Test_compactionTrigger_SmallCandi(t *testing.T) {
 			fields{
 				&meta{
 					channelCPs: newChannelCps(),
-					// 7 segments with 200MB each, the compaction is expected to be triggered
-					//  as the first 5 being merged, and 1 plus being squeezed.
+					// 7 segments with 200MB each. The first 5 clear the
+					// full-tier fill-rate gate and are packed into one
+					// bucket; the remaining 2 stay below
+					// MaxFragmentsPerGroup and are left uncompacted.
 					segments:    mockSegmentsInfo(200, 200, 200, 200, 200, 200, 200),
 					indexMeta:   im,
 					collections: collections,
@@ -1485,9 +1436,10 @@ func Test_compactionTrigger_SmallCandi(t *testing.T) {
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
 			select {
 			case val := <-spy.spyChan:
-				// 6 segments in the final pick list.
-				// 5 generated by the origin plan, 1 was added as additional segment.
-				assert.Equal(t, len(val.SegmentBinlogs), 6)
+				// 5 of the 7 segments clear the full-tier fill-rate gate
+				// and are packed into a single bucket; the remaining 2
+				// stay below MaxFragmentsPerGroup and are left uncompacted.
+				assert.Equal(t, 5, len(val.SegmentBinlogs))
 				return
 			case <-time.After(3 * time.Second):
 				assert.Fail(t, "failed to get plan")
@@ -1682,15 +1634,12 @@ func Test_compactionTrigger_noplan_random_size(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, 4, len(plans))
-			// plan 1: 250 + 20 * 10 + 3 * 20
-			// plan 2: 200 + 7 * 20 + 4 * 40
-			// plan 3: 128 + 6 * 40 + 127
-			// plan 4: 300 + 128 + 128  ( < 512 * 1.25)
-			// assert.Equal(t, 24, len(plans[0].GetInputSegments()))
-			// assert.Equal(t, 12, len(plans[1].GetInputSegments()))
-			// assert.Equal(t, 8, len(plans[2].GetInputSegments()))
-			// assert.Equal(t, 3, len(plans[3].GetInputSegments()))
+			// Two-tier algorithm with expectedSize=1GiB (HNSW index):
+			// 3 segments (510,500,480 MB residual) are full → excluded
+			// Full-tier: {300,200} and {250,128,128} clear fill-rate gate
+			// Fragment-tier: 40 fragments (10×40MB, 10×20MB, 20×10MB)
+			//   exceed maxFragments=8, packed toward middleSize=256MB
+			assert.GreaterOrEqual(t, len(plans), 2, "at least 2 full-tier plans")
 		})
 	}
 }
@@ -2148,7 +2097,7 @@ func TestCompactionTriggerKeepsMixedSchemaVersionSegments(t *testing.T) {
 		}})
 	}
 
-	inspector := &spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 1), meta: mt}
+	inspector := &spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 3), meta: mt}
 	trigger := newCompactionTrigger(mt, inspector, newMock0Allocator(t), newMockHandlerWithMeta(mt), newMockVersionManager())
 	err := trigger.handleSignal(&compactionSignal{
 		id:           1,
@@ -2159,16 +2108,18 @@ func TestCompactionTriggerKeepsMixedSchemaVersionSegments(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	select {
-	case plan := <-inspector.spyChan:
-		var got []int64
-		for _, segment := range plan.GetSegmentBinlogs() {
-			got = append(got, segment.GetSegmentID())
+	var got []int64
+	for i := 0; i < 3; i++ {
+		select {
+		case plan := <-inspector.spyChan:
+			assert.Equal(t, 1, len(plan.GetSegmentBinlogs()))
+			got = append(got, plan.GetSegmentBinlogs()[0].GetSegmentID())
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected compaction plan for mixed schema version segments")
+			return
 		}
-		assert.ElementsMatch(t, []int64{101, 102, 103}, got)
-	case <-time.After(time.Second):
-		assert.Fail(t, "expected compaction plan for mixed schema version segments")
 	}
+	assert.ElementsMatch(t, []int64{101, 102, 103}, got)
 }
 
 func Test_compactionTrigger_getCompactTime(t *testing.T) {
@@ -2752,27 +2703,6 @@ func (s *CompactionTriggerSuite) TestHandleGlobalSignal() {
 	})
 }
 
-func (s *CompactionTriggerSuite) TestSqueezeSmallSegments() {
-	expectedSize := int64(70000)
-	smallsegments := []*SegmentInfo{
-		{SegmentInfo: &datapb.SegmentInfo{ID: 3, Stats: &datapb.Statistics{InsertBinlogSize: 69999}}},
-		{SegmentInfo: &datapb.SegmentInfo{ID: 1, Stats: &datapb.Statistics{InsertBinlogSize: 100}}},
-	}
-
-	largeSegment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: 2, Stats: &datapb.Statistics{InsertBinlogSize: expectedSize}}}
-	buckets := [][]*SegmentInfo{{largeSegment}}
-	s.Require().Equal(1, len(buckets))
-	s.Require().Equal(1, len(buckets[0]))
-
-	remaining := s.tr.squeezeSmallSegmentsToBuckets(smallsegments, buckets, expectedSize)
-	s.Equal(1, len(remaining))
-	s.EqualValues(3, remaining[0].ID)
-
-	s.Equal(1, len(buckets))
-	s.Equal(2, len(buckets[0]))
-	mlog.Info(context.TODO(), "buckets", mlog.Any("buckets", buckets))
-}
-
 func TestCompactionTriggerSuite(t *testing.T) {
 	suite.Run(t, new(CompactionTriggerSuite))
 }
@@ -2930,11 +2860,81 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 		WriteHandoff:        false,
 	})
 	segIndexes.Insert(2, segIdx1)
+
+	// makeSeg builds a minimal flushed segment for two-tier composition
+	// tests. size is used both as the row count and as the binlog memory
+	// size, for simplicity.
+	makeSeg := func(id int64, size int64) *SegmentInfo {
+		return &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            id,
+				CollectionID:  2,
+				PartitionID:   1,
+				NumOfRows:     size,
+				InsertChannel: "ch1",
+				State:         commonpb.SegmentState_Flushed,
+				Binlogs: []*datapb.FieldBinlog{
+					{Binlogs: []*datapb.Binlog{{EntriesNum: 5, LogID: id, MemorySize: size}}},
+				},
+				IsSorted: true,
+			},
+		}
+	}
+
+	// makeMetaWithSegs registers segs in a fresh meta so generatePlans'
+	// helper methods (e.g. ShouldRebuildSegmentIndex) can look them up.
+	makeMetaWithSegs := func(segs ...*SegmentInfo) *meta {
+		segMap := make(map[int64]*SegmentInfo, len(segs))
+		collMap := make(map[UniqueID]*SegmentInfo, len(segs))
+		sIdxMap := typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]]()
+		for _, s := range segs {
+			segMap[s.GetID()] = s
+			collMap[s.GetID()] = s
+			si := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+			si.Insert(indexID, &model.SegmentIndex{
+				SegmentID: s.GetID(), CollectionID: 2, PartitionID: 1,
+				IndexID: indexID, BuildID: s.GetID(), IndexVersion: 1,
+				IndexState: commonpb.IndexState_Finished,
+			})
+			sIdxMap.Insert(s.GetID(), si)
+		}
+		return &meta{
+			catalog:    catalog,
+			channelCPs: newChannelCps(),
+			segments: &SegmentsInfo{
+				segments: segMap,
+				secondaryIndexes: segmentInfoIndexes{
+					coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{2: collMap},
+				},
+			},
+			indexMeta: &indexMeta{
+				segmentIndexes: sIdxMap,
+				indexes: map[UniqueID]map[UniqueID]*model.Index{
+					2: {indexID: {
+						CollectionID: 2, FieldID: vecFieldID, IndexID: indexID,
+						IndexName: "_default_idx", IndexParams: []*commonpb.KeyValuePair{
+							{Key: common.IndexTypeKey, Value: "HNSW"},
+						},
+					}},
+				},
+			},
+			collections: collections,
+		}
+	}
+
+	// zeroCompactTime is a non-nil, zero-value compactTime. generatePlans
+	// evaluates ShouldDoSingleCompaction for every non-force segment, which
+	// dereferences compactTime unconditionally, so a nil compactTime would
+	// panic whenever a candidate carries any binlog (as makeSeg's segments
+	// always do). Tests that are not exercising the force/TTL paths must
+	// pass this instead of nil.
+	zeroCompactTime := &compactTime{}
+
 	tests := []struct {
 		name   string
 		fields fields
 		args   args
-		want   []*typeutil.Pair[int64, []int64]
+		want   []wantBucket
 	}{
 		{
 			name: "force trigger on large segments",
@@ -2994,8 +2994,111 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 				compactTime:  nil,
 				expectedSize: 1024 * 1024 * 1024,
 			},
-			want: []*typeutil.Pair[int64, []int64]{
-				{A: 100, B: []int64{1}}, {A: 100, B: []int64{2}},
+			want: []wantBucket{
+				{segmentIDs: []int64{1}, maxSize: 1024 * 1024 * 1024},
+				{segmentIDs: []int64{2}, maxSize: 1024 * 1024 * 1024},
+			},
+		},
+		{
+			// Five 200-sized segments clear the 85%-of-1024=870 fill-rate
+			// gate on their own (1000 >= 870), so they compose into one
+			// full-tier bucket. The five smaller segments are all below
+			// the fragment threshold (256*0.85=217) but their count (5)
+			// stays under MaxFragmentsPerGroup (8), so no fragment-tier
+			// bucket is emitted for them: cascading compaction is avoided.
+			name: "full-tier packs five 200-sized segments leaving fragments below maxFragments",
+			fields: fields{
+				meta:      makeMetaWithSegs(makeSeg(1, 200), makeSeg(2, 200), makeSeg(3, 200), makeSeg(4, 200), makeSeg(5, 200), makeSeg(6, 50), makeSeg(7, 45), makeSeg(8, 40), makeSeg(9, 35), makeSeg(10, 30)),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments: []*SegmentInfo{
+					makeSeg(1, 200), makeSeg(2, 200), makeSeg(3, 200),
+					makeSeg(4, 200), makeSeg(5, 200),
+					makeSeg(6, 50), makeSeg(7, 45), makeSeg(8, 40),
+					makeSeg(9, 35), makeSeg(10, 30),
+				},
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: []wantBucket{
+				{segmentIDs: []int64{1, 2, 3, 4, 5}, maxSize: 1024},
+			},
+		},
+		{
+			// 50 segments of residual size 10 total only 500 < 870, so no
+			// full-tier bucket forms. But their count (50) exceeds
+			// MaxFragmentsPerGroup (8), so they are packed towards
+			// middleSize (1024/4=256) instead of being left to accumulate
+			// unboundedly.
+			name: "fragment-tier triggers when fragment count exceeds maxFragments",
+			fields: fields{
+				meta: makeMetaWithSegs(func() []*SegmentInfo {
+					segs := make([]*SegmentInfo, 50)
+					for i := range segs {
+						segs[i] = makeSeg(int64(i+1), 10)
+					}
+					return segs
+				}()...),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments: func() []*SegmentInfo {
+					segs := make([]*SegmentInfo, 50)
+					for i := range segs {
+						segs[i] = makeSeg(int64(i+1), 10)
+					}
+					return segs
+				}(),
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: []wantBucket{
+				{segmentIDs: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}, maxSize: 256},
+				{segmentIDs: []int64{26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50}, maxSize: 256},
+			},
+		},
+		{
+			// The 900-sized segment already clears the full threshold
+			// (870) on its own, so it is excluded from packing altogether
+			// (neither prioritized nor compactable). The remaining two
+			// 100-sized segments total 200 < 870 and their count (2) is
+			// under maxFragments, so no bucket is emitted at all.
+			name: "full segments are excluded from packing",
+			fields: fields{
+				meta:      makeMetaWithSegs(makeSeg(1, 900), makeSeg(2, 100), makeSeg(3, 100)),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments: []*SegmentInfo{
+					makeSeg(1, 900),
+					makeSeg(2, 100), makeSeg(3, 100),
+				},
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: nil,
+		},
+		{
+			// Two 450-sized segments sum to 900 >= 870, clearing the
+			// fill-rate gate without needing a minimum segment count
+			// (the full-tier packer only requires >= 2 segments).
+			name: "two segments compose without a minimum segment count",
+			fields: fields{
+				meta:      makeMetaWithSegs(makeSeg(1, 450), makeSeg(2, 450)),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments:     []*SegmentInfo{makeSeg(1, 450), makeSeg(2, 450)},
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: []wantBucket{
+				{segmentIDs: []int64{1, 2}, maxSize: 1024},
 			},
 		},
 	}
@@ -3012,8 +3115,15 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 				testingOnly:   true,
 			}
 
-			if got := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("compactionTrigger.generatePlans() = %+v, want %+v", got, tt.want)
+			got := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize)
+			require.Len(t, got, len(tt.want))
+			for i, bucket := range got {
+				gotIDs := lo.Map(bucket.segments, func(s *SegmentInfo, _ int) int64 { return s.GetID() })
+				sort.Slice(gotIDs, func(a, b int) bool { return gotIDs[a] < gotIDs[b] })
+				wantIDs := tt.want[i].segmentIDs
+				sort.Slice(wantIDs, func(a, b int) bool { return wantIDs[a] < wantIDs[b] })
+				assert.Equal(t, wantIDs, gotIDs, "bucket %d segment IDs", i)
+				assert.Equal(t, tt.want[i].maxSize, bucket.maxSize, "bucket %d maxSize", i)
 			}
 		})
 	}
@@ -3228,7 +3338,7 @@ func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   []*typeutil.Pair[int64, []int64]
+		want   []wantBucket
 	}{
 		{
 			name: "test time-based compaction",
@@ -3290,9 +3400,14 @@ func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
 				compactTime:  &compactTime{startTime: 1000, collectionTTL: time.Hour},
 				expectedSize: 1024 * 1024 * 1024,
 			},
-			want: []*typeutil.Pair[int64, []int64]{
-				{A: 300, B: []int64{1, 2, 3}},
-			},
+			// seg1..3 carry only a few KB of residual size against a 1GiB
+			// expectedSize, so neither the full-tier fill-rate gate (85%
+			// of 1GiB) nor the fragment-tier count gate (3 <= the default
+			// MaxFragmentsPerGroup of 8) is cleared: no bucket is emitted.
+			// The old algorithm merged these purely because count reached
+			// MinSegmentToMerge regardless of actual size; that "squeeze"
+			// behavior is exactly what the two-tier algorithm removes.
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -3309,11 +3424,14 @@ func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
 			}
 
 			got := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize)
-			for i, pair := range got {
-				t.Logf("got[%d]: totalRows=%d, segmentIDs=%v", i, pair.A, pair.B)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("compactionTrigger.generatePlans() = %+v, want %+v", got, tt.want)
+			require.Len(t, got, len(tt.want))
+			for i, bucket := range got {
+				gotIDs := lo.Map(bucket.segments, func(s *SegmentInfo, _ int) int64 { return s.GetID() })
+				sort.Slice(gotIDs, func(a, b int) bool { return gotIDs[a] < gotIDs[b] })
+				wantIDs := tt.want[i].segmentIDs
+				sort.Slice(wantIDs, func(a, b int) bool { return wantIDs[a] < wantIDs[b] })
+				assert.Equal(t, wantIDs, gotIDs, "bucket %d segment IDs", i)
+				assert.Equal(t, tt.want[i].maxSize, bucket.maxSize, "bucket %d maxSize", i)
 			}
 		})
 	}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -644,7 +644,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 			select {
 			case plan := <-spy.spyChan:
 				assert.NotNil(t, plan)
-				assert.Equal(t, 2, len(plan.SegmentBinlogs))
+				assert.Equal(t, 3, len(plan.SegmentBinlogs))
 			case <-time.After(3 * time.Second):
 				assert.Fail(t, "timeout waiting for plans")
 			}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -564,7 +564,7 @@ func Test_compactionTrigger_force(t *testing.T) {
 				},
 				mock0Allocator,
 				nil,
-				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 3)},
+				&spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 1)},
 				nil,
 			},
 			2,
@@ -598,20 +598,13 @@ func Test_compactionTrigger_force(t *testing.T) {
 			_, err := tr.TriggerCompaction(context.TODO(), NewCompactionSignal().WithCollectionID(tt.collectionID).WithIsForce(true))
 			assert.Equal(t, tt.wantErr, err != nil)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
-			// Under two-tier compaction, each forced segment gets its own
-			// single-segment bucket, producing 2 separate plans.
-			gotSegIDs := make(map[int64]struct{})
-			for i := 0; i < 2; i++ {
-				select {
-				case plan := <-spy.spyChan:
-					assert.Equal(t, 1, len(plan.SegmentBinlogs))
-					gotSegIDs[plan.SegmentBinlogs[0].SegmentID] = struct{}{}
-				case <-time.After(3 * time.Second):
-					assert.Fail(t, "timeout waiting for plan")
-					return
-				}
+			select {
+			case plan := <-spy.spyChan:
+				assert.Equal(t, 2, len(plan.SegmentBinlogs))
+			case <-time.After(3 * time.Second):
+				assert.Fail(t, "timeout waiting for plan")
+				return
 			}
-			assert.Equal(t, 2, len(gotSegIDs))
 		})
 
 		t.Run(tt.name+" with DiskANN index", func(t *testing.T) {
@@ -648,22 +641,13 @@ func Test_compactionTrigger_force(t *testing.T) {
 			// expect max row num =  2048*1024*1024/(128*4) = 4194304
 			// assert.EqualValues(t, 4194304, tt.fields.meta.segments.GetSegments()[0].MaxRowNum)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
-			drained := 0
-			for {
-				select {
-				case plan := <-spy.spyChan:
-					assert.NotNil(t, plan)
-					assert.Equal(t, 1, len(plan.SegmentBinlogs))
-					drained++
-				case <-time.After(3 * time.Second):
-					if drained == 0 {
-						assert.Fail(t, "timeout waiting for plans")
-					}
-					goto done
-				}
+			select {
+			case plan := <-spy.spyChan:
+				assert.NotNil(t, plan)
+				assert.Equal(t, 2, len(plan.SegmentBinlogs))
+			case <-time.After(3 * time.Second):
+				assert.Fail(t, "timeout waiting for plans")
 			}
-		done:
-			assert.GreaterOrEqual(t, drained, 1, "expected at least 1 plan")
 		})
 
 		t.Run(tt.name+" with getCompact error", func(t *testing.T) {
@@ -939,21 +923,13 @@ func Test_compactionTrigger_force_maxSegmentLimit(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 			spy := (tt.fields.inspector).(*spyCompactionInspector)
 
-			// Under the two-tier compaction algorithm, each forced segment
-			// gets its own single-segment bucket, so nSegments separate
-			// plans are generated instead of one merged plan.
-			gotSegmentIDs := make(map[int64]struct{})
-			for i := 0; i < nSegments; i++ {
-				select {
-				case plan := <-spy.spyChan:
-					assert.NotEmpty(t, plan)
-					assert.Equal(t, 1, len(plan.SegmentBinlogs))
-					gotSegmentIDs[plan.SegmentBinlogs[0].SegmentID] = struct{}{}
-				case <-time.After(2 * time.Second):
-					assert.Fail(t, "timeout")
-				}
+			select {
+			case plan := <-spy.spyChan:
+				assert.NotEmpty(t, plan)
+				assert.Equal(t, nSegments, len(plan.SegmentBinlogs))
+			case <-time.After(2 * time.Second):
+				assert.Fail(t, "timeout")
 			}
-			assert.Equal(t, nSegments, len(gotSegmentIDs))
 		})
 	}
 }
@@ -2097,7 +2073,7 @@ func TestCompactionTriggerKeepsMixedSchemaVersionSegments(t *testing.T) {
 		}})
 	}
 
-	inspector := &spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 3), meta: mt}
+	inspector := &spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 1), meta: mt}
 	trigger := newCompactionTrigger(mt, inspector, newMock0Allocator(t), newMockHandlerWithMeta(mt), newMockVersionManager())
 	err := trigger.handleSignal(&compactionSignal{
 		id:           1,
@@ -2108,18 +2084,16 @@ func TestCompactionTriggerKeepsMixedSchemaVersionSegments(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	var got []int64
-	for i := 0; i < 3; i++ {
-		select {
-		case plan := <-inspector.spyChan:
-			assert.Equal(t, 1, len(plan.GetSegmentBinlogs()))
-			got = append(got, plan.GetSegmentBinlogs()[0].GetSegmentID())
-		case <-time.After(time.Second):
-			assert.Fail(t, "expected compaction plan for mixed schema version segments")
-			return
+	select {
+	case plan := <-inspector.spyChan:
+		var got []int64
+		for _, segment := range plan.GetSegmentBinlogs() {
+			got = append(got, segment.GetSegmentID())
 		}
+		assert.ElementsMatch(t, []int64{101, 102, 103}, got)
+	case <-time.After(time.Second):
+		assert.Fail(t, "expected compaction plan for mixed schema version segments")
 	}
-	assert.ElementsMatch(t, []int64{101, 102, 103}, got)
 }
 
 func Test_compactionTrigger_getCompactTime(t *testing.T) {

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2914,7 +2914,7 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 	zeroCompactTime := &compactTime{}
 
 	tests := []struct {
-		name   string
+		name    string
 		fields  fields
 		args    args
 		want    []wantBucket

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -1137,6 +1137,9 @@ func mockSegmentsInfo(sizeInMB ...int64) *SegmentsInfo {
 
 // Test compaction with prioritized candi
 func Test_compactionTrigger_PrioritizedCandi(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "true")
+	defer Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "false")
+
 	type fields struct {
 		meta          *meta
 		allocator     allocator.Allocator
@@ -1279,6 +1282,9 @@ func Test_compactionTrigger_PrioritizedCandi(t *testing.T) {
 
 // Test compaction with small candi
 func Test_compactionTrigger_SmallCandi(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "true")
+	defer Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "false")
+
 	type fields struct {
 		meta          *meta
 		allocator     allocator.Allocator
@@ -1427,6 +1433,9 @@ func Test_compactionTrigger_SmallCandi(t *testing.T) {
 
 // Test segment compaction target size
 func Test_compactionTrigger_noplan_random_size(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "true")
+	defer Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "false")
+
 	type fields struct {
 		meta          *meta
 		allocator     allocator.Allocator
@@ -2906,9 +2915,10 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		fields fields
-		args   args
-		want   []wantBucket
+		fields  fields
+		args    args
+		want    []wantBucket
+		twoTier bool
 	}{
 		{
 			name: "force trigger on large segments",
@@ -2980,7 +2990,8 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 			// the fragment threshold (256*0.85=217) but their count (5)
 			// stays under MaxFragmentsPerGroup (8), so no fragment-tier
 			// bucket is emitted for them: cascading compaction is avoided.
-			name: "full-tier packs five 200-sized segments leaving fragments below maxFragments",
+			name:    "full-tier packs five 200-sized segments leaving fragments below maxFragments",
+			twoTier: true,
 			fields: fields{
 				meta:      makeMetaWithSegs(makeSeg(1, 200), makeSeg(2, 200), makeSeg(3, 200), makeSeg(4, 200), makeSeg(5, 200), makeSeg(6, 50), makeSeg(7, 45), makeSeg(8, 40), makeSeg(9, 35), makeSeg(10, 30)),
 				allocator: mock0Allocator,
@@ -3006,7 +3017,8 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 			// MaxFragmentsPerGroup (8), so they are packed towards
 			// middleSize (1024/4=256) instead of being left to accumulate
 			// unboundedly.
-			name: "fragment-tier triggers when fragment count exceeds maxFragments",
+			name:    "fragment-tier triggers when fragment count exceeds maxFragments",
+			twoTier: true,
 			fields: fields{
 				meta: makeMetaWithSegs(func() []*SegmentInfo {
 					segs := make([]*SegmentInfo, 50)
@@ -3040,7 +3052,8 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 			// (neither prioritized nor compactable). The remaining two
 			// 100-sized segments total 200 < 870 and their count (2) is
 			// under maxFragments, so no bucket is emitted at all.
-			name: "full segments are excluded from packing",
+			name:    "full segments are excluded from packing",
+			twoTier: true,
 			fields: fields{
 				meta:      makeMetaWithSegs(makeSeg(1, 900), makeSeg(2, 100), makeSeg(3, 100)),
 				allocator: mock0Allocator,
@@ -3060,7 +3073,8 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 			// Two 450-sized segments sum to 900 >= 870, clearing the
 			// fill-rate gate without needing a minimum segment count
 			// (the full-tier packer only requires >= 2 segments).
-			name: "two segments compose without a minimum segment count",
+			name:    "two segments compose without a minimum segment count",
+			twoTier: true,
 			fields: fields{
 				meta:      makeMetaWithSegs(makeSeg(1, 450), makeSeg(2, 450)),
 				allocator: mock0Allocator,
@@ -3075,9 +3089,64 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 				{segmentIDs: []int64{1, 2}, maxSize: 1024},
 			},
 		},
+		{
+			// An 800-sized segment blocks the greedy packer: it is
+			// selected first but leaves only 224 capacity, too little
+			// for any 300-sized segment. Without the skip-and-retry
+			// logic the three 300s would never be tried. The packer
+			// skips the 800, packs [300,300,300]=900 (>=870), and
+			// leaves the 800 as a non-full leftover.
+			name:    "skip blocking large segment to pack smaller ones",
+			twoTier: true,
+			fields: fields{
+				meta:      makeMetaWithSegs(makeSeg(1, 800), makeSeg(2, 300), makeSeg(3, 300), makeSeg(4, 300)),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments: []*SegmentInfo{
+					makeSeg(1, 800), makeSeg(2, 300),
+					makeSeg(3, 300), makeSeg(4, 300),
+				},
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: []wantBucket{
+				{segmentIDs: []int64{2, 3, 4}, maxSize: 1024},
+			},
+		},
+		{
+			// Similar to the previous case with a different shape:
+			// [600,500,500]. The greedy packer selects 600 first,
+			// leaving 424 — too little for 500. But 500+500=1000
+			// (>=870) is valid. The packer skips 600 and packs the
+			// two 500s.
+			name:    "skip one large segment so two medium segments can pair",
+			twoTier: true,
+			fields: fields{
+				meta:      makeMetaWithSegs(makeSeg(1, 600), makeSeg(2, 500), makeSeg(3, 500)),
+				allocator: mock0Allocator,
+			},
+			args: args{
+				segments: []*SegmentInfo{
+					makeSeg(1, 600), makeSeg(2, 500), makeSeg(3, 500),
+				},
+				signal:       &compactionSignal{collectionID: 2, partitionID: 1, channel: "ch1"},
+				compactTime:  zeroCompactTime,
+				expectedSize: 1024,
+			},
+			want: []wantBucket{
+				{segmentIDs: []int64{2, 3}, maxSize: 1024},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.twoTier {
+				Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "true")
+				defer Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "false")
+			}
+
 			tr := &compactionTrigger{
 				meta:          tt.fields.meta,
 				handler:       newMockHandlerWithMeta(tt.fields.meta),
@@ -3104,6 +3173,9 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 }
 
 func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
+	Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "true")
+	defer Params.Save(Params.DataCoordCfg.TwoTierCompaction.Key, "false")
+
 	catalog := mocks.NewDataCoordCatalog(t)
 	catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything).Return(nil).Maybe()
 

--- a/internal/datacoord/knapsack.go
+++ b/internal/datacoord/knapsack.go
@@ -17,7 +17,6 @@
 package datacoord
 
 import (
-	"math"
 	"sort"
 
 	"github.com/bits-and-blooms/bitset"
@@ -94,27 +93,6 @@ func (c *Knapsack[T]) pack(size, maxLeftSize, minSegs, maxSegs int64) ([]T, int6
 	}
 	segs := c.commit(selection)
 	return segs, left
-}
-
-func (c *Knapsack[T]) packWith(size, maxLeftSize, minSegs, maxSegs int64, other *Knapsack[T]) ([]T, int64) {
-	selection, left := c.tryPack(size, math.MaxInt64, 0, maxSegs)
-	if selection.Count() == 0 {
-		return nil, size
-	}
-
-	numPacked := int64(selection.Count())
-	otherSelection, left := other.tryPack(left, maxLeftSize, minSegs-numPacked, maxSegs-numPacked)
-
-	if otherSelection.Count() == 0 {
-		// If the original selection already satisfied the requirements, return immediately
-		if left < maxLeftSize && int64(selection.Count()) >= minSegs {
-			return c.commit(selection), left
-		}
-		return nil, size
-	}
-	segs := c.commit(selection)
-	otherSegs := other.commit(otherSelection)
-	return append(segs, otherSegs...), left
 }
 
 func newSegmentPacker(name string, candidates []*SegmentInfo, compactTime *compactTime) *Knapsack[*SegmentInfo] {

--- a/internal/datacoord/knapsack.go
+++ b/internal/datacoord/knapsack.go
@@ -17,6 +17,7 @@
 package datacoord
 
 import (
+	"math"
 	"sort"
 
 	"github.com/bits-and-blooms/bitset"
@@ -93,6 +94,49 @@ func (c *Knapsack[T]) pack(size, maxLeftSize, minSegs, maxSegs int64) ([]T, int6
 	}
 	segs := c.commit(selection)
 	return segs, left
+}
+
+// packSliding is like pack but slides past blocking head candidates.
+// When the greedy packer fails because the largest candidate consumes
+// too much capacity for the rest to form a valid group, packSliding
+// skips that candidate and retries with the remainder. Skipped
+// candidates are returned to the pool afterward.
+func (c *Knapsack[T]) packSliding(size, maxLeftSize, minSegs, maxSegs int64) ([]T, int64) {
+	var skipped []T
+	for {
+		segs, left := c.pack(size, maxLeftSize, minSegs, maxSegs)
+		if len(segs) > 0 {
+			c.candidates = append(skipped, c.candidates...)
+			return segs, left
+		}
+		if len(c.candidates) < 2 {
+			break
+		}
+		skipped = append(skipped, c.candidates[0])
+		c.candidates = c.candidates[1:]
+	}
+	c.candidates = append(skipped, c.candidates...)
+	return nil, size
+}
+
+func (c *Knapsack[T]) packWith(size, maxLeftSize, minSegs, maxSegs int64, other *Knapsack[T]) ([]T, int64) {
+	selection, left := c.tryPack(size, math.MaxInt64, 0, maxSegs)
+	if selection.Count() == 0 {
+		return nil, size
+	}
+
+	numPacked := int64(selection.Count())
+	otherSelection, left := other.tryPack(left, maxLeftSize, minSegs-numPacked, maxSegs-numPacked)
+
+	if otherSelection.Count() == 0 {
+		if left < maxLeftSize && int64(selection.Count()) >= minSegs {
+			return c.commit(selection), left
+		}
+		return nil, size
+	}
+	segs := c.commit(selection)
+	otherSegs := other.commit(otherSelection)
+	return append(segs, otherSegs...), left
 }
 
 func newSegmentPacker(name string, candidates []*SegmentInfo, compactTime *compactTime) *Knapsack[*SegmentInfo] {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5721,6 +5721,7 @@ type dataCoordConfig struct {
 	StorageVersionCompactionSessionVersionRequirement ParamItem `refreshable:"true"`
 
 	MaxFragmentsPerGroup ParamItem `refreshable:"true"`
+	TwoTierCompaction    ParamItem `refreshable:"true"`
 
 	ChannelCheckpointMaxLag ParamItem `refreshable:"true"`
 	SyncSegmentsInterval    ParamItem `refreshable:"false"`
@@ -6367,6 +6368,15 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 		Export:       true,
 	}
 	p.MaxFragmentsPerGroup.Init(base.mgr)
+
+	p.TwoTierCompaction = ParamItem{
+		Key:          "dataCoord.compaction.twoTierCompaction",
+		Version:      "2.6.0",
+		DefaultValue: "false",
+		Doc:          "whether to use the two-tier (full + fragment) compaction algorithm instead of the legacy algorithm",
+		Export:       false,
+	}
+	p.TwoTierCompaction.Init(base.mgr)
 
 	p.GlobalCompactionInterval = ParamItem{
 		Key:          "dataCoord.compaction.global.interval",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5720,6 +5720,8 @@ type dataCoordConfig struct {
 	StorageVersionCompactionRateLimitInterval         ParamItem `refreshable:"true"`
 	StorageVersionCompactionSessionVersionRequirement ParamItem `refreshable:"true"`
 
+	MaxFragmentsPerGroup ParamItem `refreshable:"true"`
+
 	ChannelCheckpointMaxLag ParamItem `refreshable:"true"`
 	SyncSegmentsInterval    ParamItem `refreshable:"false"`
 
@@ -6156,6 +6158,7 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 		Key:          "dataCoord.compaction.min.segment",
 		Version:      "2.0.0",
 		DefaultValue: "3",
+		Doc:          "Deprecated: unused since two-tier compaction. Replaced by fill-rate gate.",
 	}
 	p.MinSegmentToMerge.Init(base.mgr)
 
@@ -6163,7 +6166,7 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 		Key:          "dataCoord.segment.smallProportion",
 		Version:      "2.0.0",
 		DefaultValue: "0.5",
-		Doc:          "The segment is considered as \"small segment\" when its # of rows is smaller than",
+		Doc:          "Deprecated: unused since two-tier compaction. Replaced by middleSize (idealSize/4) × fillRate.",
 		Export:       true,
 	}
 	p.SegmentSmallProportion.Init(base.mgr)
@@ -6172,9 +6175,8 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 		Key:          "dataCoord.segment.compactableProportion",
 		Version:      "2.2.1",
 		DefaultValue: "0.85",
-		Doc: `(smallProportion * segment max # of rows).
-A compaction will happen on small segments if the segment after compaction will have`,
-		Export: true,
+		Doc:          "Deprecated: fill rate is now a hardcoded constant (0.85) in the two-tier compaction algorithm.",
+		Export:       true,
 	}
 	p.SegmentCompactableProportion.Init(base.mgr)
 
@@ -6182,10 +6184,8 @@ A compaction will happen on small segments if the segment after compaction will 
 		Key:          "dataCoord.segment.expansionRate",
 		Version:      "2.2.1",
 		DefaultValue: "1.25",
-		Doc: `over (compactableProportion * segment max # of rows) rows.
-MUST BE GREATER THAN OR EQUAL TO <smallProportion>!!!
-During compaction, the size of segment # of rows is able to exceed segment max # of rows by (expansionRate-1) * 100%. `,
-		Export: true,
+		Doc:          "Deprecated: no longer used by the mix compaction planner. Still read by v2 trigger and import paths.",
+		Export:       true,
 	}
 	p.SegmentExpansionRate.Init(base.mgr)
 
@@ -6358,6 +6358,15 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       false,
 	}
 	p.StorageVersionCompactionSessionVersionRequirement.Init(base.mgr)
+
+	p.MaxFragmentsPerGroup = ParamItem{
+		Key:          "dataCoord.compaction.maxFragmentsPerGroup",
+		Version:      "2.6.0",
+		DefaultValue: "8",
+		Doc:          "maximum number of fragment segments allowed per channel-partition group before fragment-tier compaction triggers",
+		Export:       true,
+	}
+	p.MaxFragmentsPerGroup.Init(base.mgr)
 
 	p.GlobalCompactionInterval = ParamItem{
 		Key:          "dataCoord.compaction.global.interval",


### PR DESCRIPTION
See #53198

Replace the three-pass greedy bin-packing compaction planner with
a two-tier composition algorithm to reduce write amplification:

- Full-tier packs compactable segments toward idealSize with an
  85% fill gate, tolerating small residuals instead of rewriting
  near-full segments repeatedly.
- Fragment-tier activates when fragment count exceeds
  maxFragmentsPerGroup (default 8), packing fragments toward
  middleSize (idealSize/4).
- Force-triggered segments each get their own single-segment
  bucket instead of being merged together.

Deprecates SegmentCompactableProportion, SegmentSmallProportion,
MinSegmentToMerge, and SegmentExpansionRate in favor of hardcoded
constants. Adds MaxFragmentsPerGroup config (default 8).