### PR TITLE
enhance: [2.6] cache per-chunk row counts to avoid read lock in filter eval

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -263,6 +263,13 @@ class SegmentExpr : public Expr {
         if (segment_->HasFieldData(field_id_)) {
             if (segment_->is_chunked()) {
                 num_data_chunk_ = segment_->num_chunk_data(field_id_);
+                // Cache per-chunk row counts once at construction to avoid
+                // taking the segment read lock for every chunk on every batch
+                // (each chunk_size() call acquires folly SharedMutex).
+                chunk_sizes_.resize(num_data_chunk_);
+                for (int64_t i = 0; i < num_data_chunk_; i++) {
+                    chunk_sizes_[i] = segment_->chunk_size(field_id_, i);
+                }
             } else {
                 num_data_chunk_ = upper_div(active_count_, size_per_chunk_);
             }
@@ -281,7 +288,7 @@ class SegmentExpr : public Expr {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size = chunk_sizes_[i] - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
 
@@ -895,7 +902,7 @@ class SegmentExpr : public Expr {
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
 
             // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size = chunk_sizes_[i] - data_pos;
             size = std::min(size, batch_size_ - processed_size);
 
             if (size == 0)
@@ -1067,7 +1074,7 @@ class SegmentExpr : public Expr {
         int64_t processed_size = 0;
 
         for (size_t chunk_id = 0; chunk_id < num_data_chunk_; chunk_id++) {
-            int64_t chunk_size = segment_->chunk_size(field_id_, chunk_id);
+            int64_t chunk_size = chunk_sizes_[chunk_id];
             int64_t chunk_offset = 0;
 
             while (chunk_offset < chunk_size) {
@@ -1379,7 +1386,7 @@ class SegmentExpr : public Expr {
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             int64_t size = 0;
             if (segment_->is_chunked()) {
-                size = segment_->chunk_size(field_id_, i) - data_pos;
+                size = chunk_sizes_[i] - data_pos;
             } else {
                 size = (i == (num_data_chunk_ - 1))
                            ? (segment_->type() == SegmentType::Growing
@@ -1728,6 +1735,9 @@ class SegmentExpr : public Expr {
     int64_t active_count_{0};
     int64_t num_data_chunk_{0};
     int64_t num_index_chunk_{0};
+    // Cached per-chunk row counts for chunked segments, filled once in
+    // InitSegmentExpr() to avoid repeated segment read-lock acquisition.
+    std::vector<int64_t> chunk_sizes_{};
     // State indicate position that expr computing at
     // because expr maybe called for every batch.
     int64_t current_data_chunk_{0};

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -769,10 +769,9 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
         for (int64_t chunk_id = 0;
              chunk_id < num_data_chunk_ && processed_rows < active_count_;
              ++chunk_id) {
-            const auto chunk_size =
-                segment_->is_chunked()
-                    ? segment_->chunk_size(field_id_, chunk_id)
-                    : size_per_chunk_;
+            const auto chunk_size = segment_->is_chunked()
+                                        ? chunk_sizes_[chunk_id]
+                                        : size_per_chunk_;
             const auto size =
                 std::min(chunk_size, active_count_ - processed_rows);
             segment_->ApplyFieldValidData(op_ctx_,
@@ -1184,7 +1183,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
              i < num_data_chunk_ && valid_processed_size < active_count_;
              ++i) {
             int64_t size = segment_->is_chunked()
-                               ? segment_->chunk_size(field_id_, i)
+                               ? chunk_sizes_[i]
                                : (i == num_data_chunk_ - 1
                                       ? active_count_ - valid_processed_size
                                       : size_per_chunk_);


### PR DESCRIPTION
Related to #53247

ChunkedSegmentSealedImpl::chunk_size() acquires a folly SharedMutex read lock (an 8-byte CAS/RMW) on every call via get_column(). Filter expression evaluation calls it per chunk on every batch, so the whole search path pays one atomic lock/unlock per chunk per batch. This shows up as ~17.6% aggregated time in chunk_size and ~7% each in __aarch64_cas8_acq_rel / __aarch64_ldadd4_acq_rel on the search flamegraph.

Cache the per-chunk row counts once in SegmentExpr::InitSegmentExpr() (a std::vector<int64_t> chunk_sizes_ filled at construction, mirroring the existing num_data_chunk_/size_per_chunk_ caching) and read from it in MoveCursorForDataMultipleChunk, ProcessDataChunksForMultipleChunk, ProcessAllDataChunkBatched, ProcessDataChunksForValid and the two chunk loops in UnaryExpr.cpp.

Row counts of a sealed chunked segment are immutable after load, so the cache is safe; growing segments are not chunked and stay on the existing path. This reduces O(batches x chunks) lock acquisitions to one pass at construction.