### PR TITLE
fix: preserve V2 compaction path indexes (#53200)

### DIFF
--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -226,7 +226,7 @@ func createTextIndex(ctx context.Context,
 	return textIndexLogs, nil
 }
 
-// Storage readers do not share compaction's schema-reconciliation contract, so filter physical fields before opening them.
+// V1 readers do not share compaction's schema-reconciliation contract, so filter physical fields before opening them.
 func newCompactionSegmentRecordReader(ctx context.Context, segment *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema, storageConfig *indexpb.StorageConfig, opts ...storage.RwOption) (storage.RecordReader, map[int64]struct{}, error) {
 	existingFields, err := compactionSegmentStorageFields(segment, storageConfig)
 	if err != nil {
@@ -299,8 +299,14 @@ func newCompactionSegmentRecordReaderWithFields(ctx context.Context, segment *da
 		return reader, existingFields, err
 	}
 
-	readFields := collectionSchemaFields(readSchema)
-	fieldBinlogs := filterCompactionFieldBinlogs(segment.GetFieldBinlogs(), readFields)
+	// Keep the complete packed path vector: V2 file metadata addresses column
+	// groups by path index, and the packed reader projects readSchema internally.
+	// V1 binlogs are independent per-field files and must still be filtered because
+	// its reader does not safely ignore blobs whose field is absent from readSchema.
+	fieldBinlogs := lo.Compact(segment.GetFieldBinlogs())
+	if segment.GetStorageVersion() == storage.StorageV1 {
+		fieldBinlogs = filterV1CompactionFieldBinlogs(fieldBinlogs, collectionSchemaFields(readSchema))
+	}
 	rootPath := ""
 	if storageConfig != nil {
 		rootPath = storageConfig.GetRootPath()
@@ -357,29 +363,17 @@ func compactionFieldReadable(field *schemapb.FieldSchema, existingFields map[int
 	return !field.GetIsFunctionOutput()
 }
 
-func filterCompactionFieldBinlogs(fieldBinlogs []*datapb.FieldBinlog, readFields map[int64]struct{}) []*datapb.FieldBinlog {
+func filterV1CompactionFieldBinlogs(fieldBinlogs []*datapb.FieldBinlog, readFields map[int64]struct{}) []*datapb.FieldBinlog {
 	filtered := make([]*datapb.FieldBinlog, 0, len(fieldBinlogs))
 	for _, fieldBinlog := range fieldBinlogs {
-		if compactionFieldBinlogReadable(fieldBinlog, readFields) {
+		if fieldBinlog == nil {
+			continue
+		}
+		if _, ok := readFields[fieldBinlog.GetFieldID()]; ok {
 			filtered = append(filtered, fieldBinlog)
 		}
 	}
 	return filtered
-}
-
-func compactionFieldBinlogReadable(fieldBinlog *datapb.FieldBinlog, readFields map[int64]struct{}) bool {
-	if fieldBinlog == nil {
-		return false
-	}
-	if _, ok := readFields[fieldBinlog.GetFieldID()]; ok {
-		return true
-	}
-	for _, childFieldID := range fieldBinlog.GetChildFields() {
-		if _, ok := readFields[childFieldID]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 type EntityFilter struct {

--- a/internal/datanode/compactor/compactor_common_test.go
+++ b/internal/datanode/compactor/compactor_common_test.go
@@ -25,17 +25,16 @@ func TestCompactionSegmentBinlogFieldsUsesChildFields(t *testing.T) {
 	require.NotContains(t, fields, int64(900))
 }
 
-func TestFilterCompactionFieldBinlogsKeepsChildFieldMatch(t *testing.T) {
+func TestFilterV1CompactionFieldBinlogs(t *testing.T) {
 	fieldBinlogs := []*datapb.FieldBinlog{
 		nil,
-		{FieldID: 900, ChildFields: []int64{102, 103}},
+		{FieldID: 102},
 		{FieldID: 200},
 	}
 
-	filtered := filterCompactionFieldBinlogs(fieldBinlogs, map[int64]struct{}{102: {}})
+	filtered := filterV1CompactionFieldBinlogs(fieldBinlogs, map[int64]struct{}{102: {}})
 	require.Len(t, filtered, 1)
-	require.EqualValues(t, 900, filtered[0].GetFieldID())
-	require.Equal(t, []int64{102, 103}, filtered[0].GetChildFields())
+	require.EqualValues(t, 102, filtered[0].GetFieldID())
 }
 
 func TestCompactionReadSchemaKeepsAbsentOrdinaryDropsMissingFunctionOutputs(t *testing.T) {

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
@@ -322,9 +323,9 @@ func (s *MixCompactionTaskStorageV2Suite) TestProjectedReaderPreservesPackedGrou
 	}
 	modernFieldBinlogs := storage.SortFieldBinlogs(fieldBinlogs)
 	legacyFieldBinlogs := lo.Map(modernFieldBinlogs, func(fieldBinlog *datapb.FieldBinlog, _ int) *datapb.FieldBinlog {
-		legacy := *fieldBinlog
+		legacy := proto.Clone(fieldBinlog).(*datapb.FieldBinlog)
 		legacy.ChildFields = nil
-		return &legacy
+		return legacy
 	})
 	for _, testCase := range []struct {
 		name         string

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -288,6 +288,72 @@ func (s *MixCompactionTaskStorageV2Suite) TestMergeNoExpirationLackBinlog_V1ToV2
 	s.TestMergeNoExpirationLackBinlog()
 }
 
+func (s *MixCompactionTaskStorageV2Suite) TestProjectedReaderPreservesPackedGroupPathIndexes() {
+	const segmentID = int64(1001)
+	fieldBinlogs, _, _, _, _, _, _, err := s.initStorageV2Segments(
+		1,
+		segmentID,
+		allocator.NewLocalAllocator(1000, math.MaxInt64),
+	)
+	s.Require().NoError(err)
+
+	fullSchema := s.meta.GetSchema()
+	selectedFields := lo.Filter(fullSchema.GetFields(), func(field *schemapb.FieldSchema, _ int) bool {
+		switch field.GetFieldID() {
+		case common.RowIDField, common.TimeStampField, Int64Field, FloatVectorField:
+			return true
+		default:
+			return false
+		}
+	})
+	readSchema := &schemapb.CollectionSchema{
+		Name:   fullSchema.GetName(),
+		Fields: selectedFields,
+	}
+	storageConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    paramtable.Get().LocalStorageCfg.Path.GetValue(),
+	}
+	segment := &datapb.CompactionSegmentBinlogs{
+		CollectionID:   CollectionID,
+		PartitionID:    PartitionID,
+		SegmentID:      segmentID,
+		StorageVersion: storage.StorageV2,
+	}
+	modernFieldBinlogs := storage.SortFieldBinlogs(fieldBinlogs)
+	legacyFieldBinlogs := lo.Map(modernFieldBinlogs, func(fieldBinlog *datapb.FieldBinlog, _ int) *datapb.FieldBinlog {
+		legacy := *fieldBinlog
+		legacy.ChildFields = nil
+		return &legacy
+	})
+	for _, testCase := range []struct {
+		name         string
+		fieldBinlogs []*datapb.FieldBinlog
+	}{
+		{name: "modern_v2", fieldBinlogs: modernFieldBinlogs},
+		{name: "legacy_v2", fieldBinlogs: legacyFieldBinlogs},
+	} {
+		s.Run(testCase.name, func() {
+			segment.FieldBinlogs = append([]*datapb.FieldBinlog(nil), testCase.fieldBinlogs...)
+			reader, _, err := newCompactionSegmentRecordReader(context.Background(), segment, readSchema, storageConfig,
+				storage.WithCollectionID(CollectionID),
+				storage.WithVersion(storage.StorageV2),
+				storage.WithStorageConfig(storageConfig),
+			)
+			s.Require().NoError(err)
+
+			record, err := reader.Next()
+			s.Require().NoError(err)
+			values := make([]*storage.Value, record.Len())
+			s.Require().NoError(storage.ValueDeserializerWithSelectedFields(record, values, selectedFields, true))
+			s.Require().Len(values, 1)
+			s.EqualValues(segmentID, values[0].Value.(map[int64]interface{})[Int64Field])
+			s.Equal([]float32{4, 5, 6, 7}, values[0].Value.(map[int64]interface{})[FloatVectorField])
+			s.Require().NoError(reader.Close())
+		})
+	}
+}
+
 func (s *MixCompactionTaskStorageV2Suite) initStorageV2Segments(rows int, seed int64, alloc allocator.Interface) (
 	inserts map[int64]*datapb.FieldBinlog,
 	deltas *datapb.FieldBinlog,


### PR DESCRIPTION
issue: #53200

## Summary
- preserve all valid Storage V2 physical group paths during compaction schema projection so packed path indexes stay aligned
- keep FieldID filtering limited to Storage V1 binlogs
- cover modern and legacy Storage V2 metadata with projected-reader regression tests
