### PR TITLE
fix: bound WAL close chain so RemoveWAL cannot stall StreamingNode shutdown

### DIFF
--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -2,6 +2,7 @@ package flusherimpl
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -158,7 +159,17 @@ func (impl *WALFlusherImpl) notifyFatal(err error) error {
 // Close closes the wal flusher and release all related resources for it.
 func (impl *WALFlusherImpl) Close() {
 	impl.notifier.Cancel()
-	impl.notifier.BlockUntilFinish()
+	// Bound the wait for the flusher loop. The loop normally exits right after
+	// the context is canceled, but it may be stuck inside a dispatch that
+	// blocks on an external call (e.g. a hung object-storage flush). Do not
+	// let that stall the WAL close chain forever.
+	gracefulCloseTimeout := paramtable.Get().StreamingCfg.WALCloseGracefulTimeout.GetAsDurationByParse()
+	select {
+	case <-impl.notifier.FinishChan():
+	case <-time.After(gracefulCloseTimeout):
+		impl.logger.Warn(context.TODO(), "wal flusher close timeout, abandon wait for flusher loop to finish",
+			mlog.Duration("timeout", gracefulCloseTimeout))
+	}
 
 	impl.logger.Info(context.TODO(), "wal flusher start to close the recovery storage...")
 	impl.RecoveryStorage.Close()

--- a/internal/streamingnode/server/walmanager/manager_impl.go
+++ b/internal/streamingnode/server/walmanager/manager_impl.go
@@ -141,15 +141,18 @@ func (m *managerImpl) Metrics() (*types.StreamingNodeMetrics, error) {
 
 // Close these manager and release all managed WAL.
 func (m *managerImpl) Close() {
-	m.lifetime.SetState(managerRemoveable)
+	// Reject all operations (including Remove) right away, so a RemoveWAL that
+	// arrives during shutdown fails fast instead of being accepted and waiting
+	// on the wal lifetime background task. The wait below only covers the
+	// operations that were already in flight; with a bounded WAL close chain
+	// those converge within the graceful close timeout.
+	m.lifetime.SetState(managerStopped)
 	m.lifetime.Wait()
 	// close all underlying walLifetime.
 	m.wltMap.Range(func(channel string, wlt *walLifetime) bool {
 		wlt.Close()
 		return true
 	})
-	m.lifetime.SetState(managerStopped)
-	m.lifetime.Wait()
 
 	// close all underlying wal instance by allocator if there's resource leak.
 	m.opener.Close()

--- a/internal/streamingnode/server/walmanager/manager_impl_test.go
+++ b/internal/streamingnode/server/walmanager/manager_impl_test.go
@@ -3,7 +3,9 @@ package walmanager
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -144,4 +146,73 @@ func assertShutdownError(t *testing.T, err error) {
 	assert.Error(t, err)
 	e := status.AsStreamingError(err)
 	assert.Equal(t, e.Code, streamingpb.StreamingCode_STREAMING_CODE_ON_SHUTDOWN)
+}
+
+// TestManagerCloseRejectsRemoveDuringClose verifies that a RemoveWAL arriving
+// while the manager is closing fails fast with a shutdown error, instead of
+// being accepted and waiting on a stuck wal lifetime background task.
+// Regression test for https://github.com/milvus-io/milvus/issues/53237.
+func TestManagerCloseRejectsRemoveDuringClose(t *testing.T) {
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+	)
+
+	// The first open blocks until the gate is released, so Close() has to
+	// wait for an in-flight Open operation.
+	enteredOpen := make(chan struct{})
+	openGate := make(chan struct{})
+	opener := mock_wal.NewMockOpener(t)
+	opener.EXPECT().Open(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, oo *wal.OpenOption) (wal.WAL, error) {
+			close(enteredOpen)
+			<-openGate
+			l := mock_wal.NewMockWAL(t)
+			l.EXPECT().Channel().Return(oo.Channel)
+			l.EXPECT().Close().Return()
+			return l, nil
+		})
+	opener.EXPECT().Close().Return()
+
+	m := newManager(opener)
+
+	// Start an Open and wait until it is in-flight (holding the manager
+	// lifetime and blocking the wal lifetime background task).
+	openDone := make(chan error, 1)
+	go func() { openDone <- m.Open(context.Background(), types.PChannelInfo{Name: "ch1", Term: 1}) }()
+	<-enteredOpen
+
+	// Start closing; Close() now must wait for the in-flight Open.
+	closeDone := make(chan struct{})
+	go func() { m.Close(); close(closeDone) }()
+
+	// While the manager is closing, RemoveWAL must be rejected immediately.
+	// Calls that race ahead of the close use a canceled context and return
+	// context.Canceled without blocking; once the closing state is set they
+	// return the shutdown error.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("manager Close did not reject RemoveWAL in time")
+		default:
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := m.Remove(ctx, types.PChannelInfo{Name: "ch2", Term: 1})
+		if err != nil && status.AsStreamingError(err).Code == streamingpb.StreamingCode_STREAMING_CODE_ON_SHUTDOWN {
+			break
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected error while manager is closing: %v", err)
+		}
+	}
+
+	// Release the stuck open so Close() can finish.
+	close(openGate)
+	assert.NoError(t, <-openDone)
+	<-closeDone
 }

--- a/internal/util/flowgraph/flow_graph.go
+++ b/internal/util/flowgraph/flow_graph.go
@@ -24,7 +24,9 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // Flow Graph is no longer a graph rather than a simple pipeline, this simplified our code and increase recovery speed - xiaofan.
@@ -38,6 +40,13 @@ type TimeTickedFlowGraph struct {
 	startOnce       sync.Once
 	closeWg         *sync.WaitGroup
 	closeGracefully *atomic.Bool
+
+	// closeDrainTimeout bounds the graceful drain of Close(): the single
+	// pipeline goroutine may be blocked on an external call (e.g. object
+	// storage) that neither completes nor returns an error promptly. After
+	// the timeout the drain is abandoned so a hung call cannot stall the
+	// caller (WAL close / shutdown) forever.
+	closeDrainTimeout time.Duration
 }
 
 // AddNode add Node into flowgraph and fill nodeCtxManager
@@ -121,7 +130,23 @@ func (fg *TimeTickedFlowGraph) Close() {
 				v.Close()
 			}
 		}
