### PR TITLE
fix: make internal/proxy tests compile after #52544 landed on top of #53023

### DIFF
--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -1804,9 +1804,9 @@ func TestProxy_ImportV2(t *testing.T) {
 		node.tsoAllocator = &timestampAllocator{
 			tso: newMockTimestampAllocatorInterface(),
 		}
-		scheduler, err := newTaskScheduler(ctx, node.tsoAllocator)
+		sched, err := scheduler.NewTaskScheduler(ctx, node.tsoAllocator)
 		assert.NoError(t, err)
-		node.sched = scheduler
+		node.sched = sched
 		assert.NoError(t, node.sched.Start())
 		defer node.sched.Close()
 		chMgr := channelmgr.NewMockChannelsMgr(t)

--- a/internal/proxy/task_import_test.go
+++ b/internal/proxy/task_import_test.go
@@ -451,7 +451,7 @@ func (s *ImportTaskSuite) TestExecute_PassesTheRequestContextToMixCoord() {
 		},
 		resp: &internalpb.ImportResponse{},
 	}
-	task.metaCache = mockCache
+	task.MetaCache = mockCache
 
 	err := task.Execute(ctx)
 


### PR DESCRIPTION
issue: #53242

#53023 moved the proxy task scheduler into `internal/proxy/scheduler` and renamed `newTaskScheduler` -> `scheduler.NewTaskScheduler` and `baseTask.metaCache` -> `MetaCache`. #52544 was based on pre-#53023 code and re-introduced both old identifiers in `impl_test.go` and `task_import_test.go`. The merge was textually clean, so master's proxy test binary no longer compiles and every PR's `ci-v2/build-ut-cov` Code-Check stage fails with:

```
internal/proxy/impl_test.go:1807:21: undefined: newTaskScheduler
internal/proxy/task_import_test.go:454:7: task.metaCache undefined (type *importTask has no field or method metaCache, but does have field MetaCache) (typecheck)
```

First failing master build: milvus-build-ut-ciloop-pipeline #29782 (dd75544).

This PR renames both call sites to the post-#53023 identifiers. The local variable in `TestProxy_ImportV2` is named `sched` rather than `scheduler` so it does not shadow the imported package.

Verified locally:
- `GOWORK=off go vet -tags dynamic,test ./internal/proxy/` clean
- `TestProxy_ImportV2` and `TestImportTaskSuite` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WWJEqPsUN62Dm1YdDP7R6