### PR TITLE
fix: treat zero count as null in ComputeAvgFromSumAndCount (#53204)

### DIFF
--- a/internal/agg/aggregate_util.go
+++ b/internal/agg/aggregate_util.go
@@ -594,6 +594,11 @@ func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData 
 	}
 
 	resultData := make([]float64, 0, rowCount)
+	validData := make([]bool, rowCount)
+	hasNull := false
+
+	sumValidData := typeutil.GetFieldDataValidData(sumFieldData)
+	countValidData := typeutil.GetFieldDataValidData(countFieldData)
 
 	// Compute avg = sum / count for each row
 	switch sumType {
@@ -603,9 +608,13 @@ func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData 
 			return nil, merr.WrapErrParameterInvalidMsg("sum and count field data must have the same length, got sum:%d, count:%d", len(sumData), rowCount)
 		}
 		for i := 0; i < rowCount; i++ {
-			if countData[i] == 0 {
-				return nil, merr.WrapErrParameterInvalidMsg("division by zero: count is 0 at row %d", i)
+			if countData[i] <= 0 || (len(countValidData) > 0 && !countValidData[i]) || (len(sumValidData) > 0 && !sumValidData[i]) {
+				hasNull = true
+				validData[i] = false
+				resultData = append(resultData, 0.0)
+				continue
 			}
+			validData[i] = true
 			resultData = append(resultData, float64(sumData[i])/float64(countData[i]))
 		}
 	case schemapb.DataType_Double:
@@ -614,9 +623,13 @@ func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData 
 			return nil, merr.WrapErrParameterInvalidMsg("sum and count field data must have the same length, got sum:%d, count:%d", len(sumData), rowCount)
 		}
 		for i := 0; i < rowCount; i++ {
-			if countData[i] == 0 {
-				return nil, merr.WrapErrParameterInvalidMsg("division by zero: count is 0 at row %d", i)
+			if countData[i] <= 0 || (len(countValidData) > 0 && !countValidData[i]) || (len(sumValidData) > 0 && !sumValidData[i]) {
+				hasNull = true
+				validData[i] = false
+				resultData = append(resultData, 0.0)
+				continue
 			}
+			validData[i] = true
 			resultData = append(resultData, sumData[i]/float64(countData[i]))
 		}
 	default:
@@ -624,5 +637,8 @@ func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData 
 	}
 
 	result.GetScalars().GetDoubleData().Data = resultData
+	if hasNull || len(sumValidData) > 0 || len(countValidData) > 0 {
+		typeutil.SetFieldDataValidData(result, validData)
+	}
 	return result, nil
 }

