### PR TITLE
fix: classify missing external columns as input errors

### DIFF
--- a/internal/core/src/segcore/external_utils_c.cpp
+++ b/internal/core/src/segcore/external_utils_c.cpp
@@ -39,6 +39,7 @@
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/ffi_internal/bridge.h"
+#include "milvus-storage/format/format_reader.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/reader.h"
 #include "nlohmann/json.hpp"
@@ -97,6 +98,75 @@ struct ManifestGuard {
     ManifestGuard&
     operator=(const ManifestGuard&) = delete;
 };
+
+struct SampleField {
+    milvus::FieldMeta field_meta;
+    std::string column_name;
+};
+
+std::optional<std::string>
+FindMissingSampleColumn(
+    const std::shared_ptr<milvus_storage::api::ColumnGroups>& cgs,
+    const milvus_storage::api::Properties& properties,
+    const std::vector<SampleField>& sample_fields,
+    int64_t sample_rows) {
+    std::vector<bool> assigned(sample_fields.size(), false);
+    for (const auto& column_group : *cgs) {
+        if (column_group == nullptr) {
+            return std::nullopt;
+        }
+
+        std::vector<size_t> field_indices;
+        for (size_t i = 0; i < sample_fields.size(); ++i) {
+            if (assigned[i]) {
+                continue;
+            }
+            const auto& column_name = sample_fields[i].column_name;
+            if (std::find(column_group->columns.begin(),
+                          column_group->columns.end(),
+                          column_name) != column_group->columns.end()) {
+                assigned[i] = true;
+                field_indices.push_back(i);
+            }
+        }
+        if (field_indices.empty()) {
+            continue;
+        }
+
+        int64_t remaining_rows = sample_rows;
+        for (const auto& file : column_group->files) {
+            if (remaining_rows <= 0) {
+                break;
+            }
+            const auto rows_in_file = file.end_index - file.start_index;
+            if (rows_in_file <= 0) {
+                return std::nullopt;
+            }
+
+            auto reader = milvus_storage::FormatReader::create(
+                nullptr, column_group->format, file, properties, {}, nullptr);
+            if (!reader.ok()) {
+                // Keep the original read error. A corrupt footer or failed
+                // object-store read is not evidence that the user's mapping is
+                // wrong.
+                return std::nullopt;
+            }
+            const auto& physical_schema = reader.ValueOrDie()->get_schema();
+            if (physical_schema == nullptr) {
+                return std::nullopt;
+            }
+            for (auto field_index : field_indices) {
+                const auto& column_name =
+                    sample_fields[field_index].column_name;
+                if (physical_schema->GetFieldIndex(column_name) < 0) {
+                    return column_name;
+                }
+            }
+            remaining_rows -= std::min(remaining_rows, rows_in_file);
+        }
+    }
+    return std::nullopt;
+}
 
 std::shared_ptr<milvus_storage::api::ColumnGroups>
 ReadManifestColumnGroupsWithFFI(const char* manifest_path,
@@ -187,29 +257,6 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
             return MakeCStatusError("no rows available for sampling");
         }
 
-        // 4. Create schemaless Reader (nullptr schema → types from file)
-        auto reader = milvus_storage::api::Reader::create(
-            cgs, nullptr, nullptr, *properties);
-
-        // 5. Take sample rows [0, 1, ..., actual-1]
-        std::vector<int64_t> indices(actual);
-        std::iota(indices.begin(), indices.end(), 0);
-
-        auto result = reader->take(indices, 1);
-        if (!result.ok()) {
-            auto error = milvus_storage::ToSegcoreError(result.status());
-            return milvus::FailureCStatus(&error);
-        }
-        auto table = result.ValueOrDie();
-        auto num_rows = table->num_rows();
-        if (num_rows == 0) {
-            return MakeCStatusError("sample returned 0 rows");
-        }
-
-        struct SampleField {
-            milvus::FieldMeta field_meta;
-            std::string column_name;
-        };
         std::vector<SampleField> external_fields;
         if (collection_schema.proto_blob != nullptr &&
             collection_schema.proto_size > 0) {
@@ -257,6 +304,35 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
             }
         }
 
+        // 4. Create schemaless Reader (nullptr schema → types from file)
+        auto reader = milvus_storage::api::Reader::create(
+            cgs, nullptr, nullptr, *properties);
+
+        // 5. Take sample rows [0, 1, ..., actual-1]
+        std::vector<int64_t> indices(actual);
+        std::iota(indices.begin(), indices.end(), 0);
+
+        auto result = reader->take(indices, 1);
+        if (!result.ok()) {
+            if (result.status().IsInvalid()) {
+                auto missing_column = FindMissingSampleColumn(
+                    cgs, *properties, external_fields, actual);
+                if (missing_column.has_value()) {
+                    return milvus::FailureCStatus(
+                        milvus::InvalidParameter,
+                        fmt::format("Column '{}' not found in schema",
+                                    missing_column.value()));
+                }
+            }
+            auto error = milvus_storage::ToSegcoreError(result.status());
+            return milvus::FailureCStatus(&error);
+        }
+        auto table = result.ValueOrDie();
+        auto num_rows = table->num_rows();
+        if (num_rows == 0) {
+            return MakeCStatusError("sample returned 0 rows");
+        }
+
         // 6. Calculate per-column Arrow buffer size (recursive for nested types)
         std::function<int64_t(const std::shared_ptr<arrow::ArrayData>&)>
             calcArrayDataSize =
@@ -291,10 +367,10 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
                 const auto& column_name = sample_field.column_name;
                 auto chunked = table->GetColumnByName(column_name);
                 if (chunked == nullptr) {
-                    return MakeCStatusError(
+                    return milvus::FailureCStatus(
+                        milvus::InvalidParameter,
                         fmt::format("Column '{}' not found in schema",
-                                    column_name)
-                            .c_str());
+                                    column_name));
                 }
 
                 int64_t col_bytes = 0;

