### PR TITLE
enhance: [WIP] apply Knowhere search defaults at query time

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -537,7 +537,8 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 	}
 
 	const isSecondStageSearch = false
-	req, err = optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim)
+	indexType := sd.collection.GetIndexType(req.GetReq().GetFieldId())
+	req, err = optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim, indexType)
 	if err != nil {
 		mlog.Warn(ctx, "failed to optimize search params", mlog.Err(err))
 		return nil, err

--- a/internal/querynodev2/delegator/delegator_twostage.go
+++ b/internal/querynodev2/delegator/delegator_twostage.go
@@ -133,7 +133,8 @@ func (sd *shardDelegator) twoStageSearch(
 	// ==================== Optimize with actual stats ====================
 	log.Debug(ctx, "Optimizing search params with actual stats")
 	const isSecondStageSearch = true
-	optimizedReq, err := optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim)
+	indexType := sd.collection.GetIndexType(req.GetReq().GetFieldId())
+	optimizedReq, err := optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim, indexType)
 	if err != nil {
 		log.Warn(ctx, "Two-stage search: failed to optimize search params", mlog.Err(err))
 		return nil, false, err

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -360,6 +361,21 @@ func (c *Collection) ID() int64 {
 // GetCCollection returns the CCollection of collection
 func (c *Collection) GetCCollection() *segcore.CCollection {
 	return c.ccollection
+}
+
+func (c *Collection) GetIndexType(fieldID int64) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ccollection == nil || c.ccollection.IndexMeta() == nil {
+		return ""
+	}
+	for _, indexMeta := range c.ccollection.IndexMeta().GetIndexMetas() {
+		if indexMeta.GetFieldID() == fieldID {
+			return common.GetIndexType(indexMeta.GetIndexParams())
+		}
+	}
+	return ""
 }
 
 func (c *Collection) NewSearchRequest(req *querypb.SearchRequest, placeholderGroup []byte) (*segcore.SearchRequest, error) {

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -746,6 +746,16 @@ func (s *CollectionManagerSuite) TestLoadMetaSchemaVersionCompatibility() {
 	})
 }
 