--- a/internal/agg/aggregate_util.go
+++ b/internal/agg/aggregate_util.go
@@ -566,6 +566,11 @@ func NewAggregationFieldMap(originalUserOutputFields []string, groupByFields []s
 // ComputeAvgFromSumAndCount computes average from sum and count field data.
 // It takes sumFieldData and countFieldData, computes avg = sum / count for each row,
 // and returns a new Double FieldData containing the average values.
+// In compliance with SQL-NULL aggregate semantics, if count <= 0 or if either sum
+// or count row is marked as null/invalid in its validity mask, the resulting row is
+// emitted as a SQL-NULL aggregate (filled with 0.0 and marked invalid in ValidData).
+// When nulls or input validity masks are present, a validity mask is attached to the result;
+// otherwise, for purely valid non-null rows, ValidData remains empty/nil for backwards compatibility.
 func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData *schemapb.FieldData) (*schemapb.FieldData, error) {
 	if sumFieldData == nil || countFieldData == nil {
 		return nil, merr.WrapErrServiceInternalMsg("sumFieldData and countFieldData cannot be nil")

--- a/internal/agg/aggregate_util_test.go
+++ b/internal/agg/aggregate_util_test.go
@@ -19,6 +19,8 @@ package agg
 import (
 	"testing"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,4 +92,223 @@ func TestNewAggregationFieldMap_ValidGlobalAgg(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, aggMap.Count())
 	assert.Equal(t, "count(*)", aggMap.NameAt(0))
+}
+
+func TestComputeAvgFromSumAndCount_Success(t *testing.T) {
+	// Int64 sum and Int64 count
+	sumFieldInt64 := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+	}
+	countField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{2, 4, 5}},
+				},
+			},
+		},
+	}
+
+	result, err := ComputeAvgFromSumAndCount(sumFieldInt64, countField)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, schemapb.DataType_Double, result.GetType())
+	expected := []float64{5.0, 5.0, 6.0}
+	assert.Equal(t, expected, result.GetScalars().GetDoubleData().GetData())
+
+	// Double sum and Int64 count
+	sumFieldDouble := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{10.5, 20.0, 30.25}},
+				},
+			},
+		},
+	}
+
+	result, err = ComputeAvgFromSumAndCount(sumFieldDouble, countField)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, schemapb.DataType_Double, result.GetType())
+	expectedDouble := []float64{5.25, 5.0, 6.05}
+	assert.Equal(t, expectedDouble, result.GetScalars().GetDoubleData().GetData())
+}
+
+func TestComputeAvgFromSumAndCount_ZeroCountTreatedAsNull(t *testing.T) {
+	// Group 0: nonnull group (sum=10, count=2 -> avg=5.0)
+	// Group 1: nullonly group where count is 0 (sum=0, count=0 -> avg=NULL)
+	// Group 2: nonnull group (sum=30, count=5 -> avg=6.0)
+	sumField := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{10.0, 0.0, 30.0}},
+				},
+			},
+		},
+	}
+	countField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{2, 0, 5}},
+				},
+			},
+		},
+	}
+
+	result, err := ComputeAvgFromSumAndCount(sumField, countField)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, schemapb.DataType_Double, result.GetType())
+
+	data := result.GetScalars().GetDoubleData().GetData()
+	require.Len(t, data, 3)
+	assert.Equal(t, 5.0, data[0])
+	assert.Equal(t, 0.0, data[1])
+	assert.Equal(t, 6.0, data[2])
+
+	validData := typeutil.GetFieldDataValidData(result)
+	require.Len(t, validData, 3)
+	assert.True(t, validData[0], "row 0 should be valid non-null")
+	assert.False(t, validData[1], "row 1 (zero count) should be treated as null aggregate")
+	assert.True(t, validData[2], "row 2 should be valid non-null")
+
+	// Same verification for Int64 sum
+	sumFieldInt64 := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 0, 30}},
+				},
+			},
+		},
+	}
+
+	resultInt64, err := ComputeAvgFromSumAndCount(sumFieldInt64, countField)
+	require.NoError(t, err)
+	require.NotNil(t, resultInt64)
+	validDataInt64 := typeutil.GetFieldDataValidData(resultInt64)
+	require.Len(t, validDataInt64, 3)
+	assert.True(t, validDataInt64[0])
+	assert.False(t, validDataInt64[1])
+	assert.True(t, validDataInt64[2])
+}
+
+func TestComputeAvgFromSumAndCount_NullInputs(t *testing.T) {
+	// Test when input sumFieldData or countFieldData has existing validData mask
+	sumField := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{10.0, 20.0}},
+				},
+			},
+		},
+	}
+	typeutil.SetFieldDataValidData(sumField, []bool{true, false})
+
+	countField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{2, 4}},
+				},
+			},
+		},
+	}
+
+	result, err := ComputeAvgFromSumAndCount(sumField, countField)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	validData := typeutil.GetFieldDataValidData(result)
+	require.Len(t, validData, 2)
+	assert.True(t, validData[0])
+	assert.False(t, validData[1], "null in sumFieldData should propagate to result validData")
+}
+
+func TestComputeAvgFromSumAndCount_Errors(t *testing.T) {
+	// Nil inputs
+	_, err := ComputeAvgFromSumAndCount(nil, nil)
+	assert.Error(t, err)
+
+	sumField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10}},
+				},
+			},
+		},
+	}
+	// Count field not Int64
+	invalidCountField := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{2.0}},
+				},
+			},
+		},
+	}
+	_, err = ComputeAvgFromSumAndCount(sumField, invalidCountField)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "count field must be Int64 type")
+
+	// Length mismatch
+	countFieldMismatch := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{2, 3}},
+				},
+			},
+		},
+	}
+	_, err = ComputeAvgFromSumAndCount(sumField, countFieldMismatch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must have the same length")
+
+	// Unsupported sum field type
+	unsupportedSumField := &schemapb.FieldData{
+		Type: schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"abc"}},
+				},
+			},
+		},
+	}
+	validCountField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1}},
+				},
+			},
+		},
+	}
+	_, err = ComputeAvgFromSumAndCount(unsupportedSumField, validCountField)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported sum field type")
 }

--- a/internal/agg/aggregate_util_test.go
+++ b/internal/agg/aggregate_util_test.go
@@ -19,10 +19,11 @@ package agg
 import (
 	"testing"
 
-	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
-	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestNewAggregationFieldMap_GroupByInvalidField(t *testing.T) {

--- a/internal/agg/aggregate_util_test.go
+++ b/internal/agg/aggregate_util_test.go
@@ -17,12 +17,14 @@
 package agg
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -124,6 +126,7 @@ func TestComputeAvgFromSumAndCount_Success(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_Double, result.GetType())
 	expected := []float64{5.0, 5.0, 6.0}
 	assert.Equal(t, expected, result.GetScalars().GetDoubleData().GetData())
+	assert.Empty(t, typeutil.GetFieldDataValidData(result), "result validData should be empty/nil when no nulls exist in Int64 sum")
 
 	// Double sum and Int64 count
 	sumFieldDouble := &schemapb.FieldData{
@@ -143,6 +146,7 @@ func TestComputeAvgFromSumAndCount_Success(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_Double, result.GetType())
 	expectedDouble := []float64{5.25, 5.0, 6.05}
 	assert.Equal(t, expectedDouble, result.GetScalars().GetDoubleData().GetData())
+	assert.Empty(t, typeutil.GetFieldDataValidData(result), "result validData should be empty/nil when no nulls exist in Double sum")
 }
 
 func TestComputeAvgFromSumAndCount_ZeroCountTreatedAsNull(t *testing.T) {
@@ -241,6 +245,52 @@ func TestComputeAvgFromSumAndCount_NullInputs(t *testing.T) {
 	require.Len(t, validData, 2)
 	assert.True(t, validData[0])
 	assert.False(t, validData[1], "null in sumFieldData should propagate to result validData")
+
+	// Test when countFieldData has existing validData mask (exercises countValidData branch)
+	sumFieldCountMask := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{10.0, 20.0}},
+				},
+			},
+		},
+	}
+	countFieldCountMask := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{2, 4}},
+				},
+			},
+		},
+	}
+	typeutil.SetFieldDataValidData(countFieldCountMask, []bool{true, false})
+
+	resultCountMask, err := ComputeAvgFromSumAndCount(sumFieldCountMask, countFieldCountMask)
+	require.NoError(t, err)
+	require.NotNil(t, resultCountMask)
+	validDataCountMask := typeutil.GetFieldDataValidData(resultCountMask)
+	require.Len(t, validDataCountMask, 2)
+	assert.True(t, validDataCountMask[0])
+	assert.False(t, validDataCountMask[1], "null in countFieldData should propagate to result validData")
+	assert.Equal(t, 5.0, resultCountMask.GetScalars().GetDoubleData().GetData()[0])
+	assert.Equal(t, 0.0, resultCountMask.GetScalars().GetDoubleData().GetData()[1])
+
+	// Test when both sumFieldData and countFieldData have validity masks
+	typeutil.SetFieldDataValidData(sumFieldCountMask, []bool{true, true})
+	typeutil.SetFieldDataValidData(countFieldCountMask, []bool{false, true})
+	resultBothMask, err := ComputeAvgFromSumAndCount(sumFieldCountMask, countFieldCountMask)
+	require.NoError(t, err)
+	require.NotNil(t, resultBothMask)
+	validDataBothMask := typeutil.GetFieldDataValidData(resultBothMask)
+	require.Len(t, validDataBothMask, 2)
+	assert.False(t, validDataBothMask[0], "row 0 has invalid count mask")
+	assert.True(t, validDataBothMask[1], "row 1 has valid sum and count")
+	assert.Equal(t, 0.0, resultBothMask.GetScalars().GetDoubleData().GetData()[0])
+	assert.Equal(t, 5.0, resultBothMask.GetScalars().GetDoubleData().GetData()[1])
 }
 
 func TestComputeAvgFromSumAndCount_Errors(t *testing.T) {
@@ -312,4 +362,121 @@ func TestComputeAvgFromSumAndCount_Errors(t *testing.T) {
 	_, err = ComputeAvgFromSumAndCount(unsupportedSumField, validCountField)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported sum field type")
+}
+
+// TestGroupAggReducer_AvgWithZeroCountAndNullGroup verifies end-to-end multi-segment reduction
+// for AVG aggregation when a group contains only NULL values across segments (zero count / masked sum).
+// It verifies that zero-count and masked groups survive the reducer without division-by-zero errors
+// and that SQL-NULL aggregate semantics (0.0 fill value and validData=false) are preserved.
+func TestGroupAggReducer_AvgWithZeroCountAndNullGroup(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "group_field", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "agg_field", DataType: schemapb.DataType_Int64},
+		},
+	}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_sum, FieldId: 101},
+		{Op: planpb.AggregateOp_count, FieldId: 101},
+	}
+	reducer := NewGroupAggReducer([]int64{100}, aggregates, -1, schema)
+
+	// Segment 1:
+	// Group 1: sum=10, count=2 (valid)
+	// Group 2: sum=null (masked), count=0 (zero count)
+	groupField1 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "group_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}},
+			},
+		},
+	}
+	sumField1 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "agg_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{10, 0}}},
+			},
+		},
+	}
+	typeutil.SetFieldDataValidData(sumField1, []bool{true, false})
+	countField1 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "agg_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{2, 0}}},
+			},
+		},
+	}
+
+	// Segment 2:
+	// Group 1: sum=20, count=3 (valid)
+	// Group 2: sum=null (masked), count=0 (zero count)
+	groupField2 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "group_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}},
+			},
+		},
+	}
+	sumField2 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "agg_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{20, 0}}},
+			},
+		},
+	}
+	typeutil.SetFieldDataValidData(sumField2, []bool{true, false})
+	countField2 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "agg_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{3, 0}}},
+			},
+		},
+	}
+
+	res1 := NewAggregationResult([]*schemapb.FieldData{groupField1, sumField1, countField1}, 2)
+	res2 := NewAggregationResult([]*schemapb.FieldData{groupField2, sumField2, countField2}, 2)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{res1, res2})
+	require.NoError(t, err)
+	require.NotNil(t, reduced)
+
+	reducedFields := reduced.GetFieldDatas()
+	require.Len(t, reducedFields, 3)
+
+	// Post-reduction: proxy computes AVG from reduced sum and count columns
+	avgField, err := ComputeAvgFromSumAndCount(reducedFields[1], reducedFields[2])
+	require.NoError(t, err)
+	require.NotNil(t, avgField)
+
+	groupKeys := reducedFields[0].GetScalars().GetLongData().GetData()
+	avgValues := avgField.GetScalars().GetDoubleData().GetData()
+	validData := typeutil.GetFieldDataValidData(avgField)
+
+	require.Len(t, groupKeys, 2)
+	require.Len(t, avgValues, 2)
+	require.Len(t, validData, 2)
+
+	for i, key := range groupKeys {
+		if key == 1 {
+			// Valid group: (10 + 20) / (2 + 3) = 6.0
+			assert.InDelta(t, 6.0, avgValues[i], 0.0001)
+			assert.True(t, validData[i], "group 1 should be marked valid non-null")
+		} else if key == 2 {
+			// All-NULL group: count is 0, sum is null -> emitted as SQL-NULL aggregate (0.0 fill, valid=false)
+			assert.Equal(t, 0.0, avgValues[i])
+			assert.False(t, validData[i], "group 2 (all-NULL group) should be marked invalid/null")
+		}
+	}
 }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/53204
Closes #53204

### Problem
When executing a grouped query with an aggregation such as `avg(x)` where a group contains only `NULL` values for the column `x`, the query terminates abnormally with an invalid parameter error:
```text
division by zero: count is 0 at row %d: invalid parameter
```
Because the entire query fails, valid aggregates for non-null groups are lost.

Under standard SQL aggregation semantics, `AVG(NULL)` evaluates to `NULL`, not an exception. Furthermore, `terminateAvg` in `internal/agg/operators.go` already treats zero count and null slots as `nil, nil` (SQL `NULL`), but `ComputeAvgFromSumAndCount` in `internal/agg/aggregate_util.go` was unconditionally returning an error when `countData[i] == 0`.

### Solution
1. In `ComputeAvgFromSumAndCount`:
   - Check if `countData[i] <= 0` or if the row is marked invalid in `countValidData` or `sumValidData`.
   - When a zero-count or null group is encountered, mark `validData[i] = false` and append `0.0` to maintain column array alignment.
   - If `countData[i] > 0` and both inputs are valid, mark `validData[i] = true` and compute `sum / count`.
   - Call `typeutil.SetFieldDataValidData(result, validData)` when nulls are present or when input validity masks exist.
2. Maintain full backwards compatibility for non-nullable / non-null batches (keeps `ValidData` nil when no nulls exist).
3. Added comprehensive unit tests in `internal/agg/aggregate_util_test.go`:
   - `TestComputeAvgFromSumAndCount_Success` (Int64 and Double sum with Int64 count)
   - `TestComputeAvgFromSumAndCount_ZeroCountTreatedAsNull` (verifies zero count produces null aggregate with `validData[i] == false` alongside valid groups)
   - `TestComputeAvgFromSumAndCount_NullInputs` (verifies propagation of null input validity masks)
   - `TestComputeAvgFromSumAndCount_Errors` (verifies validation for nil inputs, count type mismatch, length mismatch, unsupported sum types)

### Verification
- `go test -v ./internal/agg/...` passes cleanly (100% tests passing).
- Formatted with `gofmt`.

Signed-off-by: amasen02 <amasen02@users.noreply.github.com>
