### PR TITLE
fix: correct Go SDK GPU IVF constructor names

### DIFF
--- a/client/index/gpu.go
+++ b/client/index/gpu.go
@@ -59,13 +59,19 @@ func (idx gpuIVFFlatIndex) Params() map[string]string {
 	}
 }
 
-func NewGPUIVPFlatIndex(metricType MetricType) Index {
+// NewGPUIVFFlatIndex creates a GPU IVF_FLAT index.
+func NewGPUIVFFlatIndex(metricType MetricType) Index {
 	return gpuIVFFlatIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
 			indexType:  GPUIvfFlat,
 		},
 	}
+}
+
+// Deprecated: Use NewGPUIVFFlatIndex instead.
+func NewGPUIVPFlatIndex(metricType MetricType) Index {
+	return NewGPUIVFFlatIndex(metricType)
 }
 
 var _ Index = gpuIVFPQIndex{}
@@ -90,13 +96,19 @@ func (idx gpuIVFPQIndex) Params() map[string]string {
 	return result
 }
 
-func NewGPUIVPPQIndex(metricType MetricType) Index {
+// NewGPUIVFPQIndex creates a GPU IVF_PQ index.
+func NewGPUIVFPQIndex(metricType MetricType) Index {
 	return gpuIVFPQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
 			indexType:  GPUIvfPQ,
 		},
 	}
+}
+
+// Deprecated: Use NewGPUIVFPQIndex instead.
+func NewGPUIVPPQIndex(metricType MetricType) Index {
+	return NewGPUIVFPQIndex(metricType)
 }
 
 const (

--- a/client/index/gpu.go
+++ b/client/index/gpu.go
@@ -59,8 +59,9 @@ func (idx gpuIVFFlatIndex) Params() map[string]string {
 	}
 }
 