-		fg.closeWg.Wait()
+		// Bound the graceful drain. The whole pipeline runs in one goroutine;
+		// if a node is stuck in an external call (e.g. a hung object-storage
+		// flush) the close message cannot propagate and the wait would block
+		// forever. Abandoning the wait is safe: the stuck goroutine owns the
+		// close propagation itself, so once the external call returns it
+		// finishes the drain and exits without touching closed channels.
+		waitDone := make(chan struct{})
+		go func() {
+			fg.closeWg.Wait()
+			close(waitDone)
+		}()
+		select {
+		case <-waitDone:
+		case <-time.After(fg.closeDrainTimeout):
+			mlog.Warn(context.TODO(), "flow graph close drain timeout, abandon wait for pipeline to finish",
+				mlog.Duration("timeout", fg.closeDrainTimeout))
+		}
 
 		// free some source after all node close.
 		// such as function.
@@ -148,6 +173,8 @@ func NewTimeTickedFlowGraph(ctx context.Context) *TimeTickedFlowGraph {
 		nodeCtxManager:  &nodeCtxManager{lastAccessTime: atomic.NewTime(time.Now())},
 		closeWg:         &sync.WaitGroup{},
 		closeGracefully: atomic.NewBool(CloseImmediately),
+		closeDrainTimeout: paramtable.Get().StreamingCfg.WALCloseGracefulTimeout.
+			GetAsDurationByParse(),
 	}
 
 	return &flowGraph

--- a/internal/util/flowgraph/flow_graph_test.go
+++ b/internal/util/flowgraph/flow_graph_test.go
@@ -227,6 +227,72 @@ func TestTimeTickedFlowGraph_Close(t *testing.T) {
 	fg.Close()
 }
 
+// nodeBlocking simulates a pipeline node stuck in an external call (e.g. a
+// hung object-storage flush): its Operate blocks until releaseCh is closed.
+type nodeBlocking struct {
+	BaseNode
+	releaseCh chan struct{}
+}
+
+func (n *nodeBlocking) Name() string { return "NodeBlocking" }
+
+func (n *nodeBlocking) Operate(in []Msg) []Msg {
+	<-n.releaseCh
+	return nil
+}
+
+// TestTimeTickedFlowGraph_CloseBoundedWhenNodeBlocked verifies that Close()
+// returns within a bounded time even when a node in the pipeline is blocked
+// on an external call that never completes. Regression test for
+// https://github.com/milvus-io/milvus/issues/53237: an unbounded drain here
+// stalled the WAL close chain (and thus RemoveWAL / StreamingNode shutdown)
+// until the balancer operation timeout.
+func TestTimeTickedFlowGraph_CloseBoundedWhenNodeBlocked(t *testing.T) {
+	const MaxQueueLength = 1024
+	const drainTimeout = 200 * time.Millisecond
+
+	inputChan := make(chan float64, MaxQueueLength)
+	releaseCh := make(chan struct{})
+
+	fg := NewTimeTickedFlowGraph(context.Background())
+	// Use a short drain timeout so the test stays fast.
+	fg.closeDrainTimeout = drainTimeout
+
+	var a Node = &nodeA{
+		InputNode: InputNode{
+			BaseNode: BaseNode{
+				maxQueueLength: MaxQueueLength,
+			},
+		},
+		inputChan: inputChan,
+	}
+	var b Node = &nodeBlocking{
+		BaseNode: BaseNode{
+			maxQueueLength: MaxQueueLength,
+		},
+		releaseCh: releaseCh,
+	}
+
+	fg.AddNode(a)
+	fg.AddNode(b)
+	assert.NoError(t, fg.SetEdges(a.Name(), []string{b.Name()}))
+
+	fg.Start()
+	// Feed a message so the pipeline goroutine enters the blocking node and
+	// stays stuck until releaseCh is closed.
+	inputChan <- 1
+
+	start := time.Now()
+	fg.Close()
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, drainTimeout*5,
+		"Close() must be bounded even when a node is blocked on a hung external call")
+
+	// Release the blocked node; the pipeline goroutine then exits by itself
+	// (or stays idle waiting for input) without panicking.
+	close(releaseCh)
+}
+
 func TestBlockAll(t *testing.T) {
 	fg := NewTimeTickedFlowGraph(context.Background())
 	fg.AddNode(&nodeA{})

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -8471,6 +8471,12 @@ type streamingConfig struct {
 	WALRecoveryGracefulCloseTimeout      ParamItem `refreshable:"true"`
 	WALRecoverySchemaExpirationTolerance ParamItem `refreshable:"true"`
 
+	// wal close configuration.
+	// WALCloseGracefulTimeout bounds the graceful drain of the flowgraph
+	// (and the flusher loop wait) during WAL close, so a hung object-storage
+	// call cannot stall walLifetime.Close() / walManager.Close() / RemoveWAL.
+	WALCloseGracefulTimeout ParamItem `refreshable:"true"`
+
 	// wal rate limit
 	WALRateLimitDefaultBurst                     ParamItem `refreshable:"true"`
 	WALRateLimitNodeMemorySlowdownThreshold      ParamItem `refreshable:"true"`
@@ -8917,6 +8923,19 @@ If that persist operation exceeds this timeout, the wal recovery module will clo
 		Export:       true,
 	}
 	p.WALRecoveryGracefulCloseTimeout.Init(base.mgr)
+
+	p.WALCloseGracefulTimeout = ParamItem{
+		Key:     "streaming.walClose.gracefulTimeout",
+		Version: "3.0.0",
+		Doc: `The graceful close timeout of the wal close chain, 10s by default.
+When the wal is on-closing, the flusher/flowgraph drain tries to flush the in-flight data first.
+If a downstream call (e.g. object storage) neither completes nor returns an error promptly,
+the close chain abandons the drain after this timeout so that RemoveWAL and StreamingNode
+shutdown stay bounded instead of blocking until the balancer operation timeout (30m by default).`,
+		DefaultValue: "10s",
+		Export:       true,
+	}
+	p.WALCloseGracefulTimeout.Init(base.mgr)
 
 	p.WALRecoverySchemaExpirationTolerance = ParamItem{
 		Key:     "streaming.walRecovery.schemaExpirationTolerance",


### PR DESCRIPTION
issue: #53237

- flowgraph: bound the graceful drain of `TimeTickedFlowGraph.Close` so a hung object-storage call cannot stall the WAL close chain
- wal flusher: bound the wait for the flusher loop in `WALFlusherImpl.Close` as a backstop
- wal manager: reject RemoveWAL immediately once the manager starts closing, so StreamingNode shutdown is not blocked on an in-flight RemoveWAL
- config: add `streaming.walClose.gracefulTimeout` (default 10s) to drive the new close bounds