### PR TITLE
fix: [cp3.0] stop logging encryption key and storage credentials in compaction logs

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -20,9 +20,37 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+var _ mlog.ObjectMarshaler = Params{}
+
+// MarshalLogObject logs every tunable under the lowerCamel form of its json
+// tag, plus the non-secret locator fields of StorageConfig. The credentials in
+// StorageConfig are never logged.
+func (p Params) MarshalLogObject(enc mlog.ObjectEncoder) error {
+	enc.AddInt64("storageVersion", p.StorageVersion)
+	enc.AddString("storageFormat", p.StorageFormat)
+	enc.AddUint64("binlogMaxSize", p.BinLogMaxSize)
+	enc.AddBool("useMergeSort", p.UseMergeSort)
+	enc.AddInt("maxSegmentMergeSort", p.MaxSegmentMergeSort)
+	enc.AddFloat64("preferSegmentSizeRatio", p.PreferSegmentSizeRatio)
+	enc.AddInt("bloomFilterApplyBatchSize", p.BloomFilterApplyBatchSize)
+	enc.AddBool("useLoonFfi", p.UseLoonFFI)
+	enc.AddFloat64("lobHoleRatioThreshold", p.LOBHoleRatioThreshold)
+	enc.AddInt64("textInlineThreshold", p.TextInlineThreshold)
+	enc.AddInt64("textMaxLobFileBytes", p.TextMaxLobFileBytes)
+	enc.AddInt64("textFlushThresholdBytes", p.TextFlushThresholdBytes)
+	if cfg := p.StorageConfig; cfg != nil {
+		enc.AddString("storageType", cfg.GetStorageType())
+		enc.AddString("storageAddress", cfg.GetAddress())
+		enc.AddString("storageBucket", cfg.GetBucketName())
+		enc.AddString("storageRootPath", cfg.GetRootPath())
+	}
+	return nil
+}
 
 type Params struct {
 	StorageVersion            int64                  `json:"storage_version,omitempty"`

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -17,14 +17,82 @@
 package compaction
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+// logKeyOfJSONTag turns a json tag such as "binlog_max_size" into the log key
+// MarshalLogObject uses for it ("binlogMaxSize").
+func logKeyOfJSONTag(tag string) string {
+	parts := strings.Split(strings.Split(tag, ",")[0], "_")
+	for i := 1; i < len(parts); i++ {
+		parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func TestParamsMarshalLogObject(t *testing.T) {
+	params := Params{
+		StorageVersion:            storage.StorageV2,
+		StorageFormat:             "parquet",
+		BinLogMaxSize:             1,
+		UseMergeSort:              true,
+		MaxSegmentMergeSort:       2,
+		PreferSegmentSizeRatio:    0.5,
+		BloomFilterApplyBatchSize: 3,
+		UseLoonFFI:                true,
+		LOBHoleRatioThreshold:     0.25,
+		TextInlineThreshold:       4,
+		TextMaxLobFileBytes:       5,
+		TextFlushThresholdBytes:   6,
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType:       "remote",
+			Address:           "minio:9000",
+			BucketName:        "a-bucket",
+			RootPath:          "files",
+			AccessKeyID:       "ak-secret",
+			SecretAccessKey:   "sk-secret",
+			SslCACert:         "ca-secret",
+			GcpCredentialJSON: "gcp-secret",
+		},
+	}
+
+	sink := mlog.CaptureGlobalLogs(t, &mlog.Config{Level: "info", DisableTimestamp: true})
+	mlog.Info(context.Background(), "compact start", mlog.Any("compactionParams", params))
+	logged := sink.String()
+
+	// Every field of Params except StorageConfig must show up under the log key
+	// derived from its json tag, so a field added later cannot silently vanish
+	// from the logs.
+	typ := reflect.TypeOf(params)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Name == "StorageConfig" {
+			continue
+		}
+		tag := field.Tag.Get("json")
+		require.NotEmptyf(t, tag, "field %s must carry a json tag", field.Name)
+		assert.Contains(t, logged, logKeyOfJSONTag(tag)+"=", "field %s is missing from the log", field.Name)
+	}
+
+	for _, locator := range []string{"storageType=remote", "storageAddress=minio:9000", "storageBucket=a-bucket", "storageRootPath=files"} {
+		assert.Contains(t, logged, locator)
+	}
+	for _, secret := range []string{"ak-secret", "sk-secret", "ca-secret", "gcp-secret"} {
+		assert.NotContains(t, logged, secret)
+	}
+}
 
 func TestGetJSONParams(t *testing.T) {
 	paramtable.Init()

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -448,8 +448,13 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	defer span.End()
 	compactStart := time.Now()
 
-	mlog.Info(context.TODO(), "compact start", mlog.Any("compactionParams", t.compactionParams),
-		mlog.Any("plan", t.plan))
+	mlog.Info(ctx, "compact start",
+		mlog.Int64("planID", t.plan.GetPlanID()),
+		mlog.String("type", t.plan.GetType().String()),
+		mlog.String("channel", t.plan.GetChannel()),
+		mlog.Int("segmentNum", len(t.plan.GetSegmentBinlogs())),
+		mlog.Int64("totalRows", t.plan.GetTotalRows()),
+		mlog.Any("compactionParams", t.compactionParams))
 
 	if err := t.preCompact(); err != nil {
 		mlog.Warn(context.TODO(), "compact wrong, failed to preCompact", mlog.Err(err))

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -40,8 +40,10 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -135,6 +137,25 @@ func (s *MixCompactionTaskStorageV1Suite) prepareMissingBM25OutputSegments(isSor
 			IsSorted:     isSorted,
 		})
 	}
+}
+
+func TestMixCompactionDoesNotLogPluginContext(t *testing.T) {
+	s := newMixCompactionStorageV1SuiteForDirectTest(t)
+	s.prepareMissingBM25OutputSegments(false)
+	s.task.plan.PluginContext = []*commonpb.KeyValuePair{
+		{Key: hookutil.CipherConfigUnsafeEZK, Value: "sentinel-ezk"},
+	}
+	s.task.plan.JsonParams = `{"storage_config":{"secret_access_key":"sentinel-sk"}}`
+
+	sink := mlog.CaptureGlobalLogs(t, &mlog.Config{Level: "debug", DisableTimestamp: true})
+	_, err := s.task.Compact()
+	s.NoError(err)
+
+	logged := sink.String()
+	// segmentNum is emitted only by the rewritten "compact start" line.
+	s.Contains(logged, "segmentNum=3")
+	s.NotContains(logged, "sentinel-ezk")
+	s.NotContains(logged, "sentinel-sk")
 }
 
 func TestMixCompactionMaterializesMissingBM25OutputNoDelete(t *testing.T) {

--- a/pkg/mlog/test_sink.go
+++ b/pkg/mlog/test_sink.go
@@ -1,0 +1,78 @@
+package mlog
+
+import (
+	"bytes"
+	"sync"
+)
+
+// TestSink is an in-memory zapcore.WriteSyncer for unit tests that assert on
+// log output.
+//
+// It has to serialize its own access because InitLoggerWithWriteSyncer does not
+// wrap the syncer in zapcore.Lock - textIOCore writes straight through to it.
+// A test that installs its sink as the global logger therefore shares that sink
+// with every background goroutine that logs, while the test itself reads the
+// captured bytes back. A bare bytes.Buffer is not safe for that, and the race
+// detector reports both write/write and read/write races on it.
+type TestSink struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+// NewTestSink returns an empty TestSink.
+func NewTestSink() *TestSink {
+	return &TestSink{}
+}
+
+// Write implements zapcore.WriteSyncer.
+func (s *TestSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+// Sync implements zapcore.WriteSyncer. The sink is in memory, so there is
+// nothing to flush.
+func (s *TestSink) Sync() error {
+	return nil
+}
+
+// String returns everything written to the sink so far. It is safe to call
+// while other goroutines are still logging.
+func (s *TestSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestingTB is the subset of *testing.T that CaptureGlobalLogs needs, declared
+// here so that mlog does not have to import "testing". It mirrors how
+// InitTestLogger takes a zaptest.TestingT.
+type TestingTB interface {
+	Helper()
+	Cleanup(func())
+	Fatalf(format string, args ...any)
+}
+
+// CaptureGlobalLogs installs a TestSink as the sink of the global logger and
+// restores the previous logger when the test finishes.
+//
+// Prefer this over a per-package log buffer: the returned sink is safe to read
+// while unrelated goroutines keep writing to the global logger.
+func CaptureGlobalLogs(t TestingTB, cfg *Config, opts ...Option) *TestSink {
+	t.Helper()
+
+	sink := NewTestSink()
+	oldLogger := L()
+	oldLevel := GetAtomicLevel()
+	logger, props, err := InitLoggerWithWriteSyncer(cfg, sink, opts...)
+	if err != nil {
+		t.Fatalf("mlog: init logger with test sink: %v", err)
+		return nil
+	}
+	ReplaceGlobals(logger, props)
+	t.Cleanup(func() {
+		ReplaceGlobals(oldLogger, &ZapProperties{Level: oldLevel})
+	})
+	return sink
+}

--- a/pkg/mlog/test_sink_test.go
+++ b/pkg/mlog/test_sink_test.go
@@ -1,0 +1,81 @@
+package mlog
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupRecorder captures the cleanups CaptureGlobalLogs registers so that the
+// restore path can be asserted explicitly instead of only at test teardown.
+type cleanupRecorder struct {
+	*testing.T
+	cleanups []func()
+}
+
+func (r *cleanupRecorder) Cleanup(fn func()) {
+	r.cleanups = append(r.cleanups, fn)
+}
+
+func (r *cleanupRecorder) runCleanups() {
+	for i := len(r.cleanups) - 1; i >= 0; i-- {
+		r.cleanups[i]()
+	}
+	r.cleanups = nil
+}
+
+func TestCaptureGlobalLogsCapturesAndRestores(t *testing.T) {
+	before := L()
+	recorder := &cleanupRecorder{T: t}
+	t.Cleanup(recorder.runCleanups)
+
+	sink := CaptureGlobalLogs(recorder, &Config{Level: "debug", DisableTimestamp: true})
+	require.NotNil(t, sink)
+	require.NotSame(t, before, L())
+
+	Info(context.Background(), "captured by test sink", String("key", "value"))
+	assert.Contains(t, sink.String(), "captured by test sink")
+	assert.Contains(t, sink.String(), "key=value")
+
+	recorder.runCleanups()
+	assert.Same(t, before, L())
+}
+
+// TestCaptureGlobalLogsSinkIsConcurrencySafe is the regression test for the
+// race that a bare bytes.Buffer sink produces: the global logger is shared with
+// unrelated goroutines, so writes race with each other and with the test's own
+// reads. It only fails under -race, which is how CI runs the Go unit tests.
+func TestCaptureGlobalLogsSinkIsConcurrencySafe(t *testing.T) {
+	sink := CaptureGlobalLogs(t, &Config{Level: "debug", DisableTimestamp: true})
+
+	const (
+		writers          = 4
+		entriesPerWriter = 100
+		reads            = 200
+	)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < entriesPerWriter; j++ {
+				Info(ctx, "concurrent background log entry")
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < reads; j++ {
+			_ = sink.String()
+		}
+	}()
+	wg.Wait()
+
+	assert.Contains(t, sink.String(), "concurrent background log entry")
+}


### PR DESCRIPTION
Cherry-pick from master

pr: #53191
issue: #53190

## Summary

Cherry-picked from master PR #53191 (merged). Applied cleanly with no conflicts; the per-file diff of the cherry-picked commit is identical to the master PR.

Rebased onto the latest `3.0`.

## One extra commit, not in the master PR

`internal/compaction/params_test.go` calls `mlog.CaptureGlobalLogs`, which lives
in `pkg/mlog/test_sink.go`. That file was added on master by #52510 and never
back-ported, so the cherry-pick alone does not build on 3.0:

```
internal/compaction/params_test.go:71:15: undefined: mlog.CaptureGlobalLogs
FAIL github.com/milvus-io/milvus/internal/compaction [build failed]
```

A second commit back-ports `pkg/mlog/test_sink.go` and `pkg/mlog/test_sink_test.go`
verbatim from master at `786bd20d39` (#52510). Both files are test-only; there is
no production code change beyond the cherry-picked #53191 diff.

## Verification

- [x] Cherry-picked commit's per-file diff is byte-identical to master PR #53191 (4 files, +124/-2)
- [x] No conflict markers
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/compaction/...` — ok
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -race ./pkg/mlog/...` — ok
- [x] `go vet -tags dynamic,test ./internal/datanode/compactor/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZK5aCRZLovav7nKdtNYfo