### PR TITLE
fix: [cp3.0] use sparse data type for index raw data estimation

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -557,9 +557,10 @@ IndexFactory::VecIndexLoadResource(
                                      num_rows,
                                      dim,
                                      config);
-            has_raw_data =
-                knowhere::IndexStaticFaced<knowhere::fp32>::HasRawData(
-                    index_type, index_version, config);
+            has_raw_data = knowhere::IndexStaticFaced<
+                knowhere::sparse_u32_f32>::HasRawData(index_type,
+                                                      index_version,
+                                                      config);
             break;
         case milvus::DataType::VECTOR_INT8:
             resource = knowhere::IndexStaticFaced<

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -338,6 +338,24 @@ TEST_P(IndexLoadTest, ResourceEstimate) {
     ASSERT_EQ(request.max_disk_cost, expected.max_disk_cost);
 }
 
+TEST(IndexLoadTest, SparseIndexResourceEstimateHasRawData) {
+    milvus::segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_type = milvus::DataType::VECTOR_SPARSE_U32_F32;
+    load_index_info.element_type = milvus::DataType::NONE;
+    load_index_info.index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX_CC},
+        {"metric_type", knowhere::metric::IP},
+    };
+    load_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    load_index_info.index_size = 1024 * 1024;
+    load_index_info.num_rows = 1024;
+
+    auto request = EstimateLoadIndexResource(&load_index_info);
+
+    EXPECT_TRUE(request.has_raw_data);
+}
+
 TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
     milvus::segcore::LoadIndexInfo loadIndexInfo;
     ASSERT_FALSE(loadIndexInfo.load_resource_request.has_value());


### PR DESCRIPTION
Cherry-pick from master
pr: #53106

issue: #53105

## What this PR does

Fix sparse index resource estimation to query Knowhere's static capabilities through `IndexStaticFaced<knowhere::sparse_u32_f32>` instead of the dense `knowhere::fp32` specialization. This preserves the correct `has_raw_data` value for concurrent sparse indexes using the IP metric and removes a fallback warning on a frequently called QueryNode path.

## Changes

- Use the `sparse_u32_f32` specialization for the sparse-vector `HasRawData` query.
- Add a regression test `IndexLoadTest.SparseIndexResourceEstimateHasRawData` for `SPARSE_INVERTED_INDEX_CC` with `IP`.

## Test Plan

- Cherry-picked cleanly from master (no conflicts); diff is identical to the master commit for the two changed files.
- Full `make build-cpp-with-unittest` completed successfully (Conan 2 / Release, macOS arm64).
- Ran `IndexLoadTest.SparseIndexResourceEstimateHasRawData`: PASSED.
- Ran the full `IndexLoadTest.*` suite: 6/6 PASSED.