+func (s *CollectionManagerSuite) TestGetIndexType() {
+	collection := s.cm.Get(1)
+	s.Require().NotNil(collection)
+	s.Require().NotEmpty(collection.GetCCollection().IndexMeta().GetIndexMetas())
+
+	indexMeta := collection.GetCCollection().IndexMeta().GetIndexMetas()[0]
+	s.Equal(mock_segcore.IndexFaissIVFFlat, collection.GetIndexType(indexMeta.GetFieldID()))
+	s.Empty(collection.GetIndexType(-1))
+}
+
 func (s *CollectionManagerSuite) TestGpuIndexFlagWithCagraAdaptForCPU() {
 	schema := mock_segcore.GenTestCollectionSchema("collection_cagra", schemapb.DataType_Int64, false)
 	vectorFieldID := int64(0)

--- a/internal/querynodev2/tasks/search_task_go_reduce_test.go
+++ b/internal/querynodev2/tasks/search_task_go_reduce_test.go
@@ -1378,7 +1378,7 @@ func TestExecuteMergedSubTasks_MixedTopKWithL1Rerank(t *testing.T) {
 		t.Cleanup(func() { paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.Enable.Key) })
 		hook := fixedTopKQueryHook{topK: maxTopK, searchParam: `{}`}
 		for i, req := range requests {
-			optimized, err := optimizers.OptimizeSearchParams(ctx, req, hook, numSegments, false, func(int64) int64 { return 128 })
+			optimized, err := optimizers.OptimizeSearchParams(ctx, req, hook, numSegments, false, func(int64) int64 { return 128 }, "")
 			require.NoError(t, err)
 			requests[i] = optimized
 		}

--- a/internal/util/searchutil/optimizers/query_hook.go
+++ b/internal/util/searchutil/optimizers/query_hook.go
@@ -25,15 +25,19 @@ type QueryHook interface {
 	CalculateEffectiveSegmentNum(rowCounts []int64, topk int64) int
 }
 
-// OptimizeSearchParams optimizes search parameters using the query hook.
+// OptimizeSearchParams optimizes search parameters using the query hook and applies Knowhere search defaults.
 // numSegments is the effective segment number, pre-computed by the caller via CalculateEffectiveSegmentNum.
 // isSecondStageSearch is true for the vector search stage of two-stage search, refer to delegator_twostage.go.
 // At this time, we need to set WithFilterKey to false to allow some aggressive optimizations.
-func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, queryHook QueryHook, numSegments int, isSecondStageSearch bool, dimFunc func(fieldID int64) int64) (*querypb.SearchRequest, error) {
-	// no hook applied or disabled, just return
-	if queryHook == nil || !paramtable.Get().AutoIndexConfig.Enable.GetAsBool() {
+func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, queryHook QueryHook, numSegments int, isSecondStageSearch bool, dimFunc func(fieldID int64) int64, indexType string) (*querypb.SearchRequest, error) {
+	useQueryHook := queryHook != nil && paramtable.Get().AutoIndexConfig.Enable.GetAsBool()
+	useKnowhereDefaults := paramtable.Get().KnowhereConfig.Enable.GetAsBool() &&
+		paramtable.Get().KnowhereConfig.HasIndexParams(indexType, paramtable.SearchStage)
+	if !useQueryHook {
 		req.Req.IsTopkReduce = false
 		req.Req.IsRecallEvaluation = false
+	}
+	if !useQueryHook && !useKnowhereDefaults {
 		return req, nil
 	}
 
@@ -62,67 +66,75 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 
 	switch plan.GetNode().(type) {
 	case *planpb.PlanNode_VectorAnns:
-		// use shardNum * segments num in shard to estimate total segment number
-		estSegmentNum := numSegments * int(channelNum)
-		metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
-
-		withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
 		queryInfo := plan.GetVectorAnns().GetQueryInfo()
-		params := map[string]any{
-			common.TopKKey:         queryInfo.GetTopk(),
-			common.SearchParamKey:  queryInfo.GetSearchParams(),
-			common.SegmentNumKey:   estSegmentNum,
-			common.WithFilterKey:   withFilter && !isSecondStageSearch,
-			common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
-			common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
-			common.CollectionKey:   req.GetReq().GetCollectionID(),
-			common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
-		}
-		if withFilter && channelNum > 1 {
-			params[common.ChannelNumKey] = channelNum
-		}
-		globalRefineEnable := paramtable.Get().AutoIndexConfig.GlobalRefineEnable.GetAsBool()
-		// Only check dim threshold and other conditions when global refine is enabled to reduce overhead
-		if globalRefineEnable && (req.GetReq().GetSearchType() == internalpb.SearchType_PURE_ANN_SEARCH_NO_FILTER || req.GetReq().GetSearchType() == internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER) {
-			isFloatVector := plan.GetVectorAnns().GetVectorType() <= planpb.VectorType_BFloat16Vector && plan.GetVectorAnns().GetVectorType() >= planpb.VectorType_FloatVector
-			minDimThreshold := paramtable.Get().AutoIndexConfig.GlobalRefineMinDimThreshold.GetAsInt64()
-			// Disable global refine for group_by, non-float vector queries, and low-dimension vectors
-			if queryInfo.GetGroupByFieldId() < 0 && isFloatVector && dimFunc(plan.GetVectorAnns().GetFieldId()) >= minDimThreshold {
-				params[common.SearchTopkRatioKey] = float32(paramtable.Get().AutoIndexConfig.GlobalRefineSearchTopkRatio.GetAsFloat())
-				params[common.RefineTopkRatioKey] = float32(paramtable.Get().AutoIndexConfig.GlobalRefineRefineTopkRatio.GetAsFloat())
+		if useQueryHook {
+			// use shardNum * segments num in shard to estimate total segment number
+			estSegmentNum := numSegments * int(channelNum)
+			metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
+
+			withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
+			params := map[string]any{
+				common.TopKKey:         queryInfo.GetTopk(),
+				common.SearchParamKey:  queryInfo.GetSearchParams(),
+				common.SegmentNumKey:   estSegmentNum,
+				common.WithFilterKey:   withFilter && !isSecondStageSearch,
+				common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
+				common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
+				common.CollectionKey:   req.GetReq().GetCollectionID(),
+				common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
+			}
+			if withFilter && channelNum > 1 {
+				params[common.ChannelNumKey] = channelNum
+			}
+			globalRefineEnable := paramtable.Get().AutoIndexConfig.GlobalRefineEnable.GetAsBool()
+			// Only check dim threshold and other conditions when global refine is enabled to reduce overhead
+			if globalRefineEnable && (req.GetReq().GetSearchType() == internalpb.SearchType_PURE_ANN_SEARCH_NO_FILTER || req.GetReq().GetSearchType() == internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER) {
+				isFloatVector := plan.GetVectorAnns().GetVectorType() <= planpb.VectorType_BFloat16Vector && plan.GetVectorAnns().GetVectorType() >= planpb.VectorType_FloatVector
+				minDimThreshold := paramtable.Get().AutoIndexConfig.GlobalRefineMinDimThreshold.GetAsInt64()
+				// Disable global refine for group_by, non-float vector queries, and low-dimension vectors
+				if queryInfo.GetGroupByFieldId() < 0 && isFloatVector && dimFunc(plan.GetVectorAnns().GetFieldId()) >= minDimThreshold {
+					params[common.SearchTopkRatioKey] = float32(paramtable.Get().AutoIndexConfig.GlobalRefineSearchTopkRatio.GetAsFloat())
+					params[common.RefineTopkRatioKey] = float32(paramtable.Get().AutoIndexConfig.GlobalRefineRefineTopkRatio.GetAsFloat())
+				}
+			}
+			if err := queryHook.Run(params); err != nil {
+				log.Warn(ctx, "failed to execute queryHook", mlog.Err(err))
+				return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
+			}
+			finalTopk := params[common.TopKKey].(int64)
+			req.Req.IsTopkReduce = req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk()) && !isSecondStageSearch
+			queryInfo.Topk = finalTopk
+			queryInfo.SearchParams = params[common.SearchParamKey].(string)
+			// Pass global refine decision to C++ via proto after hook validation
+			if globalRefineVal, ok := params[common.GlobalRefineKey]; ok && globalRefineVal.(bool) {
+				queryInfo.SearchTopkRatio = params[common.SearchTopkRatioKey].(float32)
+				queryInfo.RefineTopkRatio = params[common.RefineTopkRatioKey].(float32)
+				metrics.QueryNodeGlobalRefineCount.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(collectionId)).Inc()
+			} else {
+				queryInfo.SearchTopkRatio = 0
+				queryInfo.RefineTopkRatio = 0
+			}
+			if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
+				req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
+			} else {
+				req.Req.IsRecallEvaluation = false
 			}
 		}
-		err := queryHook.Run(params)
-		if err != nil {
-			log.Warn(ctx, "failed to execute queryHook", mlog.Err(err))
-			return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
+
+		if useKnowhereDefaults {
+			merged, err := paramtable.Get().KnowhereConfig.MergeIndexParamsJSON(indexType, paramtable.SearchStage, queryInfo.GetSearchParams())
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("invalid search params: %s", err.Error())
+			}
+			queryInfo.SearchParams = merged
 		}
-		finalTopk := params[common.TopKKey].(int64)
-		isTopkReduce := req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk()) && !isSecondStageSearch
-		queryInfo.Topk = finalTopk
-		queryInfo.SearchParams = params[common.SearchParamKey].(string)
-		// Pass global refine decision to C++ via proto after hook validation
-		if globalRefineVal, ok := params[common.GlobalRefineKey]; ok && globalRefineVal.(bool) {
-			queryInfo.SearchTopkRatio = params[common.SearchTopkRatioKey].(float32)
-			queryInfo.RefineTopkRatio = params[common.RefineTopkRatioKey].(float32)
-			metrics.QueryNodeGlobalRefineCount.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(collectionId)).Inc()
-		} else {
-			queryInfo.SearchTopkRatio = 0
-			queryInfo.RefineTopkRatio = 0
-		}
+
 		serializedExprPlan, err := proto.Marshal(&plan)
 		if err != nil {
 			log.Warn(ctx, "failed to marshal optimized plan", mlog.Err(err))
 			return nil, merr.WrapErrParameterInvalid("marshalable search plan", "plan with marshal error", err.Error())
 		}
 		req.Req.SerializedExprPlan = serializedExprPlan
-		req.Req.IsTopkReduce = isTopkReduce
-		if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
-			req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
-		} else {
-			req.Req.IsRecallEvaluation = false
-		}
-
 		log.Debug(ctx, "optimized search params done", mlog.Any("queryInfo", queryInfo))
 	default:
 		log.Warn(ctx, "not supported node type", mlog.String("nodeType", fmt.Sprintf("%T", plan.GetNode())))

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -72,7 +72,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 50, true, false, `{"param": 2}`)
 
@@ -84,7 +84,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 50, false, true, `{"param": 2}`)
 	})
@@ -112,7 +112,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SerializedExprPlan: bs,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
 	})
@@ -140,9 +140,43 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
+	})
+
+	suite.Run("knowhere_search_defaults", func() {
+		params := paramtable.Get()
+		searchKey := params.KnowhereConfig.IndexParam.KeyPrefix + "CARDINAL_TIERED.search.ivf_search_ratio"
+		params.Save(params.KnowhereConfig.Enable.Key, "true")
+		params.Save(searchKey, "0.5")
+		defer params.Reset(params.KnowhereConfig.Enable.Key)
+		defer params.Remove(searchKey)
+
+		plan := &planpb.PlanNode{
+			Node: &planpb.PlanNode_VectorAnns{
+				VectorAnns: &planpb.VectorANNS{
+					QueryInfo: &planpb.QueryInfo{
+						Topk:         100,
+						SearchParams: `{"nprobe":16}`,
+					},
+				},
+			},
+		}
+		bs, err := proto.Marshal(plan)
+		suite.Require().NoError(err)
+
+		for _, isSecondStageSearch := range []bool{false, true} {
+			req, err := OptimizeSearchParams(ctx, &querypb.SearchRequest{
+				Req: &internalpb.SearchRequest{
+					SerializedExprPlan: bs,
+					IsTopkReduce:       true,
+				},
+			}, nil, 2, isSecondStageSearch, func(int64) int64 { return 512 }, "CARDINAL_TIERED")
+			suite.NoError(err)
+			suite.JSONEq(`{"ivf_search_ratio":0.5,"nprobe":16}`, suite.getQueryInfo(req).GetSearchParams())
+			suite.False(req.GetReq().GetIsTopkReduce())
+		}
 	})
 
 	suite.Run("other_plannode", func() {
@@ -169,7 +203,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SerializedExprPlan: bs,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.Equal(bs, req.GetReq().GetSerializedExprPlan())
 	})
@@ -184,7 +218,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 		_, err := OptimizeSearchParams(ctx, &querypb.SearchRequest{
 			Req:             &internalpb.SearchRequest{},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.Error(err)
 	})
 
@@ -218,7 +252,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 			Req: &internalpb.SearchRequest{
 				SerializedExprPlan: bs,
 			},
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.Error(err)
 	})
 
@@ -269,7 +303,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 		}, suite.queryHook, 2, false, func(fieldID int64) int64 {
 			suite.EqualValues(100, fieldID)
 			return 512
-		})
+		}, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
 		suite.verifyGlobalRefineRatios(req, 4, 2)
@@ -314,7 +348,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SearchType:         internalpb.SearchType_PURE_ANN_SEARCH_NO_FILTER,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
 		suite.verifyGlobalRefineRatios(req, 0, 0)
@@ -361,7 +395,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SearchType:         internalpb.SearchType_DEFAULT,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+		}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
 		suite.verifyGlobalRefineRatios(req, 0, 0)
@@ -397,7 +431,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				Req: &internalpb.SearchRequest{
 					SerializedExprPlan: bs,
 				},
-			}, suite.queryHook, 2, false, func(int64) int64 { return 512 })
+			}, suite.queryHook, 2, false, func(int64) int64 { return 512 }, "")
 		})
 	})
 }

--- a/pkg/util/paramtable/knowhere_param.go
+++ b/pkg/util/paramtable/knowhere_param.go
@@ -2,6 +2,7 @@ package paramtable
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -153,6 +154,38 @@ func (p *knowhereConfig) MergeIndexParams(indexType string, stage string, indexP
 	}
 
 	return indexParam, nil
+}
+
+func (p *knowhereConfig) HasIndexParams(indexType, stage string) bool {
+	return len(p.getIndexParam(indexType, stage)) > 0
+}
+
+func (p *knowhereConfig) MergeIndexParamsJSON(indexType, stage, rawParams string) (string, error) {
+	defaultParams := p.getIndexParam(indexType, stage)
+	if len(defaultParams) == 0 {
+		return rawParams, nil
+	}
+	if rawParams == "" {
+		rawParams = "{}"
+	}
+
+	params := make(map[string]json.RawMessage)
+	if err := json.Unmarshal([]byte(rawParams), &params); err != nil {
+		return "", err
+	}
+	for key, value := range defaultParams {
+		if _, exists := params[key]; exists {
+			continue
+		}
+		rawValue := json.RawMessage(value)
+		if !json.Valid(rawValue) {
+			rawValue, _ = json.Marshal(value)
+		}
+		params[key] = rawValue
+	}
+
+	merged, err := json.Marshal(params)
+	return string(merged), err
 }
 
 func (p *knowhereConfig) MergeResourceParams(vecFieldSize uint64, stage string, indexParam map[string]string) (map[string]string, error) {

--- a/pkg/util/paramtable/knowhere_param_test.go
+++ b/pkg/util/paramtable/knowhere_param_test.go
@@ -189,6 +189,26 @@ func TestKnowhereConfig_MergeParameter(t *testing.T) {
 	}
 }
 
+func TestKnowhereConfig_MergeIndexParamsJSON(t *testing.T) {
+	bt := NewBaseTable(SkipRemote(true))
+	cfg := &knowhereConfig{}
+	cfg.init(bt)
+
+	bt.Save("knowhere.CARDINAL_TIERED.search.ivf_search_ratio", "0.5")
+	bt.Save("knowhere.CARDINAL_TIERED.search.search_mode", "balanced")
+
+	result, err := cfg.MergeIndexParamsJSON("CARDINAL_TIERED", SearchStage, `{"ivf_search_ratio":0.8,"nprobe":16}`)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"ivf_search_ratio":0.8,"nprobe":16,"search_mode":"balanced"}`, result)
+
+	result, err = cfg.MergeIndexParamsJSON("CARDINAL_TIERED", SearchStage, `{"nprobe":16}`)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"ivf_search_ratio":0.5,"nprobe":16,"search_mode":"balanced"}`, result)
+
+	_, err = cfg.MergeIndexParamsJSON("CARDINAL_TIERED", SearchStage, "invalid")
+	assert.Error(t, err)
+}
+
 func TestKnowhereConfig_MergeWithResource(t *testing.T) {
 	cfg := &knowhereConfig{}
 


### PR DESCRIPTION
## What changed

- Resolve the searched vector field's loaded index type from QueryNode collection metadata.
- Merge matching `knowhere.<INDEX>.search.*` parameters into the serialized search plan after query-hook optimization.
- Preserve explicit request/query-hook values and retain JSON value types.
- Apply the same behavior to normal and two-stage vector searches.

## Why

Knowhere parameter groups support the `search` stage, but those defaults were not merged into live QueryNode search requests. This makes search-stage defaults usable for the actual loaded index type without changing the client-facing request shape.

issue: #53254

## Testing

- `gofmt` applied to changed Go files.
- `git diff --check` passed.
- Local compilation and unit tests were not run by request; CI validation is pending.