-// NewGPUIVFFlatIndex creates a GPU IVF_FLAT index.
-func NewGPUIVFFlatIndex(metricType MetricType) Index {
+// NewGPUIvfFlatIndex creates a GPU IVF_FLAT index.
+// Set nlist with WithExtraIndexParams when overriding the server default.
+func NewGPUIvfFlatIndex(metricType MetricType) Index {
 	return gpuIVFFlatIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
@@ -69,9 +70,9 @@ func NewGPUIVFFlatIndex(metricType MetricType) Index {
 	}
 }
 
-// Deprecated: Use NewGPUIVFFlatIndex instead.
+// Deprecated: Use NewGPUIvfFlatIndex instead.
 func NewGPUIVPFlatIndex(metricType MetricType) Index {
-	return NewGPUIVFFlatIndex(metricType)
+	return NewGPUIvfFlatIndex(metricType)
 }
 
 var _ Index = gpuIVFPQIndex{}
@@ -96,8 +97,9 @@ func (idx gpuIVFPQIndex) Params() map[string]string {
 	return result
 }
 
-// NewGPUIVFPQIndex creates a GPU IVF_PQ index.
-func NewGPUIVFPQIndex(metricType MetricType) Index {
+// NewGPUIvfPQIndex creates a GPU IVF_PQ index.
+// Set nlist, m, and nbits with WithExtraIndexParams when overriding server defaults.
+func NewGPUIvfPQIndex(metricType MetricType) Index {
 	return gpuIVFPQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
@@ -106,9 +108,9 @@ func NewGPUIVFPQIndex(metricType MetricType) Index {
 	}
 }
 
-// Deprecated: Use NewGPUIVFPQIndex instead.
+// Deprecated: Use NewGPUIvfPQIndex instead.
 func NewGPUIVPPQIndex(metricType MetricType) Index {
-	return NewGPUIVFPQIndex(metricType)
+	return NewGPUIvfPQIndex(metricType)
 }
 
 const (

--- a/client/index/gpu_test.go
+++ b/client/index/gpu_test.go
@@ -36,8 +36,10 @@ func TestGPUIndexTypes(t *testing.T) {
 
 	for _, tc := range []testCase{
 		{tag: "brute_force", idx: NewGPUBruteForceIndex(entity.L2), expect: GPUBruteForce},
-		{tag: "ivf_flat", idx: NewGPUIVPFlatIndex(entity.L2), expect: GPUIvfFlat},
-		{tag: "ivf_pq", idx: NewGPUIVPPQIndex(entity.L2), expect: GPUIvfPQ},
+		{tag: "ivf_flat", idx: NewGPUIVFFlatIndex(entity.L2), expect: GPUIvfFlat},
+		{tag: "ivf_pq", idx: NewGPUIVFPQIndex(entity.L2), expect: GPUIvfPQ},
+		{tag: "legacy_ivp_flat", idx: NewGPUIVPFlatIndex(entity.L2), expect: GPUIvfFlat},
+		{tag: "legacy_ivp_pq", idx: NewGPUIVPPQIndex(entity.L2), expect: GPUIvfPQ},
 		{tag: "cagra", idx: NewGPUCagraIndex(entity.L2, 128, 64), expect: GPUCagra},
 	} {
 		t.Run(tc.tag, func(t *testing.T) {
@@ -52,16 +54,16 @@ func TestGPUUnsetBuildParamsAreOmitted(t *testing.T) {
 	// nlist / m / nbits are unreachable through these constructors, so they sat
 	// at zero and were emitted as "0" — below every accepted range, which fails
 	// the build. An absent key lets the server apply its default instead.
-	flat := NewGPUIVPFlatIndex(entity.L2).Params()
+	flat := NewGPUIVFFlatIndex(entity.L2).Params()
 	assert.NotContains(t, flat, ivfNlistKey)
 
-	pq := NewGPUIVPPQIndex(entity.L2).Params()
+	pq := NewGPUIVFPQIndex(entity.L2).Params()
 	assert.NotContains(t, pq, ivfNlistKey)
 	assert.NotContains(t, pq, ivfPQMKey)
 	assert.NotContains(t, pq, ivfPQNbits)
 
 	// They remain reachable without changing the constructor signature.
-	withNlist := WithExtraIndexParams(NewGPUIVPFlatIndex(entity.L2), map[string]string{
+	withNlist := WithExtraIndexParams(NewGPUIVFFlatIndex(entity.L2), map[string]string{
 		ivfNlistKey: "1024",
 	}).Params()
 	assert.Equal(t, "1024", withNlist[ivfNlistKey])

--- a/client/index/gpu_test.go
+++ b/client/index/gpu_test.go
@@ -36,8 +36,8 @@ func TestGPUIndexTypes(t *testing.T) {
 
 	for _, tc := range []testCase{
 		{tag: "brute_force", idx: NewGPUBruteForceIndex(entity.L2), expect: GPUBruteForce},
-		{tag: "ivf_flat", idx: NewGPUIVFFlatIndex(entity.L2), expect: GPUIvfFlat},
-		{tag: "ivf_pq", idx: NewGPUIVFPQIndex(entity.L2), expect: GPUIvfPQ},
+		{tag: "ivf_flat", idx: NewGPUIvfFlatIndex(entity.L2), expect: GPUIvfFlat},
+		{tag: "ivf_pq", idx: NewGPUIvfPQIndex(entity.L2), expect: GPUIvfPQ},
 		{tag: "legacy_ivp_flat", idx: NewGPUIVPFlatIndex(entity.L2), expect: GPUIvfFlat},
 		{tag: "legacy_ivp_pq", idx: NewGPUIVPPQIndex(entity.L2), expect: GPUIvfPQ},
 		{tag: "cagra", idx: NewGPUCagraIndex(entity.L2, 128, 64), expect: GPUCagra},
@@ -54,16 +54,16 @@ func TestGPUUnsetBuildParamsAreOmitted(t *testing.T) {
 	// nlist / m / nbits are unreachable through these constructors, so they sat
 	// at zero and were emitted as "0" — below every accepted range, which fails
 	// the build. An absent key lets the server apply its default instead.
-	flat := NewGPUIVFFlatIndex(entity.L2).Params()
+	flat := NewGPUIvfFlatIndex(entity.L2).Params()
 	assert.NotContains(t, flat, ivfNlistKey)
 
-	pq := NewGPUIVFPQIndex(entity.L2).Params()
+	pq := NewGPUIvfPQIndex(entity.L2).Params()
 	assert.NotContains(t, pq, ivfNlistKey)
 	assert.NotContains(t, pq, ivfPQMKey)
 	assert.NotContains(t, pq, ivfPQNbits)
 
 	// They remain reachable without changing the constructor signature.
-	withNlist := WithExtraIndexParams(NewGPUIVFFlatIndex(entity.L2), map[string]string{
+	withNlist := WithExtraIndexParams(NewGPUIvfFlatIndex(entity.L2), map[string]string{
 		ivfNlistKey: "1024",
 	}).Params()
 	assert.Equal(t, "1024", withNlist[ivfNlistKey])


### PR DESCRIPTION
issue: #52726

Add `NewGPUIvfFlatIndex` and `NewGPUIvfPQIndex` using the package's existing `Ivf` spelling so callers can avoid the `IVP` typo. Keep the existing `NewGPUIVPFlatIndex` and `NewGPUIVPPQIndex` signatures as deprecated wrappers, preserving source compatibility and the existing index parameters.

Document how to supply the GPU IVF build parameters through `WithExtraIndexParams`: `nlist` for IVF_FLAT, and `nlist`, `m`, and `nbits` for IVF_PQ. This provides a typed-constructor path for the parameters raised in the issue without requiring `NewGenericIndex`.

Update the GPU index tests to exercise both the corrected and legacy constructor names, default parameter omission, and `WithExtraIndexParams` support.

Validation from `client/`:
- `go test -mod=readonly -tags dynamic,test -gcflags='all=-N -l' -count=1 -cover ./index` passes on macOS arm64 with Go 1.26.8; package coverage is 80.4%.
- `golangci-lint` v2.11.3 with the repository client config and `--build-tags dynamic,test ./index/...`: 0 issues when run as gocritic-only and as the remaining configured linters. The combined local invocation hits a ruleguard loader error across every file in `client/index`, rather than a finding in the changed files.
- `gofmt` and `git diff --check` pass.

GPU server integration tests were not run; this change only adds SDK constructor aliases and documentation.

AI assistance: OpenAI Codex assisted with source inspection, implementation, and validation.
