### PR TITLE
enhance: [cp2.6]Support idempotent broadcast, with BulkImport as its first user

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -762,7 +762,24 @@ dataCoord:
   checkAutoBalanceConfigInterval: 10 # the interval of check auto balance config
   import:
     filesPerPreImportTask: 2 # The maximum number of files allowed per pre-import task.
-    taskRetention: 10800 # The retention period in seconds for tasks in the Completed or Failed state.
+    # The retention period in seconds for tasks in the Completed or Failed state.
+    # Nothing else bounds the terminal set -- maxImportJobNum counts only jobs that are
+    # neither Completed nor Failed -- so this value alone decides how many finished
+    # importJob entries stay in etcd, each carrying its schema, file list and options
+    # plus every preimport and import task under it.
+    # The 48h default exists for BulkImport idempotency and only for it: the idempotency
+    # window is bounded by streaming.walBroadcaster.tombstone.maxLifetime, so a job GC'd
+    # earlier than its tombstone lets an in-window retry resolve to a jobID that
+    # GetImportProgress can no longer find. Keep this at >= 2x that lifetime for as long
+    # as clients send an Idempotency-Key. Twice rather than equal because a tombstone's
+    # age is measured from the last StreamingCoord start: every restart extends its
+    # remaining life by up to another maxLifetime, while this retention keeps counting
+    # from the job's own completion. Equal values hold only for a window with no restart,
+    # which is not a property a default may assume. Raise it further if StreamingCoord
+    # restarts more than once inside one tombstone lifetime.
+    # A cluster whose clients never send an Idempotency-Key is under no such requirement
+    # and can lower this freely; 10800 was the default before idempotency keys existed.
+    taskRetention: 172800
     maxSizeInMBPerImportTask: 16384 # To prevent generating of small segments, we will re-group imported files. This parameter represents the sum of file sizes in each group (each ImportTask).
     scheduleInterval: 2 # The interval for scheduling import, measured in seconds.
     checkIntervalHigh: 2 # The interval for checking import, measured in seconds, is set to a high frequency for the import checker.

--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -87,6 +87,16 @@ func (c *DDLCallbacks) importV1AckCallback(ctx context.Context, result message.B
 
 // validateImportRequest validates the import request before broadcasting.
 // This includes all validation logic previously done in CheckCallback and Proxy.
+//
+// All of this runs before the broadcaster's idempotency lookup, which cannot happen
+// until the resource keys are held inside Broadcast. A retry therefore has to pass
+// these checks again before it can resolve to its original jobID, and not all of them
+// are a pure function of the request: ValidateMaxImportJobExceed counts in-flight jobs
+// and ValidateBinlogImportRequest lists the backup files in object storage. A retry
+// sent while the job limit is saturated -- by the original request among others -- or
+// after the backup files changed is rejected here rather than returning the original
+// jobID. Retrying the same key once the limit frees up resolves normally; minting a
+// fresh key instead is what would import the data twice.
 func (s *Server) validateImportRequest(ctx context.Context, files []*msgpb.ImportFile, options []*commonpb.KeyValuePair) error {
 	// Validate timeout
 	_, err := importutilv2.GetTimeoutTs(options)
@@ -126,6 +136,37 @@ func (s *Server) validateImportRequest(ctx context.Context, files []*msgpb.Impor
 	return nil
 }
 
+// jobIDFromDuplicatedBroadcast recovers the original import jobID from the broadcast
+// message the broadcaster returned on an idempotency hit. The broadcaster does not
+// know about import-specific structures, so the decode happens here.
+//
+// The request payload is deliberately NOT compared against the original: keeping the
+// key unique per logical request is the client's contract, and enforcing it
+// server-side would mean inventing an equality predicate over file lists whose false
+// mismatches would reject legitimate retries -- pushing the caller to mint a new key
+// and import the data twice, the very outcome this feature exists to prevent.
+//
+// The collectionID comparison is not such a predicate and is not a semantic guard: the
+// idempotency key is scoped to this collection's ID, so a hit already means both
+// broadcasts targeted it. It is checked as an invariant, to fail loudly on an encoding
+// or scoping bug rather than hand back a jobID for another collection's import.
+func jobIDFromDuplicatedBroadcast(msg message.BroadcastMutableMessage, collectionID int64) (int64, error) {
+	importMsg, err := message.AsBroadcastImportMessageV1(msg)
+	if err != nil {
+		return 0, merr.Wrap(err, "malformed duplicated import broadcast message")
+	}
+	body, err := importMsg.Body()
+	if err != nil {
+		return 0, merr.Wrap(err, "malformed duplicated import broadcast message body")
+	}
+	if body.GetCollectionID() != collectionID {
+		return 0, merr.WrapErrServiceInternalMsg(
+			"idempotency scope resolved to an import into collection %d, not %d",
+			body.GetCollectionID(), collectionID)
+	}
+	return body.GetJobID(), nil
+}
+
 // broadcastImport broadcasts the import message to all vchannels.
 // This method is called from the new ImportV2 flow where proxy calls DataCoord directly.
 func (s *Server) broadcastImport(ctx context.Context,
@@ -137,7 +178,8 @@ func (s *Server) broadcastImport(ctx context.Context,
 	schema *schemapb.CollectionSchema,
 	jobID int64,
 	vchannels []string,
-) error {
+	idempotencyKey string,
+) (duplicatedJobID int64, duplicated bool, err error) {
 	// Convert files to msgpb format for validation
 	msgFiles := lo.Map(files, func(file *internalpb.ImportFile, _ int) *msgpb.ImportFile {
 		return &msgpb.ImportFile{
@@ -148,20 +190,20 @@ func (s *Server) broadcastImport(ctx context.Context,
 
 	// Validate the request before broadcasting
 	if err := s.validateImportRequest(ctx, msgFiles, options); err != nil {
-		return merr.Wrap(err, "failed to validate import request")
+		return 0, false, merr.Wrap(err, "failed to validate import request")
 	}
 
 	// Get database name from collection metadata via broker
 	// This is safer than extracting from schema which may be stale
 	broadcaster, err := s.startBroadcastWithCollectionID(ctx, collectionID)
 	if err != nil {
-		return merr.Wrap(err, "failed to start broadcast with collection id")
+		return 0, false, merr.Wrap(err, "failed to start broadcast with collection id")
 	}
 	defer broadcaster.Close()
 
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err := merr.CheckRPCCall(coll.Status, err); err != nil {
-		return err
+		return 0, false, err
 	}
 	// Build import message without deprecated MsgBase
 	msg := message.NewImportMessageBuilderV1().
@@ -180,10 +222,35 @@ func (s *Server) broadcastImport(ctx context.Context,
 			Schema:         schema, // TODO: should we use the schema from the collection?
 			JobID:          jobID,
 		}).
+		// Scoped to the collection by ID, so the same client key stays a distinct
+		// operation against another collection, and a rename does not move the key off
+		// the collection it was bound to: a retry naming the renamed collection still
+		// resolves to its original job. A retry still naming the OLD collection never
+		// reaches here -- the proxy resolves the name first -- so it fails rather than
+		// importing twice. The broadcaster adds the message type; everything else about
+		// the dedup identity is this scope.
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(collectionID, idempotencyKey)).
 		WithBroadcast(vchannels).
 		MustBuildBroadcast()
 
 	// Broadcast the message
-	_, err = broadcaster.Broadcast(ctx, msg)
-	return err
+	result, err := broadcaster.Broadcast(ctx, msg)
+	if err != nil {
+		return 0, false, err
+	}
+	if result.Duplicated == nil {
+		return 0, false, nil
+	}
+	// The broadcaster resolved this idempotency key to an earlier broadcast, so no
+	// new job was created; recover what that broadcast carried.
+	originalJobID, err := jobIDFromDuplicatedBroadcast(result.Duplicated, collectionID)
+	if err != nil {
+		return 0, false, err
+	}
+	// Never log the raw key: it is client-controlled and may carry sensitive data.
+	log.Ctx(ctx).Info("import broadcast deduplicated by idempotency key",
+		zap.Int64("collectionID", collectionID),
+		zap.Int64("jobID", originalJobID),
+		zap.String("idempotencyKeyFingerprint", message.IdempotencyKeyFingerprint(idempotencyKey)))
+	return originalJobID, true, nil
 }

--- a/internal/datacoord/ddl_callbacks_import_test.go
+++ b/internal/datacoord/ddl_callbacks_import_test.go
@@ -77,34 +77,6 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_InvalidTimeoutReturnsEr
 	s.Contains(err.Error(), "timeout")
 }
 
-func (s *ImportCallbacksSuite) TestValidateImportRequest_MaxJobsExceededReturnsError() {
-	ctx := context.Background()
-
-	mock := mockey.Mock((*importMeta).CountJobBy).To(func(_ *importMeta, _ context.Context, _ ...ImportJobFilter) int {
-		return 2000 // Exceeds default MaxImportJobNum (1024)
-	}).Build()
-	defer mock.UnPatch()
-
-	server := &Server{
-		importMeta: &importMeta{},
-	}
-
-	files := []*msgpb.ImportFile{
-		{Id: 1, Paths: []string{"/test/file1.json"}},
-	}
-	options := []*commonpb.KeyValuePair{
-		{Key: "timeout", Value: "300s"},
-	}
-
-	err := server.validateImportRequest(ctx, files, options)
-
-	s.Error(err)
-	// Job-count backpressure is a server-side condition -> ErrImportSysFailed
-	// (must not be bucketed as a user-caused failure).
-	s.True(errors.Is(err, merr.ErrImportSysFailed))
-	s.Contains(err.Error(), "The number of jobs has reached the limit")
-}
-
 func (s *ImportCallbacksSuite) TestValidateImportRequest_BalancerGetFailsReturnsError() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -224,29 +196,30 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_SuccessWithValidInput()
 // broadcastImport Tests
 // --------------------------------
 
+// A request that fails validateImportRequest is rejected before any broadcast wiring is
+// touched -- server.broker is nil here, so reaching it would panic or block. The trigger
+// is an unparsable timeout, i.e. a pure function of the request. The job-count limit is
+// admission over mutable cluster state rather than a pure function of the request, but
+// it runs in the same place -- validateImportRequest, before any resource key is taken;
+// see TestImportV2_JobLimitStillRejectsANewJob.
 func (s *ImportCallbacksSuite) TestBroadcastImport_ValidationFailsReturnsError() {
 	ctx := context.Background()
-
-	// Mock validateImportRequest to fail
-	mockCount := mockey.Mock((*importMeta).CountJobBy).To(func(_ *importMeta, _ context.Context, _ ...ImportJobFilter) int {
-		return 2000 // Exceeds limit
-	}).Build()
-	defer mockCount.UnPatch()
 
 	server := &Server{
 		importMeta: &importMeta{},
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
 		[]int64{1},
 		[]*internalpb.ImportFile{{Id: 1, Paths: []string{"/test/file.json"}}},
-		[]*commonpb.KeyValuePair{{Key: "timeout", Value: "300s"}},
+		[]*commonpb.KeyValuePair{{Key: "timeout", Value: "not-a-duration"}},
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.Error(err)
@@ -285,7 +258,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_DescribeCollectionFailsReturn
 		broker:     mockBroker,
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
@@ -295,6 +268,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_DescribeCollectionFailsReturn
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.Error(err)
@@ -343,7 +317,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_StartBroadcastFailsReturnsErr
 		broker:     mockBroker,
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
@@ -353,6 +327,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_StartBroadcastFailsReturnsErr
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.Error(err)
@@ -406,7 +381,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_SecondDescribeCollectionFails
 		broker:     mockBroker,
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
@@ -416,6 +391,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_SecondDescribeCollectionFails
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.Error(err)
@@ -467,7 +443,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_BroadcastFailsReturnsError() 
 		broker:     mockBroker,
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
@@ -477,6 +453,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_BroadcastFailsReturnsError() 
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.Error(err)
@@ -527,7 +504,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_SuccessWithValidInput() {
 		broker:     mockBroker,
 	}
 
-	err := server.broadcastImport(
+	_, _, err := server.broadcastImport(
 		ctx,
 		"test_collection",
 		100,
@@ -537,6 +514,7 @@ func (s *ImportCallbacksSuite) TestBroadcastImport_SuccessWithValidInput() {
 		&schemapb.CollectionSchema{Name: "test_collection"},
 		1000,
 		[]string{"v1"},
+		"",
 	)
 
 	s.NoError(err)
@@ -575,6 +553,9 @@ type mockBroadcastAPIImpl struct {
 	broadcastResult *types.BroadcastAppendResult
 	broadcastErr    error
 	closeCalled     atomic.Bool
+	// capturedMsg is the last message handed to Broadcast, for assertions on what the
+	// caller actually put on the wire.
+	capturedMsg message.BroadcastMutableMessage
 }
 
 func newMockBroadcastAPIImpl() *mockBroadcastAPIImpl {
@@ -597,6 +578,7 @@ func (m *mockBroadcastAPIImpl) Broadcast(ctx context.Context, msg message.Broadc
 	if msg == nil {
 		return nil, errors.New("message is nil")
 	}
+	m.capturedMsg = msg
 	if m.broadcastErr != nil {
 		return nil, m.broadcastErr
 	}
@@ -822,4 +804,34 @@ func TestImportFlowIntegration(t *testing.T) {
 
 		t.Log("Import flow documented successfully")
 	})
+}
+
+func TestJobIDFromDuplicatedBroadcast(t *testing.T) {
+	msg := message.NewImportMessageBuilderV1().
+		WithHeader(&message.ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{JobID: 4242, CollectionID: 100}).
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(100, "run-1")).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+
+	jobID, err := jobIDFromDuplicatedBroadcast(msg, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4242), jobID)
+}
+
+// The collectionID comparison is an invariant check, not a semantic guard: the key is
+// scoped to a collection ID, so a hit already means both broadcasts targeted the same
+// collection. A mismatch can only come from an encoding or scoping bug, which must fail
+// loudly rather than hand back another collection's jobID.
+func TestJobIDFromDuplicatedBroadcast_RejectsADifferentCollection(t *testing.T) {
+	msg := message.NewImportMessageBuilderV1().
+		WithHeader(&message.ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{JobID: 4242, CollectionID: 100}).
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(100, "run-1")).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+
+	_, err := jobIDFromDuplicatedBroadcast(msg, 101)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrServiceInternal))
 }

--- a/internal/datacoord/import_services_test.go
+++ b/internal/datacoord/import_services_test.go
@@ -18,15 +18,19 @@ package datacoord
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
@@ -39,7 +43,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // ================================
@@ -703,3 +710,291 @@ func (s *ImportServicesSuite) TestCreateImportJobFromAck_AssignsFileIDs() {
 }
 
 // Helper types are defined in import_callbacks_test.go (mockBalancerImpl, mockBroadcastAPIImpl, newMockBroadcastAPIImpl)
+
+// newDuplicatedImportBroadcastResult builds the result the broadcaster returns on an
+// idempotency-key hit: no append results, plus the original broadcast message, which
+// carries the original jobID, the collection that job targeted, and the files it was
+// created from. The collectionID must match the request's, or the duplicate is rejected
+// as belonging to another collection -- see newDuplicatedImportBroadcastResultForCollection.
+// importV2RequestFilePath is the single file newImportV2IdempotentRequest asks to
+// import.
+const importV2RequestFilePath = "/test/file.json"
+
+// importV2RequestCollectionID is the collection newImportV2IdempotentRequest targets.
+const importV2RequestCollectionID = int64(100)
+
+func newDuplicatedImportBroadcastResult(originalJobID int64, originalPaths ...string) *types.BroadcastAppendResult {
+	return newDuplicatedImportBroadcastResultForCollection(originalJobID, importV2RequestCollectionID, originalPaths...)
+}
+
+func newDuplicatedImportBroadcastResultForCollection(originalJobID int64, originalCollectionID int64, originalPaths ...string) *types.BroadcastAppendResult {
+	duplicated := message.NewImportMessageBuilderV1().
+		WithHeader(&message.ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{
+			JobID:        originalJobID,
+			CollectionID: originalCollectionID,
+			Files: lo.Map(originalPaths, func(path string, _ int) *msgpb.ImportFile {
+				return &msgpb.ImportFile{Paths: []string{path}}
+			}),
+		}).
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(originalCollectionID, "run-1")).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+	return &types.BroadcastAppendResult{
+		BroadcastID: 12345,
+		Duplicated:  duplicated,
+	}
+}
+
+// setupImportV2DuplicateBroadcast wires the mocks ImportV2 needs so that the broadcast
+// comes back deduplicated, and returns the server under test together with the
+// broadcast mock, so a caller can inspect the message that was actually broadcast.
+// importMeta is supplied by the caller so it can decide whether the original job still
+// exists.
+func (s *ImportServicesSuite) setupImportV2DuplicateBroadcast(importMeta ImportMeta, originalJobID int64, originalPaths ...string) (*Server, *mockBroadcastAPIImpl) {
+	mockBalancerInst := &mockBalancerImpl{}
+	mockBalance := mockey.Mock(balance.GetWithContext).To(func(ctx context.Context) (balancer.Balancer, error) {
+		return mockBalancerInst, nil
+	}).Build()
+	s.T().Cleanup(func() { mockBalance.UnPatch() })
+
+	mockAssignment := mockey.Mock((*mockBalancerImpl).GetLatestChannelAssignment).To(
+		func(_ *mockBalancerImpl) (*channel.WatchChannelAssignmentsCallbackParam, error) {
+			return &channel.WatchChannelAssignmentsCallbackParam{
+				ReplicateConfiguration: nil,
+			}, nil
+		}).Build()
+	s.T().Cleanup(func() { mockAssignment.UnPatch() })
+
+	mockBroadcastAPI := newMockBroadcastAPIImpl()
+	mockBroadcastAPI.broadcastResult = newDuplicatedImportBroadcastResult(originalJobID, originalPaths...)
+	mockBroadcast := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+		func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+			return mockBroadcastAPI, nil
+		}).Build()
+	s.T().Cleanup(func() { mockBroadcast.UnPatch() })
+
+	mockBroker := broker.NewMockBroker(s.T())
+	// Maybe rather than Times(2): a request rejected by validateImportRequest -- the
+	// job-count limit, say -- returns before either describe call.
+	mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, int64(100)).Return(&milvuspb.DescribeCollectionResponse{
+		DbName:         "test_db",
+		CollectionName: "test_collection",
+	}, nil).Maybe()
+
+	server := &Server{
+		importMeta: importMeta,
+		broker:     mockBroker,
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	mockAllocator := allocator.NewMockAllocator(s.T())
+	mockAllocator.EXPECT().AllocN(mock.Anything).Return(int64(1000), int64(1001), nil)
+	server.allocator = mockAllocator
+	return server, mockBroadcastAPI
+}
+
+func newImportV2IdempotentRequest() *internalpb.ImportRequestInternal {
+	return &internalpb.ImportRequestInternal{
+		CollectionID:   100,
+		CollectionName: "test_collection",
+		PartitionIDs:   []int64{1},
+		ChannelNames:   []string{"v1"},
+		Schema: &schemapb.CollectionSchema{
+			Name:   "test_collection",
+			DbName: "test_db",
+		},
+		Files: []*internalpb.ImportFile{
+			{Id: 1, Paths: []string{importV2RequestFilePath}},
+		},
+		Options: []*commonpb.KeyValuePair{
+			{Key: "timeout", Value: "300s"},
+		},
+	}
+}
+
+// newImportV2IdempotentContext carries the client key the way a real call does:
+// in the gRPC incoming metadata, not in the request body.
+func newImportV2IdempotentContext(key string) context.Context {
+	return metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(util.HeaderIdempotencyKey, key))
+}
+
+// A retry whose idempotency key still resolves must get the ORIGINAL jobID back,
+// not the freshly allocated one (1000 here, which stays unused).
+func (s *ImportServicesSuite) TestImportV2_DuplicateReturnsOriginalJobID() {
+	ctx := newImportV2IdempotentContext("run-1")
+
+	importMeta := NewMockImportMeta(s.T())
+
+	// validateImportRequest runs before the broadcaster's idempotency lookup, so even a
+	// request that will deduplicate is counted against the job limit first.
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(0)
+	// The duplicate branch logs the original job's state, so it looks the job up.
+	// nil is the "gone" case: the key outlived the job's own metadata retention.
+	importMeta.EXPECT().GetJob(mock.Anything, int64(4242)).Return(nil).Once()
+
+	server, _ := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(int32(0), resp.GetStatus().GetCode())
+	s.Equal("4242", resp.GetJobID())
+}
+
+// The duplicate branch logs the ORIGINAL job's state, not just its ID. A key whose
+// original ended Failed resolves to that same job for the rest of the window, so a
+// client retrying it never makes progress; without the state in the log that is
+// indistinguishable from a key waiting on a healthy job. GetJob is expected exactly
+// once, so this asserts the lookup actually runs rather than assuming it.
+func (s *ImportServicesSuite) TestImportV2_DuplicateLooksUpAFailedOriginal() {
+	ctx := newImportV2IdempotentContext("run-1")
+
+	importMeta := NewMockImportMeta(s.T())
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(0)
+	importMeta.EXPECT().GetJob(mock.Anything, int64(4242)).Return(&importJob{
+		ImportJob: &datapb.ImportJob{JobID: 4242, State: internalpb.ImportJobState_Failed},
+	}).Once()
+
+	server, _ := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.Equal(int32(0), resp.GetStatus().GetCode())
+	// A failed original still resolves to its own jobID: the key names an attempt that
+	// did happen. Recovering from it is the client's call, which is why the state is logged.
+	s.Equal("4242", resp.GetJobID())
+}
+
+// A duplicate is reported by an explicit flag, never by a non-zero jobID, so a
+// duplicated broadcast carrying jobID 0 must still take the duplicate branch and
+// return that 0 — not fall through to the freshly allocated 1000.
+func (s *ImportServicesSuite) TestImportV2_DuplicateWithZeroJobIDStaysDuplicate() {
+	ctx := newImportV2IdempotentContext("run-1")
+
+	importMeta := NewMockImportMeta(s.T())
+
+	// validateImportRequest runs before the broadcaster's idempotency lookup, so even a
+	// request that will deduplicate is counted against the job limit first.
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(0)
+	// The duplicate branch logs the original job's state, so it looks the job up.
+	// nil is the "gone" case: the key outlived the job's own metadata retention.
+	importMeta.EXPECT().GetJob(mock.Anything, int64(0)).Return(nil).Once()
+
+	server, _ := s.setupImportV2DuplicateBroadcast(importMeta, 0, importV2RequestFilePath)
+
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(int32(0), resp.GetStatus().GetCode())
+	s.NotEqual("1000", resp.GetJobID())
+	s.Equal("0", resp.GetJobID())
+}
+
+func (s *ImportServicesSuite) TestImportV2_ForwardsIdempotencyKeyUnmodifiedAtTheLimit() {
+	importMeta := NewMockImportMeta(s.T())
+
+	// validateImportRequest runs before the broadcaster's idempotency lookup, so even a
+	// request that will deduplicate is counted against the job limit first.
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(0)
+	// The duplicate branch logs the original job's state, so it looks the job up.
+	// nil is the "gone" case: the key outlived the job's own metadata retention.
+	importMeta.EXPECT().GetJob(mock.Anything, int64(4242)).Return(nil).Once()
+
+	server, broadcastAPI := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+
+	limit := paramtable.Get().StreamingCfg.IdempotencyMaxKeyLength.GetAsInt()
+	s.Equal(256, limit, "this test asserts the boundary of the DEFAULT limit, the one advertised to clients")
+	atLimit := strings.Repeat("k", limit)
+
+	ctx := newImportV2IdempotentContext(atLimit)
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.Equal(int32(0), resp.GetStatus().GetCode())
+
+	s.Require().NotNil(broadcastAPI.capturedMsg)
+	forwarded := message.IdempotencyKeyOf(broadcastAPI.capturedMsg)
+	// DataCoord must hand the client key through untouched. It is scoped on the way --
+	// that is the mechanism, and the broadcaster bounds the client portion, not the
+	// encoded value -- but nothing may alter, truncate or re-prefix the bytes the
+	// client sent, or a key sitting on the advertised limit would stop deduplicating.
+	s.Equal(atLimit, forwarded.ClientKey())
+	s.Equal(message.NewCollectionScopedIdempotencyKey(importV2RequestCollectionID, atLimit), forwarded)
+}
+
+// The dedup scope carries the collection's ID, so a duplicate resolving to another
+// collection is unreachable through the normal path: dropping db1.c1 and recreating a
+// same-named db1.c1 changes the ID, hence the scope, hence the lookup misses and a
+// fresh job is created. This pins the invariant behind that reasoning at the ImportV2
+// level -- if an encoding or scoping bug ever did hand back another collection's
+// broadcast, the request must fail rather than return that jobID. Returning it would be
+// silent and unrecoverable: checkCollection leaves a Completed job alone when its
+// collection vanishes and GetImportProgress does not re-check collection existence, so
+// the client would poll that jobID and read Completed while the new collection stays
+// empty.
+func (s *ImportServicesSuite) TestImportV2_DuplicateFromAnotherCollectionIsRejected() {
+	importMeta := NewMockImportMeta(s.T())
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(0)
+
+	server, broadcastAPI := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+	// The original broadcast targeted collection 99; the request targets 100.
+	broadcastAPI.broadcastResult = newDuplicatedImportBroadcastResultForCollection(4242, 99, importV2RequestFilePath)
+
+	ctx := newImportV2IdempotentContext("run-1")
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.NotEqual(int32(0), resp.GetStatus().GetCode())
+	s.Contains(resp.GetStatus().GetReason(), "idempotency scope resolved to an import into collection 99")
+	s.NotEqual("4242", resp.GetJobID(), "another collection's jobID must not be handed back")
+}
+
+// The documented edge of the retry contract. Everything datacoord validates runs before
+// the broadcaster's idempotency lookup, and the job-count limit is one of those checks,
+// so a retry sent while dataCoord.import.maxImportJobNum is saturated -- by the original
+// job among others -- is rejected before it can resolve. The broadcast never happens, so
+// no duplicate import is created either; retrying the same key once a slot frees up
+// resolves normally. This is pinned as a test rather than left to chance, because a
+// client that answers the rejection by minting a fresh key is what imports twice.
+func (s *ImportServicesSuite) TestImportV2_DuplicateIsRejectedWhileJobLimitIsReached() {
+	old := paramtable.Get().DataCoordCfg.MaxImportJobNum.SwapTempValue("1")
+	defer paramtable.Get().DataCoordCfg.MaxImportJobNum.SwapTempValue(old)
+
+	importMeta := NewMockImportMeta(s.T())
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(1)
+
+	server, broadcastAPI := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+
+	ctx := newImportV2IdempotentContext("run-1")
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.NotEqual(int32(0), resp.GetStatus().GetCode())
+	s.Contains(resp.GetStatus().GetReason(), "number of jobs has reached the limit")
+	s.Nil(broadcastAPI.capturedMsg, "the request must be rejected before it reaches the broadcaster")
+}
+
+// The other half: the limit still applies to a request that actually creates a job.
+func (s *ImportServicesSuite) TestImportV2_JobLimitStillRejectsANewJob() {
+	old := paramtable.Get().DataCoordCfg.MaxImportJobNum.SwapTempValue("1")
+	defer paramtable.Get().DataCoordCfg.MaxImportJobNum.SwapTempValue(old)
+
+	importMeta := NewMockImportMeta(s.T())
+	importMeta.EXPECT().CountJobBy(mock.Anything, mock.Anything).Return(1)
+
+	server, broadcastAPI := s.setupImportV2DuplicateBroadcast(importMeta, 4242, importV2RequestFilePath)
+	// This key resolves to nothing, so the broadcast would create a new task.
+	broadcastAPI.broadcastResult = &types.BroadcastAppendResult{BroadcastID: 12345}
+
+	ctx := newImportV2IdempotentContext("run-2")
+	resp, err := server.ImportV2(ctx, newImportV2IdempotentRequest())
+
+	s.NoError(err)
+	s.NotEqual(int32(0), resp.GetStatus().GetCode())
+	s.Contains(resp.GetStatus().GetReason(), "number of jobs has reached the limit")
+}

--- a/internal/datacoord/import_util_test.go
+++ b/internal/datacoord/import_util_test.go
@@ -1222,6 +1222,9 @@ func TestImportUtil_ValidateMaxImportJobExceed(t *testing.T) {
 			Return(paramtable.Get().DataCoordCfg.MaxImportJobNum.GetAsInt() + 1)
 		err := ValidateMaxImportJobExceed(ctx, mockImportMeta)
 		assert.Error(t, err)
+		// Job-count backpressure is a server-side condition -> ErrImportSysFailed
+		// (must not be bucketed as a user-caused failure).
+		assert.ErrorIs(t, err, merr.ErrImportSysFailed)
 		assert.Contains(t, err.Error(), "The number of jobs has reached the limit")
 	})
 }

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -48,6 +48,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/interceptor"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -1848,7 +1849,7 @@ func (s *Server) ImportV2(ctx context.Context, in *internalpb.ImportRequestInter
 
 	// Broadcast the import message
 	// dbName is retrieved inside broadcastImport via broker.DescribeCollectionInternal
-	err = s.broadcastImport(
+	duplicatedJobID, duplicated, err := s.broadcastImport(
 		ctx,
 		in.GetCollectionName(),
 		in.GetCollectionID(),
@@ -1858,10 +1859,29 @@ func (s *Server) ImportV2(ctx context.Context, in *internalpb.ImportRequestInter
 		in.GetSchema(),
 		jobID,
 		in.GetChannelNames(),
+		interceptor.IdempotencyKeyFromContext(ctx),
 	)
 	if err != nil {
 		log.Warn("failed to broadcast import message", zap.Error(err))
 		resp.Status = merr.Status(merr.Wrap(err, "failed to broadcast import"))
+		return resp, nil
+	}
+	if duplicated {
+		// The idempotency window still holds this key, so the original job is the
+		// answer. Whether that job is still queryable is not checked here: the client
+		// takes the jobID to GetImportProgress, which reports a missing job on its own.
+		resp.JobID = fmt.Sprint(duplicatedJobID)
+		// Log the original job's state, not just its ID. A key whose original ended
+		// Failed resolves to that same job for the rest of the window, so a client
+		// retrying it never makes progress; without the state here that looks
+		// indistinguishable from a key stuck on a healthy job.
+		originalState := "gone"
+		if job := s.importMeta.GetJob(ctx, duplicatedJobID); job != nil {
+			originalState = job.GetState().String()
+		}
+		log.Info("import request resolved to an existing job",
+			zap.String("jobID", resp.JobID),
+			zap.String("originalState", originalState))
 		return resp, nil
 	}
 

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -129,6 +129,7 @@ const (
 	DefaultOutputFields      = "*"
 	HTTPHeaderAllowInt64     = "Accept-Type-Allow-Int64"
 	HTTPHeaderDBName         = "DB-Name"
+	HTTPHeaderIdempotencyKey = "Idempotency-Key"
 	HTTPHeaderRequestTimeout = "Request-Timeout"
 	HTTPHeaderMilvusTraceID  = "X-Milvus-Trace-Id"
 	HTTPReturnCode           = "code"

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -2027,6 +2029,9 @@ func versionalV2(category string, action string) string {
 func initHTTPServerV2(proxy types.ProxyComponent, needAuth bool) *gin.Engine {
 	h := NewHandlersV2(proxy)
 	ginHandler := gin.Default()
+	// Mirror the middleware the real server installs, so tests exercise the same
+	// chain rather than a handler-only subset of it.
+	ginHandler.Use(IdempotencyKeyHandlerFunc)
 	appV2 := ginHandler.Group("/v2/vectordb", genAuthMiddleWare(needAuth))
 	h.RegisterRoutesToV2(appV2)
 
@@ -3753,4 +3758,137 @@ func TestSearchByPK(t *testing.T) {
 	})
 
 	validateTestCases(t, testEngine, queryTestCases, false)
+}
+
+func TestIdempotencyKeyHandlerFuncSetsIncomingMetadata(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v2/vectordb/jobs/import/create", nil)
+	c.Request.Header.Set(HTTPHeaderIdempotencyKey, "run-1-batch-1")
+
+	IdempotencyKeyHandlerFunc(c)
+
+	md, ok := metadata.FromIncomingContext(c.Request.Context())
+	assert.True(t, ok)
+	assert.Equal(t, []string{"run-1-batch-1"}, md.Get(util.HeaderIdempotencyKey))
+}
+
+// TestIdempotencyKeyHandlerFuncRejectsUnsendableKey pins the REST door found open by
+// the adversarial review on milvus#52544. Go's header parser accepts every byte
+// >= 0x80, gRPC refuses anything outside printable ASCII before the stream exists,
+// and ClientBase reads that codes.Internal as a broken connection -- so an unchecked
+// key turns one request into repeated resets of a shared connection. The middleware is
+// mounted on the whole engine, so this covers every v1 and v2 route.
+func TestIdempotencyKeyHandlerFuncRejectsUnsendableKey(t *testing.T) {
+	paramtable.Init()
+
+	for _, key := range []string{"批次-1", "run\t1"} {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v2/vectordb/jobs/import/create", nil)
+		c.Request.Header.Set(HTTPHeaderIdempotencyKey, key)
+
+		IdempotencyKeyHandlerFunc(c)
+
+		assert.True(t, c.IsAborted())
+		assert.Contains(t, w.Body.String(), "printable ASCII")
+		// The key must not have been copied onto the outgoing path.
+		md, ok := metadata.FromIncomingContext(c.Request.Context())
+		if ok {
+			assert.Empty(t, md.Get(util.HeaderIdempotencyKey))
+		}
+	}
+}
+
+func TestIdempotencyKeyHandlerFuncRejectsOversizedKey(t *testing.T) {
+	paramtable.Init()
+	limit := paramtable.Get().StreamingCfg.IdempotencyMaxKeyLength.GetAsInt()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v2/vectordb/jobs/import/create", nil)
+	c.Request.Header.Set(HTTPHeaderIdempotencyKey, strings.Repeat("a", limit+1))
+
+	IdempotencyKeyHandlerFunc(c)
+
+	assert.True(t, c.IsAborted())
+	assert.Contains(t, w.Body.String(), "exceeds limit")
+}
+
+func TestIdempotencyKeyHandlerFuncPreservesExistingMetadata(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/jobs/import/create", nil)
+	req = req.WithContext(metadata.NewIncomingContext(req.Context(),
+		metadata.Pairs(util.HeaderDBName, "db1")))
+	req.Header.Set(HTTPHeaderIdempotencyKey, "run-1-batch-1")
+	c.Request = req
+
+	IdempotencyKeyHandlerFunc(c)
+
+	md, _ := metadata.FromIncomingContext(c.Request.Context())
+	assert.Equal(t, []string{"db1"}, md.Get(util.HeaderDBName))
+	assert.Equal(t, []string{"run-1-batch-1"}, md.Get(util.HeaderIdempotencyKey))
+}
+
+// A request without the header must leave the context alone: an empty metadata value
+// is not the same as an absent one for the components that read it, and every route in
+// the cluster passes through this middleware.
+func TestIdempotencyKeyHandlerFuncNoHeaderIsNoop(t *testing.T) {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v2/vectordb/collections/list", nil)
+	before := c.Request.Context()
+
+	IdempotencyKeyHandlerFunc(c)
+
+	assert.Equal(t, before, c.Request.Context())
+	md, ok := metadata.FromIncomingContext(c.Request.Context())
+	if ok {
+		_, present := md[util.HeaderIdempotencyKey]
+		assert.False(t, present)
+	}
+}
+
+func TestCreateImportJobForwardsIdempotencyKeyWithAuth(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().ImportV2(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, req *internalpb.ImportRequest) (*internalpb.ImportResponse, error) {
+			md, ok := metadata.FromIncomingContext(ctx)
+			assert.True(t, ok)
+			assert.Equal(t, []string{"run-1-batch-1"}, md.Get(util.HeaderIdempotencyKey))
+			return &internalpb.ImportResponse{
+				Status: commonSuccessStatus,
+				JobID:  "1234567890",
+			}, nil
+		}).Once()
+	testEngine := initHTTPServerV2(mp, true)
+
+	bodyReader := bytes.NewReader([]byte(`{"collectionName": "` + DefaultCollectionName + `", "files": [["book.json"]]}`))
+	req := httptest.NewRequest(http.MethodPost, versionalV2(ImportJobCategory, CreateAction), bodyReader)
+	req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+	req.Header.Set(HTTPHeaderIdempotencyKey, "run-1-batch-1")
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), returnBody)
+	assert.NoError(t, err)
+	assert.Equal(t, merr.Code(nil), returnBody.Code)
+}
+
+// A browser sends the Idempotency-Key header cross-origin only if the preflight
+// response lists it in Access-Control-Allow-Headers; the header is otherwise blocked
+// before the actual request is ever sent, making idempotent import unusable from a
+// browser client.
+func TestRequestHandlerFuncAllowsIdempotencyKeyHeaderInCORS(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodOptions, "/v2/vectordb/jobs/import/create", nil)
+
+	RequestHandlerFunc(c)
+
+	assert.Contains(t, w.Header().Get("Access-Control-Allow-Headers"), HTTPHeaderIdempotencyKey)
 }

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -50,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/interceptor"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/parameterutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -2998,7 +3000,7 @@ func RequestHandlerFunc(c *gin.Context) {
 	}
 	c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 	c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
-	c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+	c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With, "+HTTPHeaderIdempotencyKey)
 	c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS, PATCH")
 	c.Writer.Header().Set("X-Content-Type-Options", "nosniff") // Prevents MIME sniffing
 
@@ -3303,4 +3305,36 @@ func genFunctionScore(ctx context.Context, functionScore *FunctionScore) (*schem
 		fScore.Params = append(fScore.Params, &commonpb.KeyValuePair{Key: key, Value: fmt.Sprintf("%v", value)})
 	}
 	return &fScore, nil
+}
+
+// IdempotencyKeyHandlerFunc copies the REST Idempotency-Key header into the gRPC
+// incoming metadata, so the proxy reads the key from exactly one place regardless of
+// whether the request arrived over REST or gRPC. Existing metadata is preserved.
+//
+// Registered as middleware rather than inside a handler wrapper: which operations are
+// idempotent is decided downstream, so every route — v1 and v2 alike — must carry the
+// key rather than drop it and force the next adopter to rediscover this hop.
+func IdempotencyKeyHandlerFunc(c *gin.Context) {
+	key := c.Request.Header.Get(HTTPHeaderIdempotencyKey)
+	if key == "" {
+		c.Next()
+		return
+	}
+	// Validate before the key reaches outgoing metadata. Go accepts header bytes
+	// gRPC does not, and this middleware is mounted on the whole engine, so an
+	// unchecked key would ride along on every coordinator RPC of any v1 or v2
+	// route -- see ValidateIdempotencyKey for what that costs.
+	if err := interceptor.ValidateIdempotencyKey(key); err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return
+	}
+	ctx := c.Request.Context()
+	md, _ := metadata.FromIncomingContext(ctx)
+	md = md.Copy()
+	md.Set(util.HeaderIdempotencyKey, key)
+	c.Request = c.Request.WithContext(metadata.NewIncomingContext(ctx, md))
+	c.Next()
 }

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -216,6 +216,7 @@ func (s *Server) startHTTPServer(errChan chan error) {
 	ginHandler.Use(accesslog.AccessLogMiddleware)
 	ginHandler.Use(httpserver.LoggerHandlerFunc(), gin.Recovery())
 	ginHandler.Use(httpserver.RequestHandlerFunc)
+	ginHandler.Use(httpserver.IdempotencyKeyHandlerFunc)
 	ginHandler.Use(func(c *gin.Context) {
 		c.Set(httpserver.ContextUsername, "")
 	})

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	pulsar2 "github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/pulsar"
 	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/interceptor"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/ratelimitutil"
@@ -1686,6 +1687,66 @@ func TestProxy_ImportV2(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int32(0), rsp.GetStatus().GetCode())
 		assert.Equal(t, "123456789", rsp.GetJobID())
+	})
+
+	// The key travels to DataCoord in the gRPC metadata, so what the proxy owes the
+	// hop is a context that still carries it when the coordinator client is called:
+	// that is what the client interceptor copies onto the outgoing call. It survives
+	// the scheduler queue, which runs the task on a context derived from this one.
+	t.Run("ImportV2 hands datacoord a context still carrying the idempotency key", func(t *testing.T) {
+		factory := dependency.NewDefaultFactory(true)
+		node, err := NewProxy(ctx, factory)
+		assert.NoError(t, err)
+		node.UpdateStateCode(commonpb.StateCode_Healthy)
+		node.tsoAllocator = &timestampAllocator{
+			tso: newMockTimestampAllocatorInterface(),
+		}
+		scheduler, err := newTaskScheduler(ctx, node.tsoAllocator)
+		assert.NoError(t, err)
+		node.sched = scheduler
+		assert.NoError(t, node.sched.Start())
+		defer node.sched.Close()
+		chMgr := NewMockChannelsMgr(t)
+		chMgr.EXPECT().getVChannels(mock.Anything).Return([]string{"ch0"}, nil)
+		node.chMgr = chMgr
+
+		mc := NewMockCache(t)
+		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
+		}, nil)
+		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+		mc.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{dbID: 1}, nil)
+		globalMetaCache = mc
+
+		capturedKey := make(chan string, 1)
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		mixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *internalpb.ImportRequestInternal, opts ...grpc.CallOption) (*internalpb.ImportResponse, error) {
+				capturedKey <- interceptor.IdempotencyKeyFromContext(ctx)
+				return &internalpb.ImportResponse{
+					Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+					JobID:  "123456789",
+				}, nil
+			})
+		node.mixCoord = mixCoord
+
+		mdCtx := metadata.NewIncomingContext(ctx, metadata.Pairs(util.HeaderIdempotencyKey, "run-1-batch-1"))
+		rsp, err := node.ImportV2(mdCtx, &internalpb.ImportRequest{
+			CollectionName: "aaa",
+			Files: []*internalpb.ImportFile{{
+				Id:    1,
+				Paths: []string{"a.json"},
+			}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int32(0), rsp.GetStatus().GetCode())
+		select {
+		case key := <-capturedKey:
+			assert.Equal(t, "run-1-batch-1", key)
+		default:
+			t.Fatal("mixCoord.ImportV2 was never called")
+		}
 	})
 
 	t.Run("GetImportProgress", func(t *testing.T) {

--- a/internal/proxy/task_import_test.go
+++ b/internal/proxy/task_import_test.go
@@ -24,11 +24,14 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/interceptor"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -435,4 +438,52 @@ func (s *ImportTaskSuite) TestPreExecute_GetCollectionIDFailsReturnsError() {
 
 	s.Error(err)
 	s.Contains(err.Error(), "collection not found")
+}
+
+// The idempotency key rides the gRPC metadata of the context, not the request
+// body, so Execute must hand the coordinator client the very context the request
+// arrived on. A context rebuilt or detached here would strip the key and the
+// client interceptor would have nothing to propagate.
+func (s *ImportTaskSuite) TestExecute_PassesTheRequestContextToMixCoord() {
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(util.HeaderIdempotencyKey, "run-1-batch-1"))
+
+	mockCache := NewMockCache(s.T())
+	mockCache.EXPECT().GetDatabaseInfo(mock.Anything, mock.Anything).Return(&databaseInfo{
+		dbID: 42,
+	}, nil)
+
+	var capturedCtx context.Context
+	mockMixCoord := mocks.NewMockMixCoordClient(s.T())
+	mockMixCoord.EXPECT().ImportV2(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, req *internalpb.ImportRequestInternal, opts ...grpc.CallOption) (*internalpb.ImportResponse, error) {
+			capturedCtx = ctx
+			return &internalpb.ImportResponse{
+				Status: merr.Success(),
+				JobID:  "12345",
+			}, nil
+		})
+
+	task := &importTask{
+		ctx:      ctx,
+		mixCoord: mockMixCoord,
+		req: &internalpb.ImportRequest{
+			DbName:         "test_db",
+			CollectionName: "test_collection",
+		},
+		collectionID: 100,
+		schema: &schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{
+				Name: "test_collection",
+			},
+		},
+		resp: &internalpb.ImportResponse{},
+	}
+	globalMetaCache = mockCache
+
+	err := task.Execute(ctx)
+
+	s.NoError(err)
+	s.Require().NotNil(capturedCtx)
+	s.Equal("run-1-batch-1", interceptor.IdempotencyKeyFromContext(capturedCtx))
 }

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -47,6 +47,7 @@ func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTask
 	pendingTasks := make([]*pendingBroadcastTask, 0, len(recoveryTasks))
 	pendingAckCallbackTasks := make([]*broadcastTask, 0, len(recoveryTasks))
 	tombstoneIDs := make([]uint64, 0, len(recoveryTasks))
+	idxOfKeys := newIdempotencyIndex()
 	for _, task := range recoveryTasks {
 		switch task.task.State {
 		case streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_WAIT_ACK:
@@ -74,12 +75,16 @@ func newBroadcastTaskManager(protos []*streamingpb.BroadcastTask) *broadcastTask
 			tombstoneIDs = append(tombstoneIDs, task.Header().BroadcastID)
 		}
 		tasks[task.Header().BroadcastID] = task
+		// Rebuild the idempotency index across EVERY state, tombstones included:
+		// a tombstoned task is exactly what a late retry must still hit.
+		idxOfKeys.Add(task.IdempotencyScope(), task.Header().BroadcastID)
 	}
 
 	m := &broadcastTaskManager{
 		lifetime:           typeutil.NewLifetime(),
 		mu:                 &sync.Mutex{},
 		tasks:              tasks,
+		idempotencyIndex:   idxOfKeys,
 		resourceKeyLocker:  rkLocker,
 		metrics:            metrics,
 		broadcastScheduler: newBroadcasterScheduler(pendingTasks, logger),
@@ -102,6 +107,7 @@ type broadcastTaskManager struct {
 	lifetime           *typeutil.Lifetime
 	mu                 *sync.Mutex
 	tasks              map[uint64]*broadcastTask // map the broadcastID to the broadcastTaskState
+	idempotencyIndex   *idempotencyIndex         // map the idempotency key to the broadcastID that owns it
 	resourceKeyLocker  *resourceKeyLocker
 	metrics            *broadcasterMetrics
 	broadcastScheduler *broadcasterScheduler // the scheduler of the broadcast task
@@ -209,9 +215,21 @@ func (bm *broadcastTaskManager) appendSharedClusterRK(resourceKeys ...message.Re
 	return append(resourceKeys, message.NewSharedClusterResourceKey())
 }
 
-// broadcast broadcasts the message to all vchannels.
-// it will block until the message is broadcasted to all vchannels
-func (bm *broadcastTaskManager) broadcast(ctx context.Context, msg message.BroadcastMutableMessage, broadcastID uint64, guards *lockGuards) (*types.BroadcastAppendResult, error) {
+// broadcast broadcasts the message to all vchannels, or resolves it to the
+// broadcast that already owns its idempotency scope, waiting for that owner to
+// complete before answering.
+//
+// Either way it consumes the caller's lock guards: a registered task takes them
+// over and releases them from its ack callback, and every other path -- shutdown,
+// duplicate -- releases them here before returning. An early return added to this
+// function MUST keep that contract; the caller cannot tell the paths apart and
+// stops releasing on all of them.
+func (bm *broadcastTaskManager) broadcast(
+	ctx context.Context,
+	msg message.BroadcastMutableMessage,
+	broadcastID uint64,
+	guards *lockGuards,
+) (*types.BroadcastAppendResult, error) {
 	if !bm.lifetime.Add(typeutil.LifetimeStateWorking) {
 		guards.Unlock()
 		return nil, status.NewOnShutdownError("broadcaster is closing")
@@ -221,11 +239,38 @@ func (bm *broadcastTaskManager) broadcast(ctx context.Context, msg message.Broad
 	// Validation is now done before calling broadcast (in DataCoord for import operations)
 	// CheckCallback mechanism has been removed as part of the import refactoring
 
-	task := bm.addBroadcastTask(msg, broadcastID, guards)
-	pendingTask := newPendingBroadcastTask(task)
+	// Stamp the broadcast header here rather than in getOrAddBroadcastTask: the
+	// header is this call's own value and does not need the manager lock.
+	msg = msg.OverwriteBroadcastHeader(broadcastID, guards.ResourceKeys()...)
+	task, created := bm.getOrAddBroadcastTask(ctx, msg, broadcastID, guards)
+	if !created {
+		// Nothing was registered and nothing reached the WAL for THIS request; the
+		// answer is the owner's. This call is about to wait on that owner, so its own
+		// guards are released first rather than held across someone else's broadcast
+		// -- they may even name a different collection than the owner's, when the
+		// two requests raced a rename.
+		guards.Unlock()
+
+		// Wait for the owner to reach the state a non-duplicate caller returns from:
+		// ack callback done. The owner is not serialized behind this caller's
+		// resource lock on the two paths that can observe it mid-flight -- a retry
+		// that raced a rename holds the stale name's lock, and a task recovered from
+		// a replicated WAL holds no lock at all -- and answering before the owner
+		// finishes hands the client a broadcastID whose effects (for import, the job
+		// itself: it is created in the ack callback) do not exist yet. The wait is
+		// bounded by the request context, which answers with the caller's own timeout
+		// instead of an ID that nothing backs. An owner already tombstoned returns
+		// immediately.
+		result, err := task.BlockUntilDone(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result.Duplicated = task.BroadcastMessage()
+		return result, nil
+	}
 
 	// Add it into broadcast scheduler to broadcast the message into all vchannels.
-	return bm.broadcastScheduler.AddTask(ctx, pendingTask)
+	return bm.broadcastScheduler.AddTask(ctx, newPendingBroadcastTask(task))
 }
 
 // LegacyAck is the legacy ack function for the broadcast task.
@@ -290,17 +335,59 @@ func (bm *broadcastTaskManager) Close() {
 	bm.ackScheduler.Close()
 }
 
-// addBroadcastTask adds the broadcast task into the manager.
-func (bm *broadcastTaskManager) addBroadcastTask(msg message.BroadcastMutableMessage, broadcastID uint64, guards *lockGuards) *broadcastTask {
-	msg = msg.OverwriteBroadcastHeader(broadcastID, guards.ResourceKeys()...)
+// getOrAddBroadcastTask resolves the idempotency scope and registers the task in
+// ONE critical section.
+//
+// The lookup and the insert used to be two critical sections on bm.mu, and only
+// the caller's resource lock kept two same-key requests out of the gap between
+// them. That works only when the lock is exclusive on the very object the scope
+// names. It is not: import scopes by collection ID (so a retry still dedups after
+// a rename) but locks by collection name, and RenameCollection takes DB-level keys
+// only. A rename between name resolution and lock acquisition therefore leaves two
+// same-key requests holding non-conflicting collection-name locks -- both miss,
+// both register, both reach the WAL, and idempotencyIndex.Add silently keeps the
+// first. Deciding under bm.mu retires that caller obligation instead of restating
+// it in a comment.
+//
+// Returns the owning task and created=false on a hit, having registered nothing;
+// the caller still holds its lock guards. Returns the newly registered task and
+// created=true on a miss, and that task now owns the guards.
+func (bm *broadcastTaskManager) getOrAddBroadcastTask(
+	ctx context.Context,
+	msg message.BroadcastMutableMessage,
+	broadcastID uint64,
+	guards *lockGuards,
+) (task *broadcastTask, created bool) {
+	// The scope comes from the message alone, so the hit path and the miss path
+	// cannot drift apart. It touches no shared state, so it is derived outside the
+	// lock.
+	scope := idempotencyScopeOfMessage(msg)
+
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
+	if ownerID, ok := bm.idempotencyIndex.Get(scope); ok {
+		if t, ok := bm.tasks[ownerID]; ok {
+			return t, false
+		}
+		// tasks and idempotencyIndex are written together under this lock and
+		// removeBroadcastTask drops the index entry first, so a scope whose owner
+		// has no task is unreachable. Say so rather than trusting the entry, and
+		// fall through to registration.
+		bm.Logger().Warn("idempotency index entry has no task, treating it as a miss",
+			zap.Uint64("ownerBroadcastID", ownerID))
+	}
+	// Constructed only once the broadcast is certain to be registered: construction
+	// counts the task into the PENDING gauge, and the hit path above transitions no
+	// state, so an earlier construction would leak that count for the lifetime of the
+	// process. It builds no shared state, but it is cheap enough to hold bm.mu across
+	// at DDL frequency.
 	newIncomingTask := newBroadcastTaskFromBroadcastMessage(msg, bm.metrics, bm.ackScheduler)
 	newIncomingTask.SetLogger(bm.Logger())
 	newIncomingTask.WithResourceKeyLockGuards(guards)
-
-	bm.mu.Lock()
 	bm.tasks[broadcastID] = newIncomingTask
-	bm.mu.Unlock()
-	return newIncomingTask
+	bm.idempotencyIndex.Add(scope, broadcastID)
+	return newIncomingTask, true
 }
 
 // getOrCreateBroadcastTask returns the task by the broadcastID
@@ -323,6 +410,7 @@ func (bm *broadcastTaskManager) getOrCreateBroadcastTask(msg message.ImmutableMe
 	newBroadcastTask := newBroadcastTaskFromImmutableMessage(msg, bm.metrics, bm.ackScheduler)
 	newBroadcastTask.SetLogger(bm.Logger())
 	bm.tasks[bh.BroadcastID] = newBroadcastTask
+	bm.idempotencyIndex.Add(newBroadcastTask.IdempotencyScope(), bh.BroadcastID)
 	return newBroadcastTask, true
 }
 
@@ -340,6 +428,9 @@ func (bm *broadcastTaskManager) removeBroadcastTask(broadcastID uint64) {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
 
+	if t, ok := bm.tasks[broadcastID]; ok {
+		bm.idempotencyIndex.Remove(t.IdempotencyScope(), broadcastID)
+	}
 	delete(bm.tasks, broadcastID)
 }
 

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -134,6 +134,17 @@ func (b *broadcastTask) BroadcastResult() (message.BroadcastMutableMessage, map[
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	msg, result, acked := b.broadcastResult()
+	if !acked {
+		panic("unreachable: BroadcastResult is called before the broadcast task is acked")
+	}
+	return msg, result
+}
+
+// broadcastResult zips the vchannels of the task with their acked checkpoints.
+// Returns acked=false and a nil result when any vchannel has no checkpoint yet.
+// Caller must hold b.mu.
+func (b *broadcastTask) broadcastResult() (message.BroadcastMutableMessage, map[string]*types.AppendResult, bool) {
 	vchannels := b.header().VChannels
 	result := make(map[string]*types.AppendResult, len(vchannels))
 	for idx, vchannel := range vchannels {
@@ -148,7 +159,7 @@ func (b *broadcastTask) BroadcastResult() (message.BroadcastMutableMessage, map[
 		}
 		cp := b.task.AckedCheckpoints[idx]
 		if cp == nil || cp.TimeTick == 0 {
-			panic("unreachable: BroadcastResult is called before the broadcast task is acked")
+			return b.msg, nil, false
 		}
 		result[vchannel] = &types.AppendResult{
 			MessageID:              message.MustUnmarshalMessageID(cp.MessageId),
@@ -156,7 +167,7 @@ func (b *broadcastTask) BroadcastResult() (message.BroadcastMutableMessage, map[
 			TimeTick:               cp.TimeTick,
 		}
 	}
-	return b.msg, result
+	return b.msg, result, true
 }
 
 // Header returns the header of the broadcast task.
@@ -171,6 +182,22 @@ func (b *broadcastTask) Header() *message.BroadcastHeader {
 // Caller must hold b.mu.
 func (b *broadcastTask) header() *message.BroadcastHeader {
 	return b.msg.BroadcastHeader()
+}
+
+// IdempotencyScope returns the idempotency scope of the message of the broadcast task.
+// Must acquire b.mu because MarkIgnore may replace b.msg concurrently.
+func (b *broadcastTask) IdempotencyScope() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return idempotencyScopeOfMessage(b.msg)
+}
+
+// BroadcastMessage returns the message of the broadcast task.
+// Must acquire b.mu because MarkIgnore may replace b.msg concurrently.
+func (b *broadcastTask) BroadcastMessage() message.BroadcastMutableMessage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.msg
 }
 
 // ControlChannelTimeTick returns the time tick of the control channel.

--- a/internal/streamingcoord/server/broadcaster/broadcaster_with_rk_guards_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_with_rk_guards_test.go
@@ -1,0 +1,89 @@
+package broadcaster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/walimplstest"
+)
+
+// TestBroadcastLeavesGuardsWithTheTaskWhenTheAckWaitFails pins who owns the resource
+// key locks when Broadcast fails AFTER the task is registered.
+//
+// The two failure classes look identical to the caller and must not be handled
+// identically: a failure before registration leaves the guards with the caller, whose
+// deferred Close() releases them, while a failure after it leaves them with the task,
+// which keeps broadcasting in the background and releases them from its ack callback
+// on another goroutine. Releasing them twice hands the same collection to a second
+// DDL mid-broadcast and unlocks a key the task no longer holds.
+func TestBroadcastLeavesGuardsWithTheTaskWhenTheAckWaitFails(t *testing.T) {
+	bm := newBroadcastTaskManagerForTest(t)
+	collKey := message.NewExclusiveCollectionNameResourceKey("db1", "coll1")
+
+	// Hold the WAL append open so the registered task cannot ack, and therefore
+	// cannot release the guards, while the assertions below run.
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAppends := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseAppends)
+
+	operator := mock_streaming.NewMockWALAccesser(t)
+	operator.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+			<-release
+			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+			for idx := range msgs {
+				resps.Responses[idx] = types.AppendResponse{
+					AppendResult: &types.AppendResult{
+						MessageID: walimplstest.NewTestMessageID(int64(idx + 1)),
+						TimeTick:  uint64(time.Now().UnixMilli()),
+					},
+				}
+			}
+			return resps
+		}).Maybe()
+	streaming.SetWALForTest(operator)
+
+	guards := bm.resourceKeyLocker.Lock(collKey)
+	api := &broadcasterWithRK{broadcaster: bm, broadcastID: 1, guards: guards}
+
+	// Registration happens before the scheduler is ever asked to wait, so an
+	// already-canceled context reproduces the real failure -- a request that times
+	// out while its broadcast is still collecting acks -- without a race.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := api.Broadcast(ctx, newImportMsgWithKey("k1"))
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "broadcaster is closing")
+
+	// The task was registered and owns the guards.
+	task, ok := bm.getBroadcastTaskByID(1)
+	require.True(t, ok)
+	require.Same(t, guards, task.guards)
+	require.Nil(t, api.guards)
+
+	// So the caller's deferred Close() must leave the lock where it is.
+	api.Close()
+	_, err = bm.resourceKeyLocker.FastLock(collKey)
+	require.ErrorIs(t, err, errFastLockFailed)
+
+	// The task releases it once, when it finishes acking.
+	releaseAppends()
+	require.Eventually(t, func() bool {
+		g, err := bm.resourceKeyLocker.FastLock(collKey)
+		if err != nil {
+			return false
+		}
+		g.Unlock()
+		return true
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/internal/streamingcoord/server/broadcaster/idempotency_index.go
+++ b/internal/streamingcoord/server/broadcaster/idempotency_index.go
@@ -1,0 +1,93 @@
+package broadcaster
+
+import (
+	"strconv"
+
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+)
+
+// idempotencyScope derives the dedup identity of a broadcast: a client key only
+// deduplicates within (messageType, the scope the key was built with).
+//
+// messageType is load-bearing and is added here rather than by the caller, because
+// CreateIndex and DropIndex on one collection carry the same scope otherwise, and
+// the second one would be silently swallowed. It is a property of the broadcast, so
+// the broadcaster owns it; the scope is a property of the operation, so the caller
+// owns it (see message.IdempotencyKey).
+//
+// Returns "" when the key is zero, i.e. the broadcast is not idempotent.
+//
+// The encoding needs no framing: messageType is decimal digits, so the first
+// separator delimits it and the key is the unbounded tail -- and the key is itself
+// injectively encoded. This string is a map key only. It embeds the raw client key,
+// so it must never be logged; log message.IdempotencyKeyFingerprint of the client
+// portion instead.
+func idempotencyScope(msgType message.MessageType, key message.IdempotencyKey) string {
+	if key == "" {
+		return ""
+	}
+	return strconv.Itoa(int(msgType)) + "/" + string(key)
+}
+
+// idempotencyScopeOfMessage derives the scope from the message alone.
+//
+// Everything the scope is built from travels in the message itself -- the type, and
+// the `_ik` property the caller scoped -- so this is the single derivation, used by
+// the lookup, by task creation and by recovery alike. It deliberately does not read
+// the broadcast header: an earlier revision derived the scope from the broadcast's
+// resource keys, which meant the lookup (which runs before the header is stamped)
+// and task creation (which runs after) had to derive it from two different places
+// and agree.
+func idempotencyScopeOfMessage(msg message.BroadcastMutableMessage) string {
+	return idempotencyScope(msg.MessageType(), message.IdempotencyKeyOf(msg))
+}
+
+// idempotencyIndex maps an idempotency scope (see idempotencyScope) to the
+// broadcastID that first used it.
+//
+// Its lifetime is tied to broadcastTaskManager.tasks: an entry appears when a task
+// is created and disappears when the task leaves the map (tombstone GC). The
+// idempotency window a client observes is therefore exactly the tombstone
+// retention window — see streaming.walBroadcaster.tombstone.{maxLifetime,maxCount}.
+//
+// Not internally locked: every caller already holds broadcastTaskManager.mu.
+type idempotencyIndex struct {
+	scopeToBroadcastID map[string]uint64
+}
+
+func newIdempotencyIndex() *idempotencyIndex {
+	return &idempotencyIndex{scopeToBroadcastID: make(map[string]uint64)}
+}
+
+// Add records the scope unless it is empty or already present. Keeping the FIRST
+// broadcastID is the whole point: a duplicate must resolve to the original
+// broadcast, not to whichever retry raced in last.
+func (i *idempotencyIndex) Add(scope string, broadcastID uint64) {
+	if scope == "" {
+		return
+	}
+	if _, ok := i.scopeToBroadcastID[scope]; ok {
+		return
+	}
+	i.scopeToBroadcastID[scope] = broadcastID
+}
+
+// Get returns the broadcastID that owns the scope.
+func (i *idempotencyIndex) Get(scope string) (uint64, bool) {
+	if scope == "" {
+		return 0, false
+	}
+	id, ok := i.scopeToBroadcastID[scope]
+	return id, ok
+}
+
+// Remove drops the entry only when it is owned by the given broadcastID, so a
+// task that lost the Add race cannot evict the owner's entry on its own GC.
+func (i *idempotencyIndex) Remove(scope string, broadcastID uint64) {
+	if scope == "" {
+		return
+	}
+	if id, ok := i.scopeToBroadcastID[scope]; ok && id == broadcastID {
+		delete(i.scopeToBroadcastID, scope)
+	}
+}

--- a/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
+++ b/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
@@ -1,0 +1,853 @@
+package broadcaster
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	internaltypes "github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/idalloc"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+)
+
+func TestIdempotencyIndex(t *testing.T) {
+	idx := newIdempotencyIndex()
+
+	// An empty key never enters the index.
+	idx.Add("", 1)
+	_, ok := idx.Get("")
+	require.False(t, ok)
+
+	idx.Add("import/1/k", 100)
+	id, ok := idx.Get("import/1/k")
+	require.True(t, ok)
+	require.Equal(t, uint64(100), id)
+
+	// On a key collision the first broadcastID wins: idempotency means a retry
+	// resolves to the ORIGINAL result, not to whichever retry raced in last.
+	idx.Add("import/1/k", 200)
+	id, ok = idx.Get("import/1/k")
+	require.True(t, ok)
+	require.Equal(t, uint64(100), id)
+
+	// Removal only applies when the broadcastID matches, so a task that lost the
+	// Add race cannot evict the owner's entry when its own tombstone is GC'd.
+	idx.Remove("import/1/k", 200)
+	id, ok = idx.Get("import/1/k")
+	require.True(t, ok)
+	require.Equal(t, uint64(100), id)
+
+	idx.Remove("import/1/k", 100)
+	_, ok = idx.Get("import/1/k")
+	require.False(t, ok)
+}
+
+// testCollectionID is the collection every scoped test key below is bound to, unless
+// a test names another one to prove two collections stay apart.
+const testCollectionID = int64(7)
+
+// newImportMsgWithKey builds an import broadcast message carrying the given client
+// idempotency key ("" means the message carries no key at all), scoped to
+// testCollectionID, as it looks when it reaches the broadcaster: not yet stamped with
+// a broadcastID or resource keys.
+func newImportMsgWithKey(key string) message.BroadcastMutableMessage {
+	return newImportMsgScoped(testCollectionID, key)
+}
+
+// newImportMsgScoped is newImportMsgWithKey against a named collection.
+func newImportMsgScoped(collectionID int64, key string) message.BroadcastMutableMessage {
+	return message.NewImportMessageBuilderV1().
+		WithHeader(&message.ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{}).
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(collectionID, key)).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+}
+
+// newCreateCollectionMsgWithKey builds a broadcast message of a DIFFERENT message type
+// carrying the given client idempotency key. Used to prove the message type is part of
+// the dedup identity.
+func newCreateCollectionMsgWithKey(key string) message.BroadcastMutableMessage {
+	return message.NewCreateCollectionMessageBuilderV1().
+		WithHeader(&message.CreateCollectionMessageHeader{}).
+		WithBody(&msgpb.CreateCollectionRequest{}).
+		WithIdempotencyKey(message.NewCollectionScopedIdempotencyKey(testCollectionID, key)).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+}
+
+// createImportBroadcastTaskProto builds a recovery proto of an import broadcast task
+// carrying the given idempotency key ("" means the task carries no key at all) and the
+// given resource keys, as the broadcaster would have stamped them.
+func createImportBroadcastTaskProto(
+	broadcastID uint64,
+	key string,
+	state streamingpb.BroadcastTaskState,
+	bitmap []byte,
+	rks ...message.ResourceKey,
+) *streamingpb.BroadcastTask {
+	if len(rks) == 0 {
+		rks = []message.ResourceKey{message.NewSharedClusterResourceKey()}
+	}
+	msg := newImportMsgWithKey(key).OverwriteBroadcastHeader(broadcastID, rks...)
+	return createNewWaitAckBroadcastTaskFromMessage(msg, state, bitmap)
+}
+
+// broadcastForTest drives one broadcast through broadcasterWithRK holding exactly the
+// given resource keys, the same way broadcastTaskManager.WithResourceKeys would.
+func broadcastForTest(
+	t *testing.T,
+	bm *broadcastTaskManager,
+	broadcastID uint64,
+	msg message.BroadcastMutableMessage,
+	rks ...message.ResourceKey,
+) *types.BroadcastAppendResult {
+	t.Helper()
+	api := &broadcasterWithRK{broadcaster: bm, broadcastID: broadcastID, guards: bm.resourceKeyLocker.Lock(rks...)}
+	defer api.Close()
+
+	result, err := api.Broadcast(context.Background(), msg)
+	require.NoError(t, err)
+	return result
+}
+
+// TestIdempotencyIndexRecovery asserts the index is rebuilt from the recovery info
+// across every task state, tombstones included: a tombstoned task is still what a
+// late retry must resolve to, until the tombstone GC drops it.
+func TestIdempotencyIndexRecovery(t *testing.T) {
+	paramtable.Init()
+	registry.ResetRegistration()
+	// Earlier tests in this package shrink the tombstone GC window to milliseconds and
+	// never restore it. Pin a long window here so the GC cannot race the assertions.
+	oldInterval := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue("1h")
+	oldLifetime := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue("1h")
+	oldCount := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue("8192")
+	defer func() {
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue(oldInterval)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue(oldLifetime)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue(oldCount)
+	}()
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	resource.InitForTest(resource.OptStreamingCatalog(meta))
+
+	// The recovered PENDING task is re-appended by the broadcast scheduler; serve it a
+	// WAL that always succeeds and never acks, so the task simply waits for acks.
+	operator := mock_streaming.NewMockWALAccesser(t)
+	appendFn := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+		resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+		for idx := range msgs {
+			resps.Responses[idx] = types.AppendResponse{
+				AppendResult: &types.AppendResult{
+					MessageID: walimplstest.NewTestMessageID(int64(idx + 1)),
+					TimeTick:  uint64(time.Now().UnixMilli()),
+				},
+			}
+		}
+		return resps
+	}
+	operator.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendFn).Maybe()
+	streaming.SetWALForTest(operator)
+
+	bm := newBroadcastTaskManager([]*streamingpb.BroadcastTask{
+		createImportBroadcastTaskProto(100, "import/1/pending",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING, []byte{0x00}),
+		createImportBroadcastTaskProto(200, "import/1/tombstone",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, []byte{0x01}),
+		createImportBroadcastTaskProto(300, "",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, []byte{0x01}),
+	})
+	defer bm.Close()
+
+	// The recovered entries are indexed by scope, not by the raw client key: the
+	// recovery rebuild must derive the very same scope the broadcast path derives.
+	scopeOf := func(clientKey string) string {
+		return idempotencyScope(message.MessageTypeImport,
+			message.NewCollectionScopedIdempotencyKey(testCollectionID, clientKey))
+	}
+
+	id, ok := bm.idempotencyIndex.Get(scopeOf("import/1/pending"))
+	require.True(t, ok)
+	require.Equal(t, uint64(100), id)
+	_, ok = bm.getBroadcastTaskByID(id)
+	require.True(t, ok)
+
+	id, ok = bm.idempotencyIndex.Get(scopeOf("import/1/tombstone"))
+	require.True(t, ok)
+	require.Equal(t, uint64(200), id)
+	_, ok = bm.getBroadcastTaskByID(id)
+	require.True(t, ok)
+
+	// The raw client key alone must never resolve: an unscoped lookup is exactly the
+	// bug that makes the same key collide across collections and message types.
+	_, ok = bm.idempotencyIndex.Get("import/1/pending")
+	require.False(t, ok)
+
+	// The keyless task must not occupy an entry.
+	require.Len(t, bm.idempotencyIndex.scopeToBroadcastID, 2)
+}
+
+// newBroadcastTaskManagerForTest recovers a broadcast task manager with the same test
+// resources TestIdempotencyIndexRecovery sets up: a catalog that accepts every save, a
+// WAL that always appends successfully, and a tombstone GC window long enough that the
+// GC cannot race the assertions.
+func newBroadcastTaskManagerForTest(t *testing.T, protos ...*streamingpb.BroadcastTask) *broadcastTaskManager {
+	paramtable.Init()
+	registry.ResetRegistration()
+	// A completed import broadcast triggers the import ack callback; without a registered
+	// one the ack scheduler blocks forever waiting for the registration future.
+	registry.RegisterImportV1AckCallback(func(ctx context.Context, result message.BroadcastResultImportMessageV1) error {
+		return nil
+	})
+	registry.RegisterCreateCollectionV1AckCallback(func(ctx context.Context, result message.BroadcastResultCreateCollectionMessageV1) error {
+		return nil
+	})
+	oldInterval := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue("1h")
+	oldLifetime := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue("1h")
+	oldCount := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue("8192")
+	t.Cleanup(func() {
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue(oldInterval)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue(oldLifetime)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue(oldCount)
+	})
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	resource.InitForTest(resource.OptStreamingCatalog(meta))
+
+	operator := mock_streaming.NewMockWALAccesser(t)
+	appendFn := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+		resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+		for idx := range msgs {
+			resps.Responses[idx] = types.AppendResponse{
+				AppendResult: &types.AppendResult{
+					MessageID: walimplstest.NewTestMessageID(int64(idx + 1)),
+					TimeTick:  uint64(time.Now().UnixMilli()),
+				},
+			}
+		}
+		return resps
+	}
+	operator.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendFn).Maybe()
+	streaming.SetWALForTest(operator)
+
+	bm := newBroadcastTaskManager(protos)
+	t.Cleanup(bm.Close)
+	return bm
+}
+
+func TestBroadcastReturnsDuplicatedOnKeyHit(t *testing.T) {
+	// Hold an EXCLUSIVE key, mirroring what import actually holds in production
+	// (SharedDBName + ExclusiveCollectionName). A shared key would not conflict
+	// with itself, which would make the release check below vacuous.
+	collectionKey := message.NewExclusiveCollectionNameResourceKey("db1", "coll1")
+
+	// Recover a manager that already owns "import/1/k" from a tombstoned task:
+	// a tombstone is exactly what a late retry is expected to hit. The original must
+	// carry the SAME resource keys the retry holds, otherwise it is a different scope.
+	bm := newBroadcastTaskManagerForTest(t,
+		createImportBroadcastTaskProto(100, "import/1/k",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, []byte{0x01}, collectionKey))
+
+	guards := bm.resourceKeyLocker.Lock(collectionKey)
+	api := &broadcasterWithRK{broadcaster: bm, broadcastID: 999, guards: guards}
+
+	result, err := api.Broadcast(context.Background(), newImportMsgWithKey("import/1/k"))
+	require.NoError(t, err)
+	require.NotNil(t, result.Duplicated)
+	// BroadcastID must be the ORIGINAL broadcast's ID, not the freshly allocated
+	// 999 that went unused.
+	require.Equal(t, uint64(100), result.BroadcastID)
+	require.Equal(t, message.NewCollectionScopedIdempotencyKey(testCollectionID, "import/1/k"),
+		message.IdempotencyKeyOf(result.Duplicated))
+
+	// The dup branch releases the guards itself before waiting on the original --
+	// a leaked guard would block every later import on that collection forever.
+	// Contend on the SAME exclusive key to prove it: acquirable already, before
+	// Close() is ever called, and Close() stays a harmless no-op after.
+	require.Nil(t, api.guards)
+
+	released := make(chan struct{})
+	go func() {
+		bm.resourceKeyLocker.Lock(collectionKey).Unlock()
+		close(released)
+	}()
+	select {
+	case <-released:
+	case <-time.After(3 * time.Second):
+		t.Fatal("resource key lock was not released after a deduplicated broadcast")
+	}
+	api.Close()
+}
+
+func TestBroadcastWithoutKeyIsUnaffected(t *testing.T) {
+	// A broadcast carrying no idempotency key follows the original path unchanged:
+	// it creates a task and consumes the guards by handing them to it.
+	//
+	// This does NOT prove the `key != ""` guard in Broadcast is present — an empty
+	// key is a structural miss in the index (Get("") always returns false), so the
+	// observable outcome is identical with or without the guard. The guard exists
+	// to skip a pointless lookup, not for correctness, and is deliberately left
+	// unasserted rather than pinned by a test that cannot fail.
+	bm := newBroadcastTaskManagerForTest(t)
+
+	guards := bm.resourceKeyLocker.Lock(message.NewSharedClusterResourceKey())
+	api := &broadcasterWithRK{broadcaster: bm, broadcastID: 999, guards: guards}
+
+	msg := message.NewImportMessageBuilderV1().
+		WithHeader(&message.ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{}).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+
+	result, err := api.Broadcast(context.Background(), msg)
+	require.NoError(t, err)
+	require.Nil(t, result.Duplicated)
+	require.Equal(t, uint64(999), result.BroadcastID)
+	// The keyless path consumes the guards: they now belong to the created task.
+	require.Nil(t, api.guards)
+}
+
+// TestIdempotencyScopeEncoding pins what makes two broadcasts the same operation.
+// A client key alone is not an identity: it deduplicates within
+// (messageType, the scope the caller bound the key to).
+func TestIdempotencyScopeEncoding(t *testing.T) {
+	keyA := message.NewCollectionScopedIdempotencyKey(7, "k")
+
+	base := idempotencyScope(message.MessageTypeImport, keyA)
+	require.NotEmpty(t, base)
+
+	// A broadcast without a client key is not idempotent and has no scope at all.
+	require.Empty(t, idempotencyScope(message.MessageTypeImport, ""))
+
+	// Same identity, same scope.
+	require.Equal(t, base, idempotencyScope(message.MessageTypeImport, keyA))
+
+	// The message type is part of the identity: CreateIndex and DropIndex on one
+	// collection carry the same scope otherwise, so without it the same client key on
+	// two different operations would collide and the second would be swallowed.
+	require.NotEqual(t, base, idempotencyScope(message.MessageTypeCreateCollection, keyA))
+
+	// So is the scope the caller bound the key to.
+	require.NotEqual(t, base, idempotencyScope(message.MessageTypeImport,
+		message.NewCollectionScopedIdempotencyKey(8, "k")))
+	require.NotEqual(t, base, idempotencyScope(message.MessageTypeImport,
+		message.NewDatabaseScopedIdempotencyKey(7, "k")))
+	require.NotEqual(t, base, idempotencyScope(message.MessageTypeImport,
+		message.NewClusterScopedIdempotencyKey("k")))
+
+	// And so is the client key itself.
+	require.NotEqual(t, base, idempotencyScope(message.MessageTypeImport,
+		message.NewCollectionScopedIdempotencyKey(7, "k2")))
+
+	// The message type is decimal digits followed by a separator, and the key is the
+	// unbounded tail, so a client key that embeds the separator cannot pose as another
+	// message type's scope.
+	require.NotEqual(t,
+		idempotencyScope(message.MessageTypeImport,
+			message.NewCollectionScopedIdempotencyKey(7, "/"+strconv.Itoa(int(message.MessageTypeCreateCollection)))),
+		idempotencyScope(message.MessageTypeCreateCollection, message.NewCollectionScopedIdempotencyKey(7, "")))
+}
+
+// TestIdempotencyScopeIgnoresResourceKeys is the property that closes the rename hole.
+//
+// The scope used to be derived from the broadcast's resource keys, which name a
+// collection rather than identify it: renaming a collection between a request and its
+// retry changed the scope, the lookup missed, and the same import ran a second time.
+// The scope now comes from the message alone, so the resource keys a broadcast happens
+// to hold -- and any rename that changes them -- cannot move it.
+func TestIdempotencyScopeIgnoresResourceKeys(t *testing.T) {
+	msg := newImportMsgWithKey("k")
+	bare := idempotencyScopeOfMessage(msg)
+	require.NotEmpty(t, bare)
+
+	beforeRename := msg.OverwriteBroadcastHeader(100,
+		message.NewSharedDBNameResourceKey("db1"),
+		message.NewExclusiveCollectionNameResourceKey("db1", "coll1"))
+	afterRename := newImportMsgWithKey("k").OverwriteBroadcastHeader(101,
+		message.NewSharedDBNameResourceKey("db1"),
+		message.NewExclusiveCollectionNameResourceKey("db1", "coll1-renamed"))
+
+	require.Equal(t, bare, idempotencyScopeOfMessage(beforeRename))
+	require.Equal(t, bare, idempotencyScopeOfMessage(afterRename))
+}
+
+// TestBroadcastDedupIsScopedToTheBroadcast drives the write side and the read side
+// against each other end to end: every broadcast below goes through
+// broadcasterWithRK.Broadcast, so a scope the two sides derive differently shows up
+// here as a duplicate that is never detected.
+func TestBroadcastDedupIsScopedToTheBroadcast(t *testing.T) {
+	bm := newBroadcastTaskManagerForTest(t)
+
+	// Shared keys throughout: a created task keeps its lock guards until it is acked,
+	// and an exclusive key would then block the next broadcast of this test forever.
+	dbKey := message.NewSharedDBNameResourceKey("db1")
+	collA := message.NewSharedCollectionNameResourceKey("db1", "coll1")
+	collB := message.NewSharedCollectionNameResourceKey("db1", "coll2")
+
+	// The first broadcast establishes the scope.
+	first := broadcastForTest(t, bm, 1, newImportMsgWithKey("k"), dbKey, collA)
+	require.Nil(t, first.Duplicated)
+	require.Equal(t, uint64(1), first.BroadcastID)
+
+	// Same message type, same resource keys, same client key: a duplicate, resolved to
+	// the ORIGINAL broadcastID. This is the assertion that fails if the write side and
+	// the read side disagree on how the scope is built.
+	dup := broadcastForTest(t, bm, 2, newImportMsgWithKey("k"), collA, dbKey)
+	require.NotNil(t, dup.Duplicated)
+	require.Equal(t, uint64(1), dup.BroadcastID)
+
+	// Different message type, everything else identical: a different operation, so it
+	// must proceed on its own broadcastID instead of being swallowed as a duplicate.
+	otherType := broadcastForTest(t, bm, 3, newCreateCollectionMsgWithKey("k"), dbKey, collA)
+	require.Nil(t, otherType.Duplicated)
+	require.Equal(t, uint64(3), otherType.BroadcastID)
+
+	// Another collection scope, everything else identical: a distinct operation.
+	otherKeys := broadcastForTest(t, bm, 4, newImportMsgScoped(testCollectionID+1, "k"), dbKey, collB)
+	require.Nil(t, otherKeys.Duplicated)
+	require.Equal(t, uint64(4), otherKeys.BroadcastID)
+
+	// Different client key.
+	otherKey := broadcastForTest(t, bm, 5, newImportMsgWithKey("k2"), dbKey, collA)
+	require.Nil(t, otherKey.Duplicated)
+	require.Equal(t, uint64(5), otherKey.BroadcastID)
+
+	// Each of those scopes now dedups within itself, the second message type included.
+	dupOtherType := broadcastForTest(t, bm, 6, newCreateCollectionMsgWithKey("k"), dbKey, collA)
+	require.NotNil(t, dupOtherType.Duplicated)
+	require.Equal(t, uint64(3), dupOtherType.BroadcastID)
+
+	dupOtherKeys := broadcastForTest(t, bm, 7, newImportMsgScoped(testCollectionID+1, "k"), dbKey, collB)
+	require.NotNil(t, dupOtherKeys.Duplicated)
+	require.Equal(t, uint64(4), dupOtherKeys.BroadcastID)
+
+	// A retry that arrives after the collection was renamed holds DIFFERENT resource
+	// keys and still resolves to its original broadcast: the scope is the collection's
+	// identity, not its name. Under the resource-key scope this was a miss, and the
+	// same files were imported a second time.
+	renamedColl := message.NewSharedCollectionNameResourceKey("db1", "coll1-renamed")
+	afterRename := broadcastForTest(t, bm, 8, newImportMsgWithKey("k"), dbKey, renamedColl)
+	require.NotNil(t, afterRename.Duplicated)
+	require.Equal(t, uint64(1), afterRename.BroadcastID)
+}
+
+// TestDuplicatedBroadcastReturnsOriginalAppendResults asserts the duplicate carries the
+// original broadcast's per-vchannel append results. A caller that dereferences
+// GetAppendResult on the duplicate path would nil-panic without them.
+func TestDuplicatedBroadcastReturnsOriginalAppendResults(t *testing.T) {
+	collKey := message.NewSharedCollectionNameResourceKey("db1", "coll1")
+	// A tombstoned original with its single vchannel acked: bitmap 0x01 gives vchannel
+	// "v1" a checkpoint of test message id 0 at time tick 1.
+	bm := newBroadcastTaskManagerForTest(t,
+		createImportBroadcastTaskProto(100, "k",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, []byte{0x01}, collKey))
+
+	result := broadcastForTest(t, bm, 999, newImportMsgWithKey("k"), collKey)
+	require.NotNil(t, result.Duplicated)
+	require.Equal(t, uint64(100), result.BroadcastID)
+
+	require.Len(t, result.AppendResults, 1)
+	appendResult := result.AppendResults["v1"]
+	require.NotNil(t, appendResult)
+	require.Equal(t, uint64(1), appendResult.TimeTick)
+	require.True(t, appendResult.MessageID.EQ(walimplstest.NewTestMessageID(0)))
+	require.True(t, appendResult.LastConfirmedMessageID.EQ(walimplstest.NewTestMessageID(0)))
+}
+
+// TestDuplicateWaitsForAnInFlightOriginal pins the duplicate branch's contract: a
+// same-key retry is answered only once the original's ack callback has run, i.e. from
+// the same state the original's own caller returns from. The retry here holds a
+// DIFFERENT collection-name key than the original -- the shape a rename race produces
+// -- so nothing but the wait itself separates it from the original's completion.
+// Without the wait this returns immediately, with a broadcastID whose import job (for
+// import, created in the ack callback) does not exist yet.
+func TestDuplicateWaitsForAnInFlightOriginal(t *testing.T) {
+	bm := newBroadcastTaskManagerForTest(t)
+
+	// Hold the WAL append open so the original stays in flight until released.
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAppends := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseAppends)
+
+	operator := mock_streaming.NewMockWALAccesser(t)
+	operator.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+			<-release
+			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+			for idx := range msgs {
+				resps.Responses[idx] = types.AppendResponse{
+					AppendResult: &types.AppendResult{
+						MessageID: walimplstest.NewTestMessageID(int64(idx + 1)),
+						TimeTick:  uint64(time.Now().UnixMilli()),
+					},
+				}
+			}
+			return resps
+		}).Maybe()
+	streaming.SetWALForTest(operator)
+
+	// The original, holding the pre-rename name's key.
+	originalDone := make(chan struct{})
+	go func() {
+		defer close(originalDone)
+		api := &broadcasterWithRK{
+			broadcaster: bm, broadcastID: 1,
+			guards: bm.resourceKeyLocker.Lock(message.NewExclusiveCollectionNameResourceKey("db1", "coll1")),
+		}
+		defer api.Close()
+		_, err := api.Broadcast(context.Background(), newImportMsgWithKey("k"))
+		require.NoError(t, err)
+	}()
+	// The retry may only start once the original is registered, or it would race the
+	// index miss instead of hitting it.
+	require.Eventually(t, func() bool {
+		_, ok := bm.getBroadcastTaskByID(1)
+		return ok
+	}, 10*time.Second, time.Millisecond)
+
+	// The retry, holding the post-rename name's key: no lock orders it behind the
+	// original.
+	var dupResult *types.BroadcastAppendResult
+	dupDone := make(chan struct{})
+	go func() {
+		defer close(dupDone)
+		api := &broadcasterWithRK{
+			broadcaster: bm, broadcastID: 2,
+			guards: bm.resourceKeyLocker.Lock(message.NewExclusiveCollectionNameResourceKey("db1", "coll1-renamed")),
+		}
+		defer api.Close()
+		var err error
+		dupResult, err = api.Broadcast(context.Background(), newImportMsgWithKey("k"))
+		require.NoError(t, err)
+	}()
+
+	// While the original is in flight, the duplicate must not have answered.
+	select {
+	case <-dupDone:
+		t.Fatal("the duplicate answered before the original completed")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	releaseAppends()
+	<-originalDone
+	<-dupDone
+
+	require.NotNil(t, dupResult.Duplicated)
+	require.Equal(t, uint64(1), dupResult.BroadcastID)
+	// Answered from a completed original, the results are whole -- the property the
+	// wait exists to provide.
+	require.Len(t, dupResult.AppendResults, 1)
+	require.NotNil(t, dupResult.AppendResults["v1"])
+}
+
+// TestDuplicateAgainstUnackedReplicatedOriginalTimesOut covers the other path that can
+// observe an incomplete original without racing anything: a task recovered from a
+// replicated WAL holds no resource lock at all, yet is indexed. When such an original
+// never completes, the duplicate must surface the caller's own timeout -- an error the
+// client retries -- never a success carrying a broadcastID that nothing backs, which is
+// what the pre-wait implementation answered here.
+func TestDuplicateAgainstUnackedReplicatedOriginalTimesOut(t *testing.T) {
+	collKey := message.NewSharedCollectionNameResourceKey("db1", "coll1")
+	// A replicated task with an empty ack bitmap: recovery neither re-appends nor acks
+	// it, so it stays incomplete for the whole test.
+	bm := newBroadcastTaskManagerForTest(t,
+		createImportBroadcastTaskProto(100, "k",
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED, []byte{0x00}, collKey))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	api := &broadcasterWithRK{broadcaster: bm, broadcastID: 999, guards: bm.resourceKeyLocker.Lock(collKey)}
+	defer api.Close()
+
+	result, err := api.Broadcast(ctx, newImportMsgWithKey("k"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, result)
+}
+
+// TestDiscardedBroadcastCountsNoPendingTask covers the one path that builds no task:
+// a dedup hit. Counting a task there would be invisible in behavior and permanent in
+// the metric, because the count is only ever undone by a state transition and this
+// path has no task left to transition.
+func TestDiscardedBroadcastCountsNoPendingTask(t *testing.T) {
+	bm := newBroadcastTaskManagerForTest(t)
+	collKey := message.NewSharedCollectionNameResourceKey("db1", "coll1")
+
+	pending := func() float64 {
+		return testutil.ToFloat64(bm.metrics.taskTotal.WithLabelValues(
+			message.MessageTypeImport.String(),
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING.String()))
+	}
+	broadcast := func(broadcastID uint64, msg message.BroadcastMutableMessage) error {
+		api := &broadcasterWithRK{broadcaster: bm, broadcastID: broadcastID, guards: bm.resourceKeyLocker.Lock(collKey)}
+		defer api.Close()
+		_, err := api.Broadcast(context.Background(), msg)
+		return err
+	}
+
+	// Settle an original first, so the gauge stops moving on its own.
+	require.NoError(t, broadcast(1, newImportMsgWithKey("k1")))
+	require.Eventually(t, func() bool {
+		task, ok := bm.getBroadcastTaskByID(1)
+		return ok && task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE
+	}, 10*time.Second, 10*time.Millisecond)
+	settled := pending()
+
+	// A retry of the same scope resolves to the original: nothing is registered.
+	require.NoError(t, broadcast(2, newImportMsgWithKey("k1")))
+	require.Equal(t, settled, pending())
+}
+
+// createBroadcastTaskProtoFromMessage builds a recovery proto for an arbitrary
+// broadcast message, so a test can drive the dedup path with a message type other
+// than import.
+func createBroadcastTaskProtoFromMessage(
+	msg message.BroadcastMutableMessage,
+	broadcastID uint64,
+	state streamingpb.BroadcastTaskState,
+	bitmap []byte,
+	rks ...message.ResourceKey,
+) *streamingpb.BroadcastTask {
+	if len(rks) == 0 {
+		rks = []message.ResourceKey{message.NewSharedClusterResourceKey()}
+	}
+	return createNewWaitAckBroadcastTaskFromMessage(msg.OverwriteBroadcastHeader(broadcastID, rks...), state, bitmap)
+}
+
+// TestNonImportBroadcastIsDeduplicated is the acceptance test for this mechanism
+// being generic rather than import-specific.
+//
+// Every other dedup test here drives an import message, so all of them would still
+// pass if the machinery had grown an import-shaped assumption somewhere. This one
+// takes a broadcast type that knows nothing about idempotency, has no proto field
+// for a key, and whose coordinator never reads one, and shows that carrying the key
+// is the ONLY thing required: it deduplicates, reports the original broadcast, and
+// replays the original's per-vchannel results.
+func TestNonImportBroadcastIsDeduplicated(t *testing.T) {
+	collKey := message.NewSharedCollectionNameResourceKey("db1", "coll1")
+	// A tombstoned original with its single vchannel acked, exactly as the import
+	// case sets up — only the message type differs.
+	bm := newBroadcastTaskManagerForTest(t,
+		createBroadcastTaskProtoFromMessage(
+			newCreateCollectionMsgWithKey("run-1"), 100,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, []byte{0x01}, collKey))
+
+	result := broadcastForTest(t, bm, 999, newCreateCollectionMsgWithKey("run-1"), collKey)
+
+	require.NotNil(t, result.Duplicated, "a keyed non-import broadcast must deduplicate too")
+	require.Equal(t, uint64(100), result.BroadcastID)
+	require.Equal(t, message.MessageTypeCreateCollection, result.Duplicated.MessageType())
+
+	// The replayed results are what make a duplicate indistinguishable from a fresh
+	// broadcast for a caller that only reads append results — which is most of the
+	// broadcast call sites in the repo.
+	require.Len(t, result.AppendResults, 1)
+	appendResult := result.AppendResults["v1"]
+	require.NotNil(t, appendResult)
+	require.Equal(t, uint64(1), appendResult.TimeTick)
+}
+
+// newBroadcastTaskManagerWithEntrypointForTest is newBroadcastTaskManagerForTest plus
+// the ID allocator broadcastTaskManager.WithResourceKeys needs, so a test can drive the
+// real entrypoint instead of constructing broadcasterWithRK by hand.
+//
+// The cluster-role check is the one step of WithResourceKeys that is stubbed. It reads a
+// process-wide balancer singleton that can only be Set once and has no reset, and
+// TestBroadcaster in this package already claims it; registering a second one panics.
+// The lock acquisition and the ID allocation -- the work that actually sits between
+// taking the resource lock and reaching the idempotency lookup -- are the real ones.
+func newBroadcastTaskManagerWithEntrypointForTest(t *testing.T, protos ...*streamingpb.BroadcastTask) *broadcastTaskManager {
+	paramtable.Init()
+	registry.ResetRegistration()
+	registry.RegisterImportV1AckCallback(func(ctx context.Context, result message.BroadcastResultImportMessageV1) error {
+		return nil
+	})
+
+	roleCheck := mockey.Mock((*broadcastTaskManager).checkClusterRole).Return(nil).Build()
+	t.Cleanup(func() { roleCheck.UnPatch() })
+
+	meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+	meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	rc := idalloc.NewMockRootCoordClient(t)
+	f := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	f.Set(rc)
+	resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
+
+	operator := mock_streaming.NewMockWALAccesser(t)
+	operator.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+			for idx := range msgs {
+				resps.Responses[idx] = types.AppendResponse{
+					AppendResult: &types.AppendResult{
+						MessageID: walimplstest.NewTestMessageID(int64(idx + 1)),
+						TimeTick:  uint64(time.Now().UnixMilli()),
+					},
+				}
+			}
+			return resps
+		}).Maybe()
+	streaming.SetWALForTest(operator)
+
+	bm := newBroadcastTaskManager(protos)
+	t.Cleanup(bm.Close)
+	return bm
+}
+
+// TestConcurrentSameKeyBroadcastsUnderDifferentResourceKeys pins the dedup guarantee
+// to the manager lock rather than to the caller's resource keys.
+//
+// TestConcurrentSameKeyBroadcastsCreateExactlyOneTask hands every goroutine the SAME
+// collection key, so they serialize on it and the lookup can never race. Import does
+// not have that luxury: it scopes the key by collection ID -- deliberately, so a retry
+// still dedups after a rename -- while startBroadcastWithCollectionID resolves the
+// collection NAME before any lock is held and locks on the name. RenameCollection
+// takes DB-level keys only, so it blocks an in-flight import, and by the time it
+// releases, the original request and its retry hold exclusive locks on two different
+// names. Same scope, non-conflicting locks, no serialization.
+//
+// The keys below are exactly that pairing: one scope, one lock per goroutine, all
+// distinct. Exactly one task may still be created.
+func TestConcurrentSameKeyBroadcastsUnderDifferentResourceKeys(t *testing.T) {
+	bm := newBroadcastTaskManagerWithEntrypointForTest(t)
+
+	const concurrency = 8
+	results := make([]*types.BroadcastAppendResult, concurrency)
+	errs := make([]error, concurrency)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			// A different collection name per goroutine, standing in for the names a
+			// rename hands out. The scope below is unchanged: it is built from the
+			// collection ID.
+			collKey := message.NewExclusiveCollectionNameResourceKey("db1", fmt.Sprintf("coll_rename_%d", i))
+			api, err := bm.WithResourceKeys(context.Background(), collKey)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer api.Close()
+			results[i], errs[i] = api.Broadcast(context.Background(), newImportMsgWithKey("renamed"))
+		}(i)
+	}
+	close(start)
+
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent same-key broadcasts did not all finish: a guard was leaked or an ack never completed")
+	}
+
+	fresh := 0
+	var originalID uint64
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		if results[i].Duplicated == nil {
+			fresh++
+			originalID = results[i].BroadcastID
+		}
+	}
+	require.Equal(t, 1, fresh,
+		"exactly one task may be created even when the callers hold different resource keys")
+	for i := 0; i < concurrency; i++ {
+		require.Equal(t, originalID, results[i].BroadcastID)
+	}
+	require.Len(t, bm.idempotencyIndex.scopeToBroadcastID, 1)
+}
+
+// TestConcurrentSameKeyBroadcastsCreateExactlyOneTask is the invariant import's dedup
+// correctness rests on, driven through the REAL entrypoint.
+//
+// Every other test in this file builds broadcasterWithRK directly, which means it never
+// exercises what makes concurrency safe: the lookup lives behind resource keys that
+// WithResourceKeys acquires, and WithResourceKeys does non-trivial work between taking
+// the lock and reaching the lookup (allocating a broadcastID, checking the cluster
+// role). If the second request were not serialized behind the first's ack, it would
+// miss the index and create a second import job -- exactly the duplication this feature
+// exists to prevent, and invisible to every direct-construction test.
+func TestConcurrentSameKeyBroadcastsCreateExactlyOneTask(t *testing.T) {
+	bm := newBroadcastTaskManagerWithEntrypointForTest(t)
+
+	// Exclusive, and on the collection the key is scoped to: that pairing is what the
+	// serialization guarantee is stated in terms of.
+	collKey := message.NewExclusiveCollectionNameResourceKey("db1", "coll1")
+
+	const concurrency = 8
+	results := make([]*types.BroadcastAppendResult, concurrency)
+	errs := make([]error, concurrency)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			api, err := bm.WithResourceKeys(context.Background(), collKey)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer api.Close()
+			results[i], errs[i] = api.Broadcast(context.Background(), newImportMsgWithKey("k"))
+		}(i)
+	}
+	close(start)
+
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent same-key broadcasts did not all finish: a guard was leaked or an ack never completed")
+	}
+
+	fresh := 0
+	var originalID uint64
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		if results[i].Duplicated == nil {
+			fresh++
+			originalID = results[i].BroadcastID
+		}
+	}
+	require.Equal(t, 1, fresh, "exactly one of the concurrent same-key broadcasts may create a task")
+
+	// Every request, the winner included, answers with the same broadcastID: a client
+	// that retried while its original was still in flight gets the original's job.
+	for i := 0; i < concurrency; i++ {
+		require.Equal(t, originalID, results[i].BroadcastID)
+	}
+	// And the index holds exactly that one entry for the scope.
+	require.Len(t, bm.idempotencyIndex.scopeToBroadcastID, 1)
+}

--- a/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
+++ b/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
@@ -684,6 +684,20 @@ func newBroadcastTaskManagerWithEntrypointForTest(t *testing.T, protos ...*strea
 		return nil
 	})
 
+	// Earlier tests in this package shrink the tombstone GC window to milliseconds and
+	// never restore it. The idempotency entry lives exactly as long as its task's
+	// tombstone, so under that window the GC can drop the winner's entry before a
+	// slow caller reaches the lookup, and the caller creates a second task. Pin a long
+	// window, as newBroadcastTaskManagerForTest does.
+	oldInterval := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue("1h")
+	oldLifetime := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue("1h")
+	oldCount := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue("8192")
+	t.Cleanup(func() {
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue(oldInterval)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue(oldLifetime)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue(oldCount)
+	})
+
 	roleCheck := mockey.Mock((*broadcastTaskManager).checkClusterRole).Return(nil).Build()
 	t.Cleanup(func() { roleCheck.UnPatch() })
 

--- a/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
@@ -14,7 +14,12 @@ import (
 // tombstoneItem is a tombstone item with expired time.
 type tombstoneItem struct {
 	broadcastID uint64
-	createTime  time.Time // the time when the tombstone is created, when recovery, the createTime will be reset to the current time, but it's ok.
+	// createTime is when the tombstone was created. Recovery resets it to the current
+	// time, so a restart delays this tombstone's GC by up to another maxLifetime. That
+	// makes the idempotency window the tombstone backs a lower bound rather than an
+	// exact one, so any retention coupled to maxLifetime must leave margin rather than
+	// match it exactly.
+	createTime time.Time
 }
 
 // tombstoneScheduler is a scheduler for the tombstone.

--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -289,6 +289,7 @@ func (c *ClientBase[T]) connect(ctx context.Context) error {
 			grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 				interceptor.ClusterInjectionUnaryClientInterceptor(),
 				interceptor.ServerIDInjectionUnaryClientInterceptor(c.GetNodeID()),
+				interceptor.IdempotencyKeyPropagationUnaryClientInterceptor(),
 			)),
 			grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(
 				interceptor.ClusterInjectionStreamClientInterceptor(),
@@ -327,6 +328,7 @@ func (c *ClientBase[T]) connect(ctx context.Context) error {
 			grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 				interceptor.ClusterInjectionUnaryClientInterceptor(),
 				interceptor.ServerIDInjectionUnaryClientInterceptor(c.GetNodeID()),
+				interceptor.IdempotencyKeyPropagationUnaryClientInterceptor(),
 			)),
 			grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(
 				interceptor.ClusterInjectionStreamClientInterceptor(),

--- a/pkg/streaming/util/message/builder.go
+++ b/pkg/streaming/util/message/builder.go
@@ -268,6 +268,31 @@ func (b *mutableMesasgeBuilder[H, B]) WithProperties(kvs map[string]string) *mut
 	return b
 }
 
+// WithIdempotencyKey creates a new builder carrying the idempotency key of an
+// idempotent write. A zero key is a no-op, so callers can pass the key
+// unconditionally without materializing an empty property.
+//
+// The parameter is an `IdempotencyKey` rather than a string because a key is
+// meaningless without the scope it deduplicates within: it is built by one of the
+// New*ScopedIdempotencyKey constructors, which is what keeps a caller from
+// shipping an accidentally unscoped key.
+//
+// The key is a property rather than a per-message-type header field so that every
+// producer and consumer reads it the same way (see `IdempotencyKeyOf`), and so
+// that a broadcast message carries it without any per-type schema change.
+//
+// A deduplicated broadcast returns the ORIGINAL broadcast's per-channel append
+// results, so a caller reading `BroadcastAppendResult.GetAppendResult(...)` needs no
+// special handling for the duplicate path. The one exception is an original that has
+// not finished being acked, which leaves the results nil; a caller that dereferences
+// them without a nil check would panic there — a branch no success-path test reaches.
+func (b *mutableMesasgeBuilder[H, B]) WithIdempotencyKey(key IdempotencyKey) *mutableMesasgeBuilder[H, B] {
+	if key != "" {
+		b.properties.Set(messageIdempotencyKey, string(key))
+	}
+	return b
+}
+
 // WithCipher creates a new builder with cipher property.
 func (b *mutableMesasgeBuilder[H, B]) WithCipher(cipherConfig *CipherConfig) *mutableMesasgeBuilder[H, B] {
 	b.cipherConfig = cipherConfig

--- a/pkg/streaming/util/message/idempotency.go
+++ b/pkg/streaming/util/message/idempotency.go
@@ -1,0 +1,137 @@
+package message
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+const idempotencyKeyFingerprintBytes = 16
+
+// IdempotencyScopeDomain names the kind of object a client key deduplicates within.
+//
+// The domain is carried explicitly rather than inferred from the scope id, even
+// though collection ids and database ids come from one rootcoord allocator today
+// and therefore never collide. Inferring it would make the broadcaster depend on
+// an allocator property it does not own, and would lock every future scope into
+// having an int64 identity at all. The failure mode of getting that wrong is two
+// unrelated operations sharing one dedup entry, i.e. one of them silently
+// swallowed, and the encoding is persisted in the WAL and in etcd, so it cannot
+// be revised cheaply after release.
+type IdempotencyScopeDomain int
+
+const (
+	IdempotencyScopeCluster    IdempotencyScopeDomain = 1
+	IdempotencyScopeDatabase   IdempotencyScopeDomain = 2
+	IdempotencyScopeCollection IdempotencyScopeDomain = 3
+)
+
+// IdempotencyKey is a client-supplied idempotency key together with the scope it
+// deduplicates within, encoded as `<domain>:<scopeID>:<clientKey>`.
+//
+// The scope is an IDENTITY, never a name: a collection id rather than a
+// collection name. That is what keeps a key bound to the object it was issued
+// against when that object is renamed -- a retry that names the renamed object
+// still resolves to the original -- and what makes a drop-and-recreate under the
+// same name a different operation. It does not make a stale name work: whatever
+// resolves the caller's name to an id runs before any of this.
+//
+// Callers choose the scope explicitly through one of the New*ScopedIdempotencyKey
+// constructors; there is no constructor that takes a bare string, so a caller
+// cannot end up with an unscoped key by omission. Choosing cluster scope is a
+// decision that reads as one.
+//
+// The encoding is injective without any framing tricks: the domain and the scope
+// id are decimal digits, so the first two colons delimit them and the client key
+// is the unbounded tail. A crafted client key cannot impersonate another scope no
+// matter what it contains.
+//
+// The empty value means "not an idempotent write". Every constructor returns it
+// for an empty client key, so an absent key can never encode to a non-empty scope
+// -- which would otherwise make every keyless broadcast of one message type
+// deduplicate against every other.
+type IdempotencyKey string
+
+// NewClusterScopedIdempotencyKey scopes the key to the whole cluster: the client
+// key must be unique across every object, and the operation is deduplicated
+// wherever it happens.
+func NewClusterScopedIdempotencyKey(clientKey string) IdempotencyKey {
+	return newIdempotencyKey(IdempotencyScopeCluster, 0, clientKey)
+}
+
+// NewDatabaseScopedIdempotencyKey scopes the key to one database, so the same
+// client key stays a distinct operation against another database.
+func NewDatabaseScopedIdempotencyKey(dbID int64, clientKey string) IdempotencyKey {
+	return newIdempotencyKey(IdempotencyScopeDatabase, dbID, clientKey)
+}
+
+// NewCollectionScopedIdempotencyKey scopes the key to one collection, so the same
+// client key stays a distinct operation against another collection.
+func NewCollectionScopedIdempotencyKey(collectionID int64, clientKey string) IdempotencyKey {
+	return newIdempotencyKey(IdempotencyScopeCollection, collectionID, clientKey)
+}
+
+// newIdempotencyKey encodes the scope onto the client key. The scope id is unused
+// for cluster scope and encoded as 0 there.
+func newIdempotencyKey(domain IdempotencyScopeDomain, scopeID int64, clientKey string) IdempotencyKey {
+	if clientKey == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(strconv.Itoa(int(domain)))
+	b.WriteByte(':')
+	b.WriteString(strconv.FormatInt(scopeID, 10))
+	b.WriteByte(':')
+	b.WriteString(clientKey)
+	return IdempotencyKey(b.String())
+}
+
+// ClientKey returns the client-supplied portion, i.e. the key without the scope
+// this package encoded onto it. It is the only way back: the encoding is one-way
+// for everything else, and the scope is chosen by the caller, so a holder of an
+// encoded key cannot otherwise tell which bytes came from the client.
+//
+// Nothing in the request path needs it. Both places that bound or fingerprint a
+// client key -- the REST middleware and the propagation interceptor -- see the raw
+// string before this package encodes anything onto it, and the broadcaster indexes
+// the encoded form whole. This exists for a holder of an encoded key that must show
+// the client its own key back, or attribute one in a log.
+//
+// A value this package did not produce has no recoverable client portion, so it is
+// returned whole rather than guessed at.
+func (k IdempotencyKey) ClientKey() string {
+	parts := strings.SplitN(string(k), ":", 3)
+	if len(parts) < 3 {
+		return string(k)
+	}
+	return parts[2]
+}
+
+// IdempotencyKeyOf returns the idempotency key carried by the message, or "" when
+// the message is not an idempotent write.
+//
+// The key lives in the `_ik` property rather than in a header field, so this one
+// accessor serves every message type and every message stage (broadcast, mutable,
+// immutable). Callers that only honor the key on specific message types must gate
+// on the type themselves: any message may technically carry the property.
+func IdempotencyKeyOf(msg BasicMessage) IdempotencyKey {
+	if msg == nil {
+		return ""
+	}
+	key, _ := msg.Properties().Get(messageIdempotencyKey)
+	return IdempotencyKey(key)
+}
+
+// IdempotencyKeyFingerprint returns a stable identifier suitable for correlating
+// idempotency-key events in logs. The original key must never be logged: it is
+// client-controlled and may contain sensitive data.
+//
+// This obfuscates the key, it does not protect it: an unkeyed digest of a
+// low-entropy client key (a run id, a short batch name) is recoverable by anyone
+// who can guess candidates. Use it to correlate log lines, never as a security
+// control or an authorization token.
+func IdempotencyKeyFingerprint(clientKey string) string {
+	sum := sha256.Sum256([]byte(clientKey))
+	return hex.EncodeToString(sum[:idempotencyKeyFingerprintBytes])
+}

--- a/pkg/streaming/util/message/idempotency_test.go
+++ b/pkg/streaming/util/message/idempotency_test.go
@@ -1,0 +1,119 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+)
+
+func TestIdempotencyKeyProperty(t *testing.T) {
+	require.Empty(t, IdempotencyKeyOf(nil))
+
+	// A broadcast message carrying a key is read back through the same accessor
+	// that serves every other message type and stage.
+	msg := NewImportMessageBuilderV1().
+		WithHeader(&ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{}).
+		WithIdempotencyKey(NewCollectionScopedIdempotencyKey(1, "key-1")).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+	require.Equal(t, IdempotencyKey("3:1:key-1"), IdempotencyKeyOf(msg))
+
+	// An empty key must not materialize the property at all, so a non-idempotent
+	// broadcast carries exactly the properties it carried before this feature.
+	keyless := NewImportMessageBuilderV1().
+		WithHeader(&ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{}).
+		WithIdempotencyKey(NewCollectionScopedIdempotencyKey(1, "")).
+		WithBroadcast([]string{"v1"}).
+		MustBuildBroadcast()
+	require.Empty(t, IdempotencyKeyOf(keyless))
+	require.NotContains(t, keyless.Properties().ToRawMap(), messageIdempotencyKey)
+}
+
+func TestIdempotencyKeySurvivesSplit(t *testing.T) {
+	// Every per-vchannel message that SplitIntoMutableMessage produces must still
+	// carry the key: neither the WAL append path nor the recovery side can read it
+	// otherwise, which would silently disable deduplication.
+	msg := NewImportMessageBuilderV1().
+		WithHeader(&ImportMessageHeader{}).
+		WithBody(&msgpb.ImportMsg{}).
+		WithIdempotencyKey(NewCollectionScopedIdempotencyKey(1, "key-1")).
+		WithBroadcast([]string{"v1", "v2"}).
+		MustBuildBroadcast().
+		WithBroadcastID(1)
+	splitted := msg.SplitIntoMutableMessage()
+	require.Len(t, splitted, 2)
+	for _, m := range splitted {
+		require.Equal(t, IdempotencyKey("3:1:key-1"), IdempotencyKeyOf(m))
+	}
+}
+
+func TestIdempotencyKeyFingerprint(t *testing.T) {
+	fp := IdempotencyKeyFingerprint("tenant-secret-key")
+	require.Len(t, fp, idempotencyKeyFingerprintBytes*2)
+	require.NotContains(t, fp, "tenant")
+	require.Equal(t, fp, IdempotencyKeyFingerprint("tenant-secret-key"))
+	require.NotEqual(t, fp, IdempotencyKeyFingerprint("other-key"))
+}
+
+// TestScopedIdempotencyKeyEncoding pins what makes two client keys the same
+// operation, and what keeps them apart.
+func TestScopedIdempotencyKeyEncoding(t *testing.T) {
+	base := NewCollectionScopedIdempotencyKey(449988, "k")
+
+	// The same key against the same collection is the same operation.
+	require.Equal(t, base, NewCollectionScopedIdempotencyKey(449988, "k"))
+
+	// A different collection, a different client key, or a different scope kind is
+	// a different operation. The scope kind matters even though collection ids and
+	// database ids come from one allocator today: the encoding must not depend on
+	// that.
+	require.NotEqual(t, base, NewCollectionScopedIdempotencyKey(449989, "k"))
+	require.NotEqual(t, base, NewCollectionScopedIdempotencyKey(449988, "k2"))
+	require.NotEqual(t, base, NewDatabaseScopedIdempotencyKey(449988, "k"))
+	require.NotEqual(t, base, NewClusterScopedIdempotencyKey("k"))
+
+	// Cluster scope has no object to name, so it encodes a scope id of 0. It is the
+	// domain, not the id, that keeps it apart from a real object.
+	require.Equal(t, IdempotencyKey("1:0:k"), NewClusterScopedIdempotencyKey("k"))
+}
+
+// TestScopedIdempotencyKeyResistsCraftedClientKey proves a client cannot reach
+// another scope's entry by embedding the encoding's separator in its key. The
+// client key is the unbounded tail, so it is inert no matter what it holds.
+func TestScopedIdempotencyKeyResistsCraftedClientKey(t *testing.T) {
+	// A client key crafted to look like "collection 7, key v" when appended.
+	crafted := NewClusterScopedIdempotencyKey("3:7:v")
+	legit := NewCollectionScopedIdempotencyKey(7, "v")
+	require.NotEqual(t, crafted, legit)
+
+	// The same in the other direction: the crafted key cannot pose as cluster scope.
+	require.NotEqual(t, NewCollectionScopedIdempotencyKey(7, "1:0:v"), NewClusterScopedIdempotencyKey("v"))
+}
+
+// TestIdempotencyKeyClientKey covers what bounds and fingerprints are taken over:
+// the client's own bytes, never the scope this package prepended.
+func TestIdempotencyKeyClientKey(t *testing.T) {
+	require.Equal(t, "k", NewCollectionScopedIdempotencyKey(449988, "k").ClientKey())
+	require.Equal(t, "k", NewClusterScopedIdempotencyKey("k").ClientKey())
+
+	// A client key containing the separator round-trips whole.
+	require.Equal(t, "a:b:c", NewCollectionScopedIdempotencyKey(1, "a:b:c").ClientKey())
+
+	// A value this package did not produce has no recoverable client portion, so it
+	// is returned whole rather than reported as empty -- a bound taken over it must
+	// stay conservative.
+	require.Equal(t, "garbage", IdempotencyKey("garbage").ClientKey())
+}
+
+// TestZeroClientKeyNeverEncodesAScope guards the trap that would make every
+// keyless broadcast of one message type deduplicate against every other: an empty
+// client key must produce the zero key, not a non-empty scope prefix.
+func TestZeroClientKeyNeverEncodesAScope(t *testing.T) {
+	require.Empty(t, NewCollectionScopedIdempotencyKey(449988, ""))
+	require.Empty(t, NewDatabaseScopedIdempotencyKey(12, ""))
+	require.Empty(t, NewClusterScopedIdempotencyKey(""))
+}

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -17,6 +17,7 @@ const (
 	messageNotPersisteted                   = "_np"  // check if the message is unpersisted.
 	messagePChannelLevel                    = "_pcl" // mark the message as pchannel level message.
 	messageReplicateMesssageHeader          = "_rh"  // replicate message header.
+	messageIdempotencyKey                   = "_ik"  // scoped idempotency key of an idempotent write, see `IdempotencyKey`.
 )
 
 var (

--- a/pkg/streaming/util/types/responses.go
+++ b/pkg/streaming/util/types/responses.go
@@ -12,9 +12,34 @@ import (
 type BroadcastAppendResult struct {
 	BroadcastID   uint64                   // the broadcast id of the append operation.
 	AppendResults map[string]*AppendResult // make the channel name to the append result.
+
+	// Duplicated is non-nil when the broadcast was deduplicated by its idempotency
+	// key: no new broadcast task was created, and BroadcastID is the ID of the
+	// ORIGINAL broadcast. It carries the original broadcast message so the caller
+	// can recover its own response payload (the import jobID, for imports).
+	//
+	// AppendResults is filled in from the original broadcast's per-vchannel
+	// checkpoints and is never nil here: the duplicate path waits for the original's
+	// ack callback before answering, the same state a non-duplicate caller returns
+	// from, so a caller cannot tell a deduplicated broadcast from a fresh one. That
+	// wait is load-bearing, not politeness -- the original is not always serialized
+	// in front of this caller by a resource lock (a retry that raced a rename holds
+	// the stale name's lock; a task recovered from a replicated WAL holds none), and
+	// without it a duplicate could be answered from an original whose effects do not
+	// exist yet.
+	//
+	// Only the in-process broadcaster path fills this field. The gRPC client path
+	// (GRPCBroadcastServiceImpl.Broadcast) leaves it nil regardless of whether the
+	// broadcast was deduplicated, so it must not be read as "was not a duplicate"
+	// there.
+	Duplicated message.BroadcastMutableMessage
 }
 
 // GetAppendResult returns the append result of the given channel.
+//
+// A deduplicated broadcast returns the ORIGINAL broadcast's result for the
+// channel, so callers need no special handling for the duplicate path. It still
+// returns nil when the original had not finished being acked; see Duplicated.
 func (r *BroadcastAppendResult) GetAppendResult(channelName string) *AppendResult {
 	return r.AppendResults[channelName]
 }

--- a/pkg/streaming/util/types/responses_test.go
+++ b/pkg/streaming/util/types/responses_test.go
@@ -114,3 +114,11 @@ func TestAppendResponses_FillAllResponse(t *testing.T) {
 		assert.Equal(t, resp, r)
 	}
 }
+
+func TestBroadcastAppendResultDuplicated(t *testing.T) {
+	// A broadcast that was not deduplicated leaves Duplicated nil and keeps the
+	// existing lookup behavior unchanged.
+	fresh := &BroadcastAppendResult{BroadcastID: 1, AppendResults: map[string]*AppendResult{}}
+	assert.Nil(t, fresh.Duplicated)
+	assert.Nil(t, fresh.GetAppendResult("v1"))
+}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -63,8 +63,9 @@ const (
 
 	IdentifierKey = "identifier"
 
-	HeaderUserAgent = "user-agent"
-	HeaderDBName    = "dbName"
+	HeaderUserAgent      = "user-agent"
+	HeaderDBName         = "dbName"
+	HeaderIdempotencyKey = "idempotency-key"
 
 	RoleConfigPrivileges = "privileges"
 	RoleConfigObjectType = "object_type"

--- a/pkg/util/interceptor/idempotency_interceptor.go
+++ b/pkg/util/interceptor/idempotency_interceptor.go
@@ -1,0 +1,125 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptor
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// ValidateIdempotencyKey rejects a client-supplied key that cannot survive the
+// transport, or that exceeds streaming.idempotency.maxKeyLength.
+//
+// gRPC refuses a metadata value holding any byte outside printable ASCII, and it
+// does so before the stream exists, as codes.Internal. ClientBase reads that code
+// as a broken connection and answers it by retrying and periodically resetting the
+// shared client, so a key the HTTP layer happily accepts -- Go allows every byte
+// >= 0x80 in a header value -- turns one request into repeated teardowns of a
+// connection every caller on that proxy shares. Refusing the key at the door keeps
+// that out of the transport and names it as the parameter error it is.
+//
+// The length bound is enforced here and at the REST middleware, and nowhere else:
+// these are the only two doors a client key enters through, and both sit in front
+// of the copy that puts the key on every coordinator RPC of the request, so a check
+// any later would be measuring a key that has already crossed process boundaries
+// and been retained. The broadcaster deliberately re-checks nothing -- a second
+// bound behind these doors could only ever reject a key they had already admitted,
+// which for a retry inside its idempotency window means answering it with an error
+// instead of the original result.
+//
+// The bound is refreshable, so lowering it does reject in-window retries at these
+// doors. That is a property of the doors, not something a later check could undo.
+//
+// An absent key is valid: a request without one is simply not idempotent.
+func ValidateIdempotencyKey(key string) error {
+	if key == "" {
+		return nil
+	}
+	limit := paramtable.Get().StreamingCfg.IdempotencyMaxKeyLength.GetAsInt()
+	if len(key) > limit {
+		return merr.WrapErrParameterInvalidMsg(
+			"idempotency key length %d exceeds limit %d", len(key), limit)
+	}
+	for i := 0; i < len(key); i++ {
+		if key[i] < 0x20 || key[i] > 0x7E {
+			return merr.WrapErrParameterInvalidMsg(
+				"idempotency key must be printable ASCII, found byte %#x at offset %d", key[i], i)
+		}
+	}
+	return nil
+}
+
+// IdempotencyKeyFromContext returns the client-supplied idempotency key carried
+// in the gRPC incoming metadata, or "" when the request carries none.
+//
+// Read at the RPC entrypoint rather than in a dedicated server interceptor,
+// matching how the db name is handled: the entrypoint already owns the incoming
+// metadata, so an extra interceptor would only add a hop.
+func IdempotencyKeyFromContext(ctx context.Context) string {
+	// ValueFromIncomingContext, not FromIncomingContext: the latter copies the
+	// whole incoming metadata -- one map plus one []string per entry -- and this
+	// runs on every outgoing unary RPC through
+	// IdempotencyKeyPropagationUnaryClientInterceptor, i.e. on the cluster's
+	// hottest path, almost always to learn the key is absent. The lookup below
+	// allocates only when it matches.
+	//
+	// util.HeaderIdempotencyKey is already lowercase, which is the form gRPC
+	// normalizes metadata keys to, so the exact-key hit carries it; the
+	// EqualFold fallback inside covers metadata that was not built through the
+	// helpers, which is what the copy-and-lower above used to cover.
+	values := metadata.ValueFromIncomingContext(ctx, util.HeaderIdempotencyKey)
+	if len(values) < 1 {
+		return ""
+	}
+	return values[0]
+}
+
+// IdempotencyKeyPropagationUnaryClientInterceptor returns a new unary client
+// interceptor that copies the idempotency key of the incoming request onto the
+// outgoing context, so an idempotent API needs no request field of its own to
+// carry the key across a component hop.
+//
+// A request without a key is left untouched: every RPC in the cluster goes
+// through this chain, and an empty metadata value is not the same as an absent
+// one for the components that read it.
+//
+// This covers the clients built on grpcclient.ClientBase — the coordinator and
+// node clients. The streaming clients maintain their own interceptor chains and
+// are deliberately not covered: a coordinator reaches the broadcaster in-process,
+// and from there the key travels as the `_ik` message property rather than as
+// metadata.
+func IdempotencyKeyPropagationUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if key := IdempotencyKeyFromContext(ctx); key != "" {
+			// The gRPC ingress has no middleware of its own, so this is where a key
+			// that did not come through the REST door is first seen. Fail the call
+			// rather than forward it: forwarding is what turns a bad key into a
+			// transport-level codes.Internal and a connection reset.
+			if err := ValidateIdempotencyKey(key); err != nil {
+				return err
+			}
+			ctx = metadata.AppendToOutgoingContext(ctx, util.HeaderIdempotencyKey, key)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}

--- a/pkg/util/interceptor/idempotency_interceptor_test.go
+++ b/pkg/util/interceptor/idempotency_interceptor_test.go
@@ -1,0 +1,154 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestIdempotencyKeyFromContext(t *testing.T) {
+	assert.Equal(t, "", IdempotencyKeyFromContext(context.Background()))
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(make(map[string]string)))
+	assert.Equal(t, "", IdempotencyKeyFromContext(ctx))
+
+	ctx = metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(util.HeaderIdempotencyKey, "run-1-batch-1"))
+	assert.Equal(t, "run-1-batch-1", IdempotencyKeyFromContext(ctx))
+
+	// gRPC normalizes metadata keys to lower case, so a differently-cased header
+	// from the client still resolves.
+	ctx = metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("Idempotency-Key", "run-1-batch-2"))
+	assert.Equal(t, "run-1-batch-2", IdempotencyKeyFromContext(ctx))
+}
+
+func TestIdempotencyKeyPropagationUnaryClientInterceptor(t *testing.T) {
+	method := "MockMethod"
+	req := &milvuspb.InsertRequest{}
+	interceptor := IdempotencyKeyPropagationUnaryClientInterceptor()
+
+	invokeWith := func(ctx context.Context) metadata.MD {
+		var forwarded metadata.MD
+		invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			forwarded, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		}
+		assert.NoError(t, interceptor(ctx, method, req, nil, nil, invoker))
+		return forwarded
+	}
+
+	t.Run("key present is forwarded exactly once", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(),
+			metadata.Pairs(util.HeaderIdempotencyKey, "run-1-batch-1"))
+		md := invokeWith(ctx)
+		assert.Equal(t, []string{"run-1-batch-1"}, md.Get(util.HeaderIdempotencyKey))
+	})
+
+	t.Run("no key leaves the outgoing metadata without the header", func(t *testing.T) {
+		// An empty value is not the same as an absent one downstream, so the
+		// header must genuinely not be there.
+		md := invokeWith(metadata.NewOutgoingContext(context.Background(),
+			metadata.Pairs("existing", "value")))
+		assert.Empty(t, md.Get(util.HeaderIdempotencyKey))
+		_, ok := md[util.HeaderIdempotencyKey]
+		assert.False(t, ok)
+		assert.Equal(t, []string{"value"}, md.Get("existing"))
+	})
+
+	t.Run("existing outgoing metadata is preserved", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(),
+			metadata.Pairs(util.HeaderIdempotencyKey, "run-1-batch-1"))
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("existing", "value"))
+		md := invokeWith(ctx)
+		assert.Equal(t, []string{"run-1-batch-1"}, md.Get(util.HeaderIdempotencyKey))
+		assert.Equal(t, []string{"value"}, md.Get("existing"))
+	})
+}
+
+// TestValidateIdempotencyKey covers the door the adversarial review on milvus#52544
+// found open: Go accepts header bytes >= 0x80, gRPC rejects everything outside
+// printable ASCII as codes.Internal, and ClientBase answers that code by resetting
+// the connection every caller on the proxy shares.
+func TestValidateIdempotencyKey(t *testing.T) {
+	paramtable.Init()
+	limit := paramtable.Get().StreamingCfg.IdempotencyMaxKeyLength.GetAsInt()
+
+	t.Run("absent key is valid", func(t *testing.T) {
+		assert.NoError(t, ValidateIdempotencyKey(""))
+	})
+
+	t.Run("printable ASCII is valid", func(t *testing.T) {
+		assert.NoError(t, ValidateIdempotencyKey("run-1/batch_2.a~b c"))
+		// The range is inclusive at both ends.
+		assert.NoError(t, ValidateIdempotencyKey("\x20\x7e"))
+	})
+
+	t.Run("non-ASCII is rejected", func(t *testing.T) {
+		// The exact value grpc-go would fail the stream on.
+		err := ValidateIdempotencyKey("批次-1")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "printable ASCII")
+	})
+
+	t.Run("control bytes are rejected", func(t *testing.T) {
+		// HTAB passes net/textproto but not grpc-go.
+		assert.ErrorIs(t, ValidateIdempotencyKey("run\t1"), merr.ErrParameterInvalid)
+		assert.ErrorIs(t, ValidateIdempotencyKey("run\n1"), merr.ErrParameterInvalid)
+	})
+
+	t.Run("oversized key is rejected at the door", func(t *testing.T) {
+		assert.NoError(t, ValidateIdempotencyKey(strings.Repeat("a", limit)))
+		err := ValidateIdempotencyKey(strings.Repeat("a", limit+1))
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "exceeds limit")
+	})
+}
+
+// TestIdempotencyKeyPropagationRejectsInvalidKey pins the gRPC ingress door: a key
+// that did not come through the REST middleware must fail the call here rather than
+// be forwarded, since forwarding is what produces the transport-level failure.
+func TestIdempotencyKeyPropagationRejectsInvalidKey(t *testing.T) {
+	paramtable.Init()
+
+	invoked := false
+	invoker := func(ctx context.Context, method string, req, reply interface{},
+		cc *grpc.ClientConn, opts ...grpc.CallOption,
+	) error {
+		invoked = true
+		return nil
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(util.HeaderIdempotencyKey, "批次-1"))
+	err := IdempotencyKeyPropagationUnaryClientInterceptor()(
+		ctx, "/milvus.proto.data.DataCoord/ImportV2", nil, nil, nil, invoker)
+
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.False(t, invoked, "the call must not reach the transport")
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6137,10 +6137,26 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.FilesPerPreImportTask.Init(base.mgr)
 
 	p.ImportTaskRetention = ParamItem{
-		Key:          "dataCoord.import.taskRetention",
-		Version:      "2.4.0",
-		Doc:          "The retention period in seconds for tasks in the Completed or Failed state.",
-		DefaultValue: "10800",
+		Key:     "dataCoord.import.taskRetention",
+		Version: "2.4.0",
+		Doc: `The retention period in seconds for tasks in the Completed or Failed state.
+Nothing else bounds the terminal set -- maxImportJobNum counts only jobs that are
+neither Completed nor Failed -- so this value alone decides how many finished
+importJob entries stay in etcd, each carrying its schema, file list and options
+plus every preimport and import task under it.
+The 48h default exists for BulkImport idempotency and only for it: the idempotency
+window is bounded by streaming.walBroadcaster.tombstone.maxLifetime, so a job GC'd
+earlier than its tombstone lets an in-window retry resolve to a jobID that
+GetImportProgress can no longer find. Keep this at >= 2x that lifetime for as long
+as clients send an Idempotency-Key. Twice rather than equal because a tombstone's
+age is measured from the last StreamingCoord start: every restart extends its
+remaining life by up to another maxLifetime, while this retention keeps counting
+from the job's own completion. Equal values hold only for a window with no restart,
+which is not a property a default may assume. Raise it further if StreamingCoord
+restarts more than once inside one tombstone lifetime.
+A cluster whose clients never send an Idempotency-Key is under no such requirement
+and can lower this freely; 10800 was the default before idempotency keys existed.`,
+		DefaultValue: "172800",
 		PanicIfEmpty: false,
 		Export:       true,
 	}
@@ -7079,6 +7095,9 @@ type streamingConfig struct {
 	WALBroadcasterTombstoneMaxCount      ParamItem `refreshable:"true"`
 	WALBroadcasterTombstoneMaxLifetime   ParamItem `refreshable:"true"`
 
+	// idempotency
+	IdempotencyMaxKeyLength ParamItem `refreshable:"true"`
+
 	// txn
 	TxnDefaultKeepaliveTimeout ParamItem `refreshable:"true"`
 
@@ -7360,6 +7379,19 @@ too few tombstones may lead to ABA issues in the state of milvus cluster.`,
 		Export:       false,
 	}
 	p.WALBroadcasterTombstoneMaxLifetime.Init(base.mgr)
+
+	p.IdempotencyMaxKeyLength = ParamItem{
+		Key:     "streaming.idempotency.maxKeyLength",
+		Version: "2.6.6",
+		Doc: `The max length in bytes of a client-supplied idempotency key, 256 by default.
+The key is stored in the message properties of every write it guards, so an
+oversized key inflates both the WAL entry and the in-memory dedup index.
+A value of 0 rejects every non-empty key, disabling idempotency keys entirely;
+requests that carry no key are accepted at any value.`,
+		DefaultValue: "256",
+		Export:       false,
+	}
+	p.IdempotencyMaxKeyLength.Init(base.mgr)
 
 	// txn
 	p.TxnDefaultKeepaliveTimeout = ParamItem{

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -616,7 +616,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 10, Params.CheckAutoBalanceConfigInterval.GetAsInt())
 		assert.Equal(t, false, Params.AutoUpgradeSegmentIndex.GetAsBool())
 		assert.Equal(t, 2, Params.FilesPerPreImportTask.GetAsInt())
-		assert.Equal(t, 10800*time.Second, Params.ImportTaskRetention.GetAsDuration(time.Second))
+		assert.Equal(t, 172800*time.Second, Params.ImportTaskRetention.GetAsDuration(time.Second))
 		assert.Equal(t, 16384, Params.MaxSizeInMBPerImportTask.GetAsInt())
 		assert.Equal(t, 2*time.Second, Params.ImportScheduleInterval.GetAsDuration(time.Second))
 		assert.Equal(t, 2*time.Second, Params.ImportCheckIntervalHigh.GetAsDuration(time.Second))
@@ -1004,4 +1004,26 @@ func TestQueryNodeMaxLoadingMemoryRatio(t *testing.T) {
 
 	params.Save(item.Key, "1.1")
 	assert.InDelta(t, 1.0, item.GetAsFloat(), 0.0001)
+}
+
+func TestImportIdempotencyParams(t *testing.T) {
+	params := ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+
+	assert.Equal(t, 256, params.StreamingCfg.IdempotencyMaxKeyLength.GetAsInt())
+
+	// The advertised idempotency window is the tombstone retention, so an import
+	// job must outlive its tombstone. Otherwise a retry inside the window resolves
+	// to a jobID GetImportProgress can no longer find.
+	assert.Equal(t, 172800, params.DataCoordCfg.ImportTaskRetention.GetAsInt())
+
+	// Headroom, not equality. A tombstone's age is measured from the last
+	// StreamingCoord start, so a restart extends its remaining life by up to another
+	// maxLifetime while this retention keeps counting from the job's own completion.
+	// Equal defaults satisfy the >= above yet break on the first restart, which is
+	// how adversarial review on milvus#52544 found this; one restart per tombstone
+	// lifetime is what the 2x covers.
+	assert.GreaterOrEqual(t,
+		params.DataCoordCfg.ImportTaskRetention.GetAsDuration(time.Second),
+		2*params.StreamingCfg.WALBroadcasterTombstoneMaxLifetime.GetAsDurationByParse())
 }

--- a/tests/integration/import/idempotency_test.go
+++ b/tests/integration/import/idempotency_test.go
@@ -1,0 +1,240 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/tests/integration"
+)
+
+// IdempotencySuite covers the client-visible contract of an idempotent BulkImport
+// end to end: the key travels as gRPC metadata from the client, through the proxy
+// and DataCoord, into the broadcast message property, and is deduplicated by the
+// StreamingCoord broadcaster.
+//
+// The unit tests prove each hop in isolation. Only these tests prove the hops are
+// actually connected: a key dropped anywhere along the way leaves every unit test
+// green while silently disabling deduplication.
+type IdempotencySuite struct {
+	integration.MiniClusterSuite
+}
+
+// withIdempotencyKey attaches the key the way a real client does — as outgoing
+// gRPC metadata, which the proxy reads back as incoming metadata.
+func withIdempotencyKey(ctx context.Context, key string) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, util.HeaderIdempotencyKey, key)
+}
+
+func (s *IdempotencySuite) createCollection(ctx context.Context, name string) *schemapb.CollectionSchema {
+	schema := integration.ConstructSchema(name, dim, false)
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	status, err := s.Cluster.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		CollectionName: name,
+		Schema:         marshaledSchema,
+		ShardsNum:      common.DefaultShardsNum,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, status.GetErrorCode())
+	return schema
+}
+
+// countRows runs a Strong-consistency count(*), which is what makes a duplicated
+// import observable: a second job would double the row count.
+func (s *IdempotencySuite) countRows(ctx context.Context, collectionName string) int {
+	c := s.Cluster
+
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(dim, "HNSW", "L2"),
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, createIndexStatus.GetErrorCode())
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, loadStatus.GetErrorCode())
+	s.WaitForLoad(ctx, collectionName)
+
+	queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+		CollectionName:   collectionName,
+		Expr:             integration.Int64Field + " >= 0",
+		OutputFields:     []string{"count(*)"},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+	s.NoError(merr.CheckRPCCall(queryResult, err))
+	return int(queryResult.GetFieldsData()[0].GetScalars().GetLongData().GetData()[0])
+}
+
+// TestImport_SameKeyImportsOnce is the core end-to-end guarantee: an orchestrator
+// that retries after losing the response gets the ORIGINAL jobID back and the data
+// is imported exactly once.
+func (s *IdempotencySuite) TestImport_SameKeyImportsOnce() {
+	const rowCount = 100
+
+	c := s.Cluster
+	ctx, cancel := context.WithTimeout(c.GetContext(), 300*time.Second)
+	defer cancel()
+
+	collectionName := "TestImportIdem_" + funcutil.RandomString(8)
+	schema := s.createCollection(ctx, collectionName)
+
+	filePath, err := GenerateParquetFile(c, schema, rowCount)
+	s.NoError(err)
+
+	req := &internalpb.ImportRequest{
+		CollectionName: collectionName,
+		Files:          []*internalpb.ImportFile{{Paths: []string{filePath}}},
+	}
+	keyedCtx := withIdempotencyKey(ctx, "run-1-batch-1-"+funcutil.RandomString(8))
+
+	first, err := c.ProxyClient.ImportV2(keyedCtx, req)
+	s.NoError(err)
+	s.Equal(int32(0), first.GetStatus().GetCode())
+	s.NotEmpty(first.GetJobID())
+
+	// The retry an orchestrator issues after it crashed before persisting the jobID.
+	second, err := c.ProxyClient.ImportV2(keyedCtx, req)
+	s.NoError(err)
+	s.Equal(int32(0), second.GetStatus().GetCode())
+	s.Equal(first.GetJobID(), second.GetJobID(),
+		"a retry carrying the same idempotency key must resolve to the original job")
+
+	s.NoError(WaitForImportDone(ctx, c, first.GetJobID()))
+
+	// The assertion that actually rules out a duplicate import: one job's worth of rows.
+	s.Equal(rowCount, s.countRows(ctx, collectionName),
+		"the retried import must not have written a second copy of the data")
+}
+
+// TestImport_DifferentKeysCreateDistinctJobs is the negative control for the test
+// above: without it, an implementation that returned the first job for EVERY
+// request would pass the same-key assertions.
+func (s *IdempotencySuite) TestImport_DifferentKeysCreateDistinctJobs() {
+	const rowCount = 10
+
+	c := s.Cluster
+	ctx, cancel := context.WithTimeout(c.GetContext(), 300*time.Second)
+	defer cancel()
+
+	collectionName := "TestImportIdemDistinct_" + funcutil.RandomString(8)
+	schema := s.createCollection(ctx, collectionName)
+
+	filePath, err := GenerateParquetFile(c, schema, rowCount)
+	s.NoError(err)
+
+	req := &internalpb.ImportRequest{
+		CollectionName: collectionName,
+		Files:          []*internalpb.ImportFile{{Paths: []string{filePath}}},
+	}
+	suffix := funcutil.RandomString(8)
+
+	first, err := c.ProxyClient.ImportV2(withIdempotencyKey(ctx, "key-a-"+suffix), req)
+	s.NoError(err)
+	s.Equal(int32(0), first.GetStatus().GetCode())
+
+	second, err := c.ProxyClient.ImportV2(withIdempotencyKey(ctx, "key-b-"+suffix), req)
+	s.NoError(err)
+	s.Equal(int32(0), second.GetStatus().GetCode())
+
+	s.NotEqual(first.GetJobID(), second.GetJobID(),
+		"distinct idempotency keys are distinct logical requests and must get distinct jobs")
+
+	s.NoError(WaitForImportDone(ctx, c, first.GetJobID()))
+	s.NoError(WaitForImportDone(ctx, c, second.GetJobID()))
+}
+
+// TestImport_SameKeyAfterRenameImportsOnce is what scoping the key by collection ID
+// rather than by collection name buys, end to end.
+//
+// The scope is the collection's identity, so a key stays bound to the same
+// collection across a RenameCollection. A name-scoped key would miss here and
+// import the same files a second time. Note what the retry has to carry: the
+// collection's CURRENT name. The proxy resolves the request's collection name
+// through its meta cache before any of this is reached, so a replay still naming
+// the old collection fails there with collection-not-found -- safely, with no
+// second import, but without recovering the original jobID.
+func (s *IdempotencySuite) TestImport_SameKeyAfterRenameImportsOnce() {
+	const rowCount = 100
+
+	c := s.Cluster
+	ctx, cancel := context.WithTimeout(c.GetContext(), 300*time.Second)
+	defer cancel()
+
+	suffix := funcutil.RandomString(8)
+	collectionName := "TestImportIdemRename_" + suffix
+	renamedName := "TestImportIdemRenamed_" + suffix
+	schema := s.createCollection(ctx, collectionName)
+
+	filePath, err := GenerateParquetFile(c, schema, rowCount)
+	s.NoError(err)
+
+	keyedCtx := withIdempotencyKey(ctx, "run-1-batch-1-"+suffix)
+	first, err := c.ProxyClient.ImportV2(keyedCtx, &internalpb.ImportRequest{
+		CollectionName: collectionName,
+		Files:          []*internalpb.ImportFile{{Paths: []string{filePath}}},
+	})
+	s.NoError(err)
+	s.Equal(int32(0), first.GetStatus().GetCode())
+	s.NotEmpty(first.GetJobID())
+
+	renameStatus, err := c.MilvusClient.RenameCollection(ctx, &milvuspb.RenameCollectionRequest{
+		OldName: collectionName,
+		NewName: renamedName,
+	})
+	s.NoError(merr.CheckRPCCall(renameStatus, err))
+
+	// The same logical request, retried under the collection's new name.
+	second, err := c.ProxyClient.ImportV2(keyedCtx, &internalpb.ImportRequest{
+		CollectionName: renamedName,
+		Files:          []*internalpb.ImportFile{{Paths: []string{filePath}}},
+	})
+	s.NoError(err)
+	s.Equal(int32(0), second.GetStatus().GetCode())
+	s.Equal(first.GetJobID(), second.GetJobID(),
+		"the key is scoped to the collection id, so a rename must not turn a retry into a new job")
+
+	s.NoError(WaitForImportDone(ctx, c, first.GetJobID()))
+
+	s.Equal(rowCount, s.countRows(ctx, renamedName),
+		"the retry issued after the rename must not have written a second copy of the data")
+}
+
+func TestIdempotencySuite(t *testing.T) {
+	suite.Run(t, new(IdempotencySuite))
+}


### PR DESCRIPTION
Cherry-pick from master

pr: #52544
issue: #50954

## Summary

Manual port of master PR #52544 (merged) to 2.6. The 2.6 branch is on the `pkg/v2` module and lacks several master commits this PR was written against, so a plain cherry-pick conflicted in 14 files. 22 of the 31 files are line-for-line identical to the master diff modulo the module path; the rest are adapted to 2.6's shape as listed below. Behaviour is the same.

## Differences from the master diff

- `pkg/v3` → `pkg/v2` and `go-api/v3` → `go-api/v2` import paths everywhere; `mlog` calls rewritten to `log` + zap.
- `broadcaster_with_rk.go` is left as on 2.6 (no #50796 trace propagation); the broadcast header stamp is done in `broadcastTaskManager.broadcast` after the lifetime check, before `getOrAddBroadcastTask`, still outside the manager lock.
- `ddl_callbacks_import.go` / `services.go`: ported onto the 2.6 bodies of `broadcastImport` and `ImportV2`, without the per-file PK range block (#51825) and the under-lock replication re-check (#50164) that 2.6 does not have; `merr.CheckRPCCall(coll.Status, err)` keeps the 2.6 signature.
- proxy tests use `globalMetaCache`, `databaseInfo{dbID:}` and the in-package `NewMockChannelsMgr` / `getVChannels`.
- `broadcaster_with_rk_guards_test.go` asserts the error is not a shutdown error instead of using `IsBroadcastTaskNotCreated`, which 2.6 lacks.
- `import_services_test.go` / `handler_v2_test.go` carry two test constants and one import the 2.6 files did not have.
- `properties.go` adds only `_ik`; the two `docs/agent_guides` files do not exist on 2.6 and are dropped.

## Verification

- [x] `go vet` on all 12 touched packages
- [x] Unit tests: the 15 tests added in `broadcaster/` plus `TestBroadcaster`; httpserver (7), proxy import tasks, datacoord import callbacks/services (48), and the four `pkg/` packages
- [x] `tests/integration/import` idempotency suite (3 cases) against real `bin/milvus` processes on 2.6 — all pass, with `import request resolved to an existing job` observed twice in datacoord logs, i.e. the dedup path was exercised
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

Note: `TestResourceKeyLocker/deadlock_prevention` fails on a clean 2.6 checkout as well when the whole package runs, and passes alone; this PR does not touch `resource_key_locker.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiydbgqqCdNu5vGQThy6v5


---

Also folds in master PR #53313 (`test: pin tombstone GC window in broadcaster idempotency tests`), so `TestConcurrentSameKeyBroadcastsCreateExactlyOneTask` does not arrive on this branch with the known flake.