--- a/internal/storagev2/packed/ffi_sample_test.go
+++ b/internal/storagev2/packed/ffi_sample_test.go
@@ -1,0 +1,171 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build dynamic
+
+package packed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestSampleExternalFieldSizesMissingMappedColumnIsInputError(t *testing.T) {
+	rootPath := t.TempDir()
+	storageConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    rootPath,
+	}
+
+	physicalSchema := arrow.NewSchema([]arrow.Field{{
+		Name:     "actual_column",
+		Type:     arrow.PrimitiveTypes.Int64,
+		Nullable: false,
+		Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+	}}, nil)
+	writer, err := NewFFIPackedWriter(
+		"files/external_sample_source/1",
+		physicalSchema,
+		[]storagecommon.ColumnGroup{{Columns: []int{0}, GroupID: storagecommon.DefaultShortColumnGroupID}},
+		storageConfig,
+		nil,
+	)
+	require.NoError(t, err)
+	defer writer.Destroy()
+
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, physicalSchema)
+	defer builder.Release()
+	builder.Field(0).(*array.Int64Builder).AppendValues([]int64{1, 2}, nil)
+	record := builder.NewRecord()
+	defer record.Release()
+	require.NoError(t, writer.WriteRecordBatch(record))
+
+	output, err := writer.Close()
+	require.NoError(t, err)
+	defer output.Destroy()
+	sourceManifest, err := CommitManifestUpdates(
+		"files/external_sample_source/1",
+		ManifestEarliest,
+		storageConfig,
+		&ManifestUpdates{NewFiles: output},
+	)
+	require.NoError(t, err)
+	fragments, err := ReadFragmentsFromManifest(sourceManifest, storageConfig, []string{"actual_column"})
+	require.NoError(t, err)
+	require.NotEmpty(t, fragments)
+	collectionSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
+		FieldID:       100,
+		Name:          "value",
+		DataType:      schemapb.DataType_Int64,
+		ExternalField: "actual_column",
+	}}}
+	fieldSizes, err := SampleExternalFieldSizes(
+		sourceManifest,
+		1,
+		1,
+		"",
+		"",
+		collectionSchema,
+		storageConfig,
+	)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int64{"actual_column": 8}, fieldSizes)
+
+	externalManifestBase := "files/external_sample_manifest/1"
+	for i := range fragments {
+		fragments[i].FilePath, err = filepath.Rel(filepath.Join(externalManifestBase, "_data"), fragments[i].FilePath)
+		require.NoError(t, err)
+	}
+
+	// External manifests use the requested mapping as their logical column list.
+	// Keep the same physical parquet file but declare a column that it does not
+	// contain, reproducing a stale/incorrect external_field mapping.
+	externalManifest, err := CreateManifestForSegment(
+		externalManifestBase,
+		[]string{"missing_column"},
+		"parquet",
+		fragments,
+		storageConfig,
+	)
+	require.NoError(t, err)
+
+	collectionSchema.Fields[0].ExternalField = "missing_column"
+	_, err = SampleExternalFieldSizes(
+		externalManifest,
+		1,
+		1,
+		"",
+		"",
+		collectionSchema,
+		storageConfig,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Column 'missing_column' not found in schema")
+	require.Equal(t, merr.InputError, merr.GetErrorType(err))
+}
+
+func TestSampleExternalFieldSizesCorruptFileRemainsSystemError(t *testing.T) {
+	rootPath := t.TempDir()
+	storageConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    rootPath,
+	}
+
+	corruptFile := "files/external_corrupt_source/data.parquet"
+	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(rootPath, corruptFile)), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootPath, corruptFile), []byte("not parquet"), 0o600))
+
+	externalManifestBase := "files/external_corrupt_manifest/1"
+	relativeFile, err := filepath.Rel(filepath.Join(externalManifestBase, "_data"), corruptFile)
+	require.NoError(t, err)
+	externalManifest, err := CreateManifestForSegment(
+		externalManifestBase,
+		[]string{"missing_column"},
+		"parquet",
+		[]Fragment{{FilePath: relativeFile, StartRow: 0, EndRow: 1, RowCount: 1}},
+		storageConfig,
+	)
+	require.NoError(t, err)
+
+	collectionSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
+		FieldID:       100,
+		Name:          "value",
+		DataType:      schemapb.DataType_Int64,
+		ExternalField: "missing_column",
+	}}}
+	_, err = SampleExternalFieldSizes(
+		externalManifest,
+		1,
+		1,
+		"",
+		"",
+		collectionSchema,
+		storageConfig,
+	)
+	require.Error(t, err)
+	require.NotEqual(t, merr.InputError, merr.GetErrorType(err))
+}


### PR DESCRIPTION
issue: #53209

## What changed

`SampleExternalFieldSizes` now verifies physical file schemas when the initial sample read returns Arrow `Invalid`. A mapped column that is confirmed absent is returned as segcore `InvalidParameter`, so Go receives an `InputError` instead of `DataFormatBroken` / `SystemError`.

The verification is limited to the error path. If a file cannot be opened or its schema cannot be read, the original storage error is preserved. The post-read missing-column check uses the same `InvalidParameter` classification.

## Why

External manifests use `external_field` mappings as their logical column list. If that logical list contains a column missing from the physical Parquet schema, the initial reader failure was previously collapsed into `DataFormatBroken` (2024). Retry-aware callers could then repeatedly retry a deterministic request error.

## Validation

- Added a real Parquet regression test that passes on a valid mapping and confirms a missing mapped column reaches Go as `merr.InputError`. The regression fails before this change with `merr.SystemError`.
- Added a corrupt-Parquet case confirming unreadable storage remains a system error.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/storagev2/packed`
- `clang-format --dry-run --Werror internal/core/src/segcore/external_utils_c.cpp`
- Compiled the changed C++ translation unit and linked it into `libmilvus_core` for the Go regression run.

A fresh full core rebuild was blocked locally in the Rust dependency build (`zerocopy` errors with rustc 1.92); it failed before the Milvus C++ link. CI remains the full clean-build validation.
