### PR TITLE
enhance: reduce DynamicPool scheduling for index resource estimation

### DIFF
--- a/internal/querynodev2/segments/load_index_info.go
+++ b/internal/querynodev2/segments/load_index_info.go
@@ -28,10 +28,6 @@ import "C"
 import (
 	"context"
 	"unsafe"
-
-	"google.golang.org/protobuf/proto"
-
-	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
 )
 
 // LoadIndexInfo is a wrapper of the underlying C-structure C.CLoadIndexInfo
@@ -39,41 +35,24 @@ type LoadIndexInfo struct {
 	cLoadIndexInfo C.CLoadIndexInfo
 }
 
-// newLoadIndexInfo returns a new LoadIndexInfo and error
+// newLoadIndexInfo creates a CLoadIndexInfo on the current DynamicPool worker.
 func newLoadIndexInfo(ctx context.Context) (*LoadIndexInfo, error) {
 	var cLoadIndexInfo C.CLoadIndexInfo
 
-	var status C.CStatus
-	GetDynamicPool().Submit(func() (any, error) {
-		status = C.NewLoadIndexInfo(&cLoadIndexInfo)
-		return nil, nil
-	}).Await()
+	status := C.NewLoadIndexInfo(&cLoadIndexInfo)
 	if err := HandleCStatus(ctx, &status, "NewLoadIndexInfo failed"); err != nil {
 		return nil, err
 	}
 	return &LoadIndexInfo{cLoadIndexInfo: cLoadIndexInfo}, nil
 }
 
-// deleteLoadIndexInfo would delete C.CLoadIndexInfo
+// deleteLoadIndexInfo deletes a CLoadIndexInfo on the current DynamicPool worker.
 func deleteLoadIndexInfo(info *LoadIndexInfo) {
-	GetDynamicPool().Submit(func() (any, error) {
-		C.DeleteLoadIndexInfo(info.cLoadIndexInfo)
-		return nil, nil
-	}).Await()
+	C.DeleteLoadIndexInfo(info.cLoadIndexInfo)
 }
 
-func (li *LoadIndexInfo) appendLoadIndexInfo(ctx context.Context, info *cgopb.LoadIndexInfo) error {
-	marshaled, err := proto.Marshal(info)
-	if err != nil {
-		return err
-	}
-
-	var status C.CStatus
-	_, _ = GetDynamicPool().Submit(func() (any, error) {
-		status = C.FinishLoadIndexInfo(li.cLoadIndexInfo, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)))
-		return nil, nil
-	}).Await()
-
+func (li *LoadIndexInfo) appendLoadIndexInfo(ctx context.Context, marshaled []byte) error {
+	status := C.FinishLoadIndexInfo(li.cLoadIndexInfo, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)))
 	return HandleCStatus(ctx, &status, "FinishLoadIndexInfo failed")
 }
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1153,13 +1153,6 @@ func GetCLoadInfoWithFunc(ctx context.Context,
 	indexInfo *querypb.FieldIndexInfo,
 	f func(c *LoadIndexInfo) error,
 ) error {
-	// 1.
-	loadIndexInfo, err := newLoadIndexInfo(ctx)
-	if err != nil {
-		return err
-	}
-	defer deleteLoadIndexInfo(loadIndexInfo)
-
 	indexParams := funcutil.KeyValuePair2Map(indexInfo.IndexParams)
 	// as Knowhere reports error if encounter an unknown param, we need to delete it
 	delete(indexParams, common.MmapEnabledKey)
@@ -1218,13 +1211,29 @@ func GetCLoadInfoWithFunc(ctx context.Context,
 		IndexStorePathVersion:     indexInfo.GetIndexStorePathVersion(),
 	}
 
-	// 2.
-	if err := loadIndexInfo.appendLoadIndexInfo(ctx, indexInfoProto); err != nil {
-		mlog.Warn(ctx, "fail to append load index info", mlog.Err(err))
+	marshaled, err := proto.Marshal(indexInfoProto)
+	if err != nil {
 		return err
 	}
-	loadIndexInfo.setShard(loadInfo.GetInsertChannel())
-	return f(loadIndexInfo)
+
+	// Keep the complete CLoadIndexInfo lifecycle in one DynamicPool task. The
+	// callback runs on that worker and must call C APIs directly instead of
+	// submitting another task to DynamicPool.
+	_, err = GetDynamicPool().Submit(func() (any, error) {
+		loadIndexInfo, err := newLoadIndexInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer deleteLoadIndexInfo(loadIndexInfo)
+
+		if err := loadIndexInfo.appendLoadIndexInfo(ctx, marshaled); err != nil {
+			mlog.Warn(ctx, "fail to append load index info", mlog.Err(err))
+			return nil, err
+		}
+		loadIndexInfo.setShard(loadInfo.GetInsertChannel())
+		return nil, f(loadIndexInfo)
+	}).Await()
+	return err
 }
 
 func (s *LocalSegment) syncFieldJSONStatsFromLoadInfo(ctx context.Context, loadInfo *querypb.SegmentLoadInfo) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1998,11 +1998,8 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			var estimateResult ResourceEstimate
 			err = GetCLoadInfoWithFunc(ctx, fieldSchema, loadInfo, fieldIndexInfo, func(c *LoadIndexInfo) error {
-				GetDynamicPool().Submit(func() (any, error) {
-					loadResourceRequest := C.EstimateLoadIndexResource(c.cLoadIndexInfo)
-					estimateResult = GetResourceEstimate(&loadResourceRequest)
-					return nil, nil
-				}).Await()
+				loadResourceRequest := C.EstimateLoadIndexResource(c.cLoadIndexInfo)
+				estimateResult = GetResourceEstimate(&loadResourceRequest)
 				return nil
 			})
 			if err != nil {
@@ -2203,11 +2200,8 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			var estimateResult ResourceEstimate
 			err = GetCLoadInfoWithFunc(ctx, fieldSchema, loadInfo, fieldIndexInfo, func(c *LoadIndexInfo) error {
-				GetDynamicPool().Submit(func() (any, error) {
-					loadResourceRequest := C.EstimateLoadIndexResource(c.cLoadIndexInfo)
-					estimateResult = GetResourceEstimate(&loadResourceRequest)
-					return nil, nil
-				}).Await()
+				loadResourceRequest := C.EstimateLoadIndexResource(c.cLoadIndexInfo)
+				estimateResult = GetResourceEstimate(&loadResourceRequest)
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
issue: #53244

## What problem does this PR solve?

QueryNode index resource estimation currently schedules each C operation separately on DynamicPool. Creating a `CLoadIndexInfo`, initializing it, estimating its resource usage, and releasing it each require an individual submission and wait.

When segment loading estimates many indexed fields concurrently, these repeated submissions add avoidable scheduler contention and worker handoffs.

## What is changed?

- Marshal `cgopb.LoadIndexInfo` before entering DynamicPool.
- Run `CLoadIndexInfo` creation, initialization, resource estimation, and cleanup in one DynamicPool task.
- Call the estimation callback directly from the DynamicPool worker to avoid nested submissions.
- Keep the resource admission lock and physical memory/disk snapshot behavior unchanged.

## Verification

- `git diff --check`
- Static analysis was stopped before completion; CI will run the full checks.
