### PR TITLE
enhance: [cp 2.6] optimize array_contains single-target with direct typed comparison

### DIFF
--- a/internal/core/src/exec/expression/ExprArrayTest.cpp
+++ b/internal/core/src/exec/expression/ExprArrayTest.cpp
@@ -1336,6 +1336,8 @@ TEST(Expr, TestArrayContainsFloatLiteralCastsToElementType) {
         array_value);
     expect_only_first_match(std::make_shared<plan::FilterBitsNode>(
         DEFAULT_PLANNODE_ID, array_expr));
+}
+
 // Behavior coverage for ExecArrayContains across single- and multi-target
 // invocations and across INT64 / VARCHAR element types. Exercises the typed
 // cached set path (no MultiElement / variant round-trip).

--- a/internal/core/src/exec/expression/ExprArrayTest.cpp
+++ b/internal/core/src/exec/expression/ExprArrayTest.cpp
@@ -1336,6 +1336,214 @@ TEST(Expr, TestArrayContainsFloatLiteralCastsToElementType) {
         array_value);
     expect_only_first_match(std::make_shared<plan::FilterBitsNode>(
         DEFAULT_PLANNODE_ID, array_expr));
+// Behavior coverage for ExecArrayContains across single- and multi-target
+// invocations and across INT64 / VARCHAR element types. Exercises the typed
+// cached set path (no MultiElement / variant round-trip).
+TEST(Expr, TestArrayContainsTargetCoverage) {
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto long_array_fid =
+        schema->AddDebugField("long_array", DataType::ARRAY, DataType::INT64);
+    auto string_array_fid = schema->AddDebugField(
+        "string_array", DataType::ARRAY, DataType::VARCHAR);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    int N = 1000;
+    std::map<std::string, std::vector<ScalarFieldProto>> array_cols;
+    int num_iters = 1;
+    for (int iter = 0; iter < num_iters; ++iter) {
+        auto raw_data = DataGen(schema, N, iter);
+        auto new_long_array_col =
+            raw_data.get_col<ScalarFieldProto>(long_array_fid);
+        auto new_string_array_col =
+            raw_data.get_col<ScalarFieldProto>(string_array_fid);
+        array_cols["long"].insert(array_cols["long"].end(),
+                                  new_long_array_col.begin(),
+                                  new_long_array_col.end());
+        array_cols["string"].insert(array_cols["string"].end(),
+                                    new_string_array_col.begin(),
+                                    new_string_array_col.end());
+        seg->PreInsert(N);
+        seg->Insert(iter * N,
+                    N,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+    }
+
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+
+    // --- Single-target Contains on INT64 ---
+    {
+        int64_t target = 10;
+        auto check = [target](const std::vector<int64_t>& values) {
+            return std::find(values.begin(), values.end(), target) !=
+                   values.end();
+        };
+        proto::plan::GenericValue gen_val;
+        gen_val.set_int64_val(target);
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(long_array_fid, DataType::ARRAY, DataType::INT64),
+            proto::plan::JSONContainsExpr_JSONOp_Contains,
+            true,
+            std::vector<proto::plan::GenericValue>{gen_val});
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        BitsetType final_bits =
+            ExecuteQueryExpr(plan, seg_promote, N * num_iters, MAX_TIMESTAMP);
+        EXPECT_EQ(final_bits.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto array = milvus::Array(array_cols["long"][i]);
+            std::vector<int64_t> res;
+            for (int j = 0; j < array.length(); ++j) {
+                res.push_back(array.get_data<int64_t>(j));
+            }
+            ASSERT_EQ(final_bits[i], check(res)) << "@" << i;
+        }
+    }
+
+    // --- Single-target Contains on VARCHAR ---
+    {
+        std::string target = "1sads";
+        auto check = [&target](const std::vector<std::string_view>& values) {
+            return std::find(values.begin(), values.end(), target) !=
+                   values.end();
+        };
+        proto::plan::GenericValue gen_val;
+        gen_val.set_string_val(target);
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(
+                string_array_fid, DataType::ARRAY, DataType::VARCHAR),
+            proto::plan::JSONContainsExpr_JSONOp_Contains,
+            true,
+            std::vector<proto::plan::GenericValue>{gen_val});
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        BitsetType final_bits =
+            ExecuteQueryExpr(plan, seg_promote, N * num_iters, MAX_TIMESTAMP);
+        EXPECT_EQ(final_bits.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto array = milvus::Array(array_cols["string"][i]);
+            std::vector<std::string_view> res;
+            for (int j = 0; j < array.length(); ++j) {
+                res.push_back(array.get_data<std::string_view>(j));
+            }
+            ASSERT_EQ(final_bits[i], check(res)) << "@" << i;
+        }
+    }
+
+    // --- ContainsAny with a one-element target list ---
+    {
+        int64_t target = 100;
+        auto check = [target](const std::vector<int64_t>& values) {
+            return std::find(values.begin(), values.end(), target) !=
+                   values.end();
+        };
+        proto::plan::GenericValue gen_val;
+        gen_val.set_int64_val(target);
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(long_array_fid, DataType::ARRAY, DataType::INT64),
+            proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+            true,
+            std::vector<proto::plan::GenericValue>{gen_val});
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        BitsetType final_bits =
+            ExecuteQueryExpr(plan, seg_promote, N * num_iters, MAX_TIMESTAMP);
+        EXPECT_EQ(final_bits.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto array = milvus::Array(array_cols["long"][i]);
+            std::vector<int64_t> res;
+            for (int j = 0; j < array.length(); ++j) {
+                res.push_back(array.get_data<int64_t>(j));
+            }
+            ASSERT_EQ(final_bits[i], check(res)) << "@" << i;
+        }
+    }
+
+    // --- Multi-target ContainsAny on INT64 (no element should match all
+    //     three targets, but each row may match any of them). ---
+    {
+        std::vector<int64_t> targets = {10, 100, 1000};
+        auto check = [&targets](const std::vector<int64_t>& values) {
+            for (auto t : targets) {
+                if (std::find(values.begin(), values.end(), t) !=
+                    values.end()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        std::vector<proto::plan::GenericValue> vals;
+        for (auto t : targets) {
+            proto::plan::GenericValue gv;
+            gv.set_int64_val(t);
+            vals.push_back(gv);
+        }
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(long_array_fid, DataType::ARRAY, DataType::INT64),
+            proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+            true,
+            vals);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        BitsetType final_bits =
+            ExecuteQueryExpr(plan, seg_promote, N * num_iters, MAX_TIMESTAMP);
+        EXPECT_EQ(final_bits.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto array = milvus::Array(array_cols["long"][i]);
+            std::vector<int64_t> res;
+            for (int j = 0; j < array.length(); ++j) {
+                res.push_back(array.get_data<int64_t>(j));
+            }
+            ASSERT_EQ(final_bits[i], check(res)) << "@" << i;
+        }
+    }
+
+    // --- Multi-target ContainsAny on VARCHAR. ---
+    {
+        std::vector<std::string> targets = {"1sads", "10dsf", "100"};
+        auto check = [&targets](const std::vector<std::string_view>& values) {
+            for (auto const& t : targets) {
+                if (std::find(values.begin(), values.end(), t) !=
+                    values.end()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        std::vector<proto::plan::GenericValue> vals;
+        for (const auto& t : targets) {
+            proto::plan::GenericValue gv;
+            gv.set_string_val(t);
+            vals.push_back(gv);
+        }
+        auto expr = std::make_shared<milvus::expr::JsonContainsExpr>(
+            expr::ColumnInfo(
+                string_array_fid, DataType::ARRAY, DataType::VARCHAR),
+            proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+            true,
+            vals);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        BitsetType final_bits =
+            ExecuteQueryExpr(plan, seg_promote, N * num_iters, MAX_TIMESTAMP);
+        EXPECT_EQ(final_bits.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto array = milvus::Array(array_cols["string"][i]);
+            std::vector<std::string_view> res;
+            for (int j = 0; j < array.length(); ++j) {
+                res.push_back(array.get_data<std::string_view>(j));
+            }
+            ASSERT_EQ(final_bits[i], check(res)) << "@" << i;
+        }
+    }
 }
 
 TEST(Expr, TestArrayContainsEmptyValues) {

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -306,6 +306,23 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
         std::conditional_t<std::is_same_v<ExprValueType, std::string>,
                            std::string_view,
                            ExprValueType>;
+
+    // Typed cached set used directly inside the array scan loop, mirroring
+    // the pattern in ExecArrayContainsAll. Skips the MultiElement variant
+    // round-trip, virtual dispatch and runtime type checks in In().
+    //   string: owning std::string set with transparent hash, so string_view
+    //           lookups are zero-copy and the set never holds dangling views.
+    //   bool:   std::unordered_set<bool>, since std::hash<bool> is safe.
+    //           ankerl::unordered_dense::set<bool> is avoided for the same
+    //           reason as SetElement<bool> in Element.h (wyhash 8-byte read).
+    //   other:  ankerl::unordered_dense::set<ExprValueType>.
+    using TypedSet = std::conditional_t<
+        std::is_same_v<ExprValueType, std::string>,
+        ankerl::unordered_dense::set<std::string, StringHash, std::equal_to<>>,
+        std::conditional_t<std::is_same_v<ExprValueType, bool>,
+                           std::unordered_set<bool>,
+                           ankerl::unordered_dense::set<ExprValueType>>>;
+
     auto* input = context.get_offset_input();
     const auto& bitmap_input = context.get_bitmap_input();
     auto real_batch_size =
@@ -323,9 +340,15 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
 
     if (!arg_inited_) {
-        arg_set_ = std::make_shared<SetElement<GetType>>(expr_->vals_);
+        auto elements = std::make_shared<TypedSet>();
+        elements->max_load_factor(0.5f);
+        for (const auto& val : expr_->vals_) {
+            elements->insert(GetValueWithCastNumber<ExprValueType>(val));
+        }
+        arg_cached_set_ = elements;
         arg_inited_ = true;
     }
+    auto elements = std::static_pointer_cast<TypedSet>(arg_cached_set_);
 
     int processed_cursor = 0;
     auto execute_sub_batch =
@@ -337,7 +360,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
             const int size,
             TargetBitmapView res,
             TargetBitmapView valid_res,
-            const std::shared_ptr<MultiElement>& elements) {
+            const TypedSet& elements) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {
@@ -347,7 +370,8 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
         auto executor = [&](size_t i) {
             const auto& array = data[i];
             for (int j = 0; j < array.length(); ++j) {
-                if (elements->In(array.template get_data<GetType>(j))) {
+                if (elements.find(array.template get_data<GetType>(j)) !=
+                    elements.end()) {
                     return true;
                 }
             }
@@ -379,10 +403,10 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
                                                     input,
                                                     res,
                                                     valid_res,
-                                                    arg_set_);
+                                                    *elements);
     } else {
         processed_size = ProcessDataChunks<milvus::ArrayView>(
-            execute_sub_batch, std::nullptr_t{}, res, valid_res, arg_set_);
+            execute_sub_batch, std::nullptr_t{}, res, valid_res, *elements);
     }
     AssertInfo(processed_size == real_batch_size,
                "internal error: expr processed rows {} not equal "


### PR DESCRIPTION
issue: #48410
pr: #48411

- expression executor: single-target array_contains now compares directly against a typed cached set (TypedSet), skipping MultiElement variant construction, virtual dispatch and per-element binary search
