### PR TITLE
enhance: pin sealed snapshot once per request

### DIFF
--- a/internal/core/src/exec/QueryContext.h
+++ b/internal/core/src/exec/QueryContext.h
@@ -348,6 +348,16 @@ class QueryContext : public Context {
         return enable_sub_expr_cache_write_;
     }
 
+    void
+    set_read_snapshot(std::shared_ptr<const segcore::SegmentReadSnapshot> s) {
+        read_snapshot_ = std::move(s);
+    }
+
+    std::shared_ptr<const segcore::SegmentReadSnapshot>
+    get_read_snapshot() const {
+        return read_snapshot_;
+    }
+
  private:
     folly::Executor* executor_;
     //folly::Executor::KeepAlive<> executor_keepalive_;
@@ -385,6 +395,12 @@ class QueryContext : public Context {
     // Set by element-level filter/search operators after row-to-element
     // conversion.
     bool bitset_is_element_level_{false};
+
+    // Request-scoped sealed read snapshot, captured exactly once in
+    // ExecPlanNodeVisitor::visit() while the request read lease is held.
+    // Expressions borrow the raw pointer at construction; the shared_ptr here
+    // is the single owner for the whole ExecuteTask.
+    std::shared_ptr<const segcore::SegmentReadSnapshot> read_snapshot_{nullptr};
 
     // MVCC fast path: set true when sealed + no-filter + no-delete + no-TTL
     bool all_rows_visible_{false};

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -118,9 +118,9 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                         segment_chunk_reader_.SizePerChunk();
                     return {offset / size_per_chunk, offset % size_per_chunk};
                 } else if (segment_chunk_reader_.segment_->is_chunked() &&
-                           segment_chunk_reader_.segment_->num_chunk_data(
+                           segment_chunk_reader_.NumChunkData(
                                expr_->GetColumn().field_id_) > 0) {
-                    return segment_chunk_reader_.segment_->get_chunk_by_offset(
+                    return segment_chunk_reader_.GetChunkByOffset(
                         expr_->GetColumn().field_id_, offset);
                 } else {
                     return {0, offset};

--- a/internal/core/src/exec/expression/ColumnExpr.h
+++ b/internal/core/src/exec/expression/ColumnExpr.h
@@ -107,6 +107,11 @@ class PhyColumnExpr : public Expr {
     }
 
     void
+    SetSnapshot(const segcore::SegmentReadSnapshot* snapshot) override {
+        segment_chunk_reader_.SetSnapshot(snapshot);
+    }
+
+    void
     MoveCursorForIndexed() {
         current_chunk_pos_ = current_chunk_pos_ + batch_size_ >=
                                      segment_chunk_reader_.active_count_
@@ -122,7 +127,7 @@ class PhyColumnExpr : public Expr {
                 use_index_data_ && segment_chunk_reader_.segment_->type() ==
                                        SegmentType::Sealed
                     ? current_chunk_pos_
-                    : segment_chunk_reader_.segment_->num_rows_until_chunk(
+                    : segment_chunk_reader_.NumRowsUntilChunk(
                           expr_->GetColumn().field_id_, current_chunk_id_) +
                           current_chunk_pos_;
             return current_rows;

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -58,16 +58,16 @@ PhyCompareFilterExpr::CanUseBothDataFastPath() {
         return true;
     }
 
-    auto left_chunks = segment->num_chunk_data(left_field_);
-    auto right_chunks = segment->num_chunk_data(right_field_);
+    auto left_chunks = segment_chunk_reader_.NumChunkData(left_field_);
+    auto right_chunks = segment_chunk_reader_.NumChunkData(right_field_);
     if (left_chunks <= 0 || right_chunks <= 0 || left_chunks != right_chunks) {
         can_use_both_data_sequential_fast_path_ = false;
         return false;
     }
 
     for (int64_t i = 0; i <= left_chunks; ++i) {
-        if (segment->num_rows_until_chunk(left_field_, i) !=
-            segment->num_rows_until_chunk(right_field_, i)) {
+        if (segment_chunk_reader_.NumRowsUntilChunk(left_field_, i) !=
+            segment_chunk_reader_.NumRowsUntilChunk(right_field_, i)) {
             can_use_both_data_sequential_fast_path_ = false;
             return false;
         }
@@ -103,11 +103,9 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
         TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
 
         auto left_raw_data_chunk_count =
-            segment_chunk_reader_.segment_->num_chunk_data(
-                expr_->left_field_id_);
+            segment_chunk_reader_.NumChunkData(expr_->left_field_id_);
         auto right_raw_data_chunk_count =
-            segment_chunk_reader_.segment_->num_chunk_data(
-                expr_->right_field_id_);
+            segment_chunk_reader_.NumChunkData(expr_->right_field_id_);
 
         int64_t processed_rows = 0;
         const auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
@@ -120,8 +118,7 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
                 return {offset / size_per_chunk, offset % size_per_chunk};
             } else if (segment_chunk_reader_.segment_->is_chunked() &&
                        raw_data_chunk_count > 0) {
-                return segment_chunk_reader_.segment_->get_chunk_by_offset(
-                    field, offset);
+                return segment_chunk_reader_.GetChunkByOffset(field, offset);
             } else {
                 return {0, offset};
             }

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -239,6 +239,11 @@ class PhyCompareFilterExpr : public Expr {
         }
     }
 
+    void
+    SetSnapshot(const segcore::SegmentReadSnapshot* snapshot) override {
+        segment_chunk_reader_.SetSnapshot(snapshot);
+    }
+
     std::string
     ToString() const override {
         return fmt::format("{}", expr_->ToString());
@@ -279,12 +284,11 @@ class PhyCompareFilterExpr : public Expr {
     int64_t
     GetCurrentRows() {
         if (segment_chunk_reader_.segment_->is_chunked()) {
-            auto current_rows =
-                left_use_index_data_
-                    ? left_current_chunk_pos_
-                    : segment_chunk_reader_.segment_->num_rows_until_chunk(
-                          left_field_, left_current_chunk_id_) +
-                          left_current_chunk_pos_;
+            auto current_rows = left_use_index_data_
+                                    ? left_current_chunk_pos_
+                                    : segment_chunk_reader_.NumRowsUntilChunk(
+                                          left_field_, left_current_chunk_id_) +
+                                          left_current_chunk_pos_;
             return current_rows;
         } else {
             return segment_chunk_reader_.segment_->type() ==
@@ -343,8 +347,8 @@ class PhyCompareFilterExpr : public Expr {
                     auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
                     return {offset / size_per_chunk, offset % size_per_chunk};
                 } else {
-                    return segment_chunk_reader_.segment_->get_chunk_by_offset(
-                        field, offset);
+                    return segment_chunk_reader_.GetChunkByOffset(field,
+                                                                  offset);
                 }
             };
 
@@ -550,8 +554,7 @@ class PhyCompareFilterExpr : public Expr {
                         : segment_chunk_reader_.SizePerChunk() - data_pos;
             } else {
                 size =
-                    segment_chunk_reader_.segment_->chunk_size(left_field_, i) -
-                    data_pos;
+                    segment_chunk_reader_.ChunkSize(left_field_, i) - data_pos;
             }
 
             if (processed_size + size >= batch_size_) {

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -481,6 +481,10 @@ CompileExpression(const expr::TypedExprPtr& expr,
     } else {
         ThrowInfo(UnexpectedError, "unsupport expr: {}", expr->ToString());
     }
+    // Bind the request-scoped sealed read snapshot (nullptr for growing /
+    // non-pinned paths) to this expression. Runs for the whole compiled tree
+    // because CompileExpression is recursive over inputs.
+    result->SetSnapshot(context->get_read_snapshot().get());
     return result;
 }
 

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -296,6 +296,15 @@ class Expr : public std::enable_shared_from_this<Expr> {
         }
     }
 
+    // Bind the request-scoped sealed read snapshot to this expression.
+    // Called right after construction by the expression compiler; the pointer
+    // is borrowed from the owning QueryContext and stays valid for the whole
+    // ExecuteTask. Default no-op for expressions without per-chunk segment
+    // reads.
+    virtual void
+    SetSnapshot(const segcore::SegmentReadSnapshot* snapshot) {
+    }
+
  protected:
     DataType type_;
     std::vector<std::shared_ptr<Expr>> inputs_;
@@ -379,7 +388,7 @@ class SegmentExpr : public Expr {
         has_field_data_at_init_ = segment_->HasFieldData(field_id_);
         if (has_field_data_at_init_) {
             if (segment_->is_chunked()) {
-                num_data_chunk_ = segment_->num_chunk_data(field_id_);
+                num_data_chunk_ = NumChunkData(field_id_);
             } else {
                 num_data_chunk_ = upper_div(active_count_, size_per_chunk_);
             }
@@ -414,12 +423,43 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    void
+    SetSnapshot(const segcore::SegmentReadSnapshot* snapshot) override {
+        snapshot_ = snapshot;
+    }
+
+    // Metadata reads through the pinned snapshot when available, else fall
+    // back to the segment (growing segments / non-pinned paths). The fallback
+    // keeps every call identical to the pre-pin behavior.
+    int64_t
+    ChunkSize(FieldId field_id, int64_t chunk_id) const {
+        return snapshot_ ? snapshot_->chunk_size(field_id, chunk_id)
+                         : segment_->chunk_size(field_id, chunk_id);
+    }
+
+    int64_t
+    NumRowsUntilChunk(FieldId field_id, int64_t chunk_id) const {
+        return snapshot_ ? snapshot_->num_rows_until_chunk(field_id, chunk_id)
+                         : segment_->num_rows_until_chunk(field_id, chunk_id);
+    }
+
+    std::pair<int64_t, int64_t>
+    GetChunkByOffset(FieldId field_id, int64_t offset) const {
+        return snapshot_ ? snapshot_->get_chunk_by_offset(field_id, offset)
+                         : segment_->get_chunk_by_offset(field_id, offset);
+    }
+
+    int64_t
+    NumChunkData(FieldId field_id) const {
+        return snapshot_ ? snapshot_->num_chunk_data(field_id)
+                         : segment_->num_chunk_data(field_id);
+    }
+
     // Global row offset of (chunk, chunk_pos) within the segment.
     int64_t
     RowOffsetInSegment(size_t chunk, int64_t chunk_pos) const {
         return segment_->is_chunked()
-                   ? segment_->num_rows_until_chunk(field_id_, chunk) +
-                         chunk_pos
+                   ? NumRowsUntilChunk(field_id_, chunk) + chunk_pos
                    : static_cast<int64_t>(chunk) * size_per_chunk_ + chunk_pos;
     }
 
@@ -586,7 +626,7 @@ class SegmentExpr : public Expr {
             current_rows =
                 UseIndexCursor() && segment_->type() == SegmentType::Sealed
                     ? current_chunk_pos
-                    : segment_->num_rows_until_chunk(field_id_, current_chunk) +
+                    : NumRowsUntilChunk(field_id_, current_chunk) +
                           current_chunk_pos;
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
@@ -661,8 +701,7 @@ class SegmentExpr : public Expr {
             current_rows = current_chunk_pos;
         } else if (segment_->is_chunked()) {
             current_rows =
-                segment_->num_rows_until_chunk(field_id_, current_chunk) +
-                current_chunk_pos;
+                NumRowsUntilChunk(field_id_, current_chunk) + current_chunk_pos;
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
         }
@@ -970,8 +1009,7 @@ class SegmentExpr : public Expr {
             int64_t chunk_id = 0;
             int64_t chunk_offset = 0;
             if (!input->empty()) {
-                auto resolved =
-                    segment_->get_chunk_by_offset(field_id_, (*input)[0]);
+                auto resolved = GetChunkByOffset(field_id_, (*input)[0]);
                 chunk_id = resolved.first;
                 chunk_offset = resolved.second;
             }
@@ -982,8 +1020,8 @@ class SegmentExpr : public Expr {
                 batch_offsets.push_back(static_cast<int32_t>(chunk_offset));
                 ++input_pos;
                 while (input_pos < input->size()) {
-                    auto resolved = segment_->get_chunk_by_offset(
-                        field_id_, (*input)[input_pos]);
+                    auto resolved =
+                        GetChunkByOffset(field_id_, (*input)[input_pos]);
                     chunk_id = resolved.first;
                     chunk_offset = resolved.second;
                     if (chunk_id != run_chunk_id) {
@@ -1048,7 +1086,7 @@ class SegmentExpr : public Expr {
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, offset);
+                    GetChunkByOffset(field_id_, offset);
                 // chunk_data<VectorArrayView> would read the wrong layout:
                 // storage holds VectorArray, and nullable rows may be compacted.
                 // Use chunk_view to build logical VectorArrayView rows.
@@ -1107,7 +1145,7 @@ class SegmentExpr : public Expr {
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, offset);
+                    GetChunkByOffset(field_id_, offset);
                 if (chunk_id != cached_chunk_id) {
                     pw.emplace(
                         segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id));
@@ -1521,7 +1559,7 @@ class SegmentExpr : public Expr {
             // Start of a new chunk batch
             auto run = resolve_run(i);
             auto [chunk_id, chunk_offset] =
-                segment_->get_chunk_by_offset(field_id_, run.row_id);
+                GetChunkByOffset(field_id_, run.row_id);
 
             // Collect consecutive runs belonging to the same chunk
             offsets.clear();
@@ -1537,7 +1575,7 @@ class SegmentExpr : public Expr {
             while (i < element_ids->size()) {
                 auto next_run = resolve_run(i);
                 auto [next_chunk_id, next_chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, next_run.row_id);
+                    GetChunkByOffset(field_id_, next_run.row_id);
 
                 if (next_chunk_id != chunk_id) {
                     break;  // Different chunk, process current batch
@@ -1861,8 +1899,7 @@ class SegmentExpr : public Expr {
             std::vector<int32_t> segment_offsets_array;
             if constexpr (NeedSegmentOffsets) {
                 segment_offsets_array.resize(size);
-                auto start_offset =
-                    segment_->num_rows_until_chunk(field_id_, i) + data_pos;
+                auto start_offset = NumRowsUntilChunk(field_id_, i) + data_pos;
                 for (int64_t j = 0; j < size; ++j) {
                     int64_t offset = start_offset + j;
                     segment_offsets_array[j] = static_cast<int32_t>(offset);
@@ -2027,12 +2064,12 @@ class SegmentExpr : public Expr {
 
         // Find starting chunk and offset
         auto [start_chunk_id, start_chunk_offset] =
-            segment_->get_chunk_by_offset(field_id_, segment_offset);
+            GetChunkByOffset(field_id_, segment_offset);
 
         for (size_t chunk_id = start_chunk_id;
              chunk_id < num_data_chunk_ && remaining > 0;
              chunk_id++) {
-            int64_t chunk_size = segment_->chunk_size(field_id_, chunk_id);
+            int64_t chunk_size = ChunkSize(field_id_, chunk_id);
             int64_t chunk_offset =
                 (chunk_id == start_chunk_id) ? start_chunk_offset : 0;
 
@@ -2105,7 +2142,7 @@ class SegmentExpr : public Expr {
              chunk_id < num_data_chunk_ && processed_size < row_count;
              ++chunk_id) {
             auto chunk_size = segment_->is_chunked()
-                                  ? segment_->chunk_size(field_id_, chunk_id)
+                                  ? ChunkSize(field_id_, chunk_id)
                                   : size_per_chunk_;
             auto size = std::min(chunk_size, row_count - processed_size);
             if (size == 0) {
@@ -2606,7 +2643,7 @@ class SegmentExpr : public Expr {
     int64_t
     GetDataChunkRemainingRows(size_t chunk_id, int64_t data_pos) const {
         if (segment_->is_chunked()) {
-            return segment_->chunk_size(field_id_, chunk_id) - data_pos;
+            return ChunkSize(field_id_, chunk_id) - data_pos;
         }
 
         const auto chunk_start =
@@ -3084,6 +3121,9 @@ class SegmentExpr : public Expr {
     }
 
     const segcore::SegmentInternalInterface* segment_;
+    // Request-scoped sealed read snapshot, borrowed from the owning
+    // QueryContext. Null for growing segments and non-pinned paths.
+    const segcore::SegmentReadSnapshot* snapshot_{nullptr};
     const FieldId field_id_;
     bool is_pk_field_{false};
     DataType pk_type_;

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -740,7 +740,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size = ChunkSize(field_id_, i) - data_pos;
             size = std::min(size, real_batch_size - processed_rows);
 
             if (size > 0) {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -754,7 +754,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
                 is_same = [this, reverse](milvus::proto::plan::Array& val,
                                           int64_t offset) -> bool {
                     auto [chunk_idx, chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, offset);
+                        GetChunkByOffset(field_id_, offset);
                     auto pw = segment_->template chunk_view<milvus::ArrayView>(
                         op_ctx_, field_id_, chunk_idx);
                     auto chunk = pw.get();

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -283,6 +283,9 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
                            std::shared_ptr<milvus::exec::BaseConfig>>(),
         entity_ttl_physical_time_us_);
 
+    // Pin the sealed published snapshot exactly once for this request.
+    query_context->set_read_snapshot(segment->CaptureReadSnapshot());
+
     // Set op context to query context
     auto op_context = milvus::OpContext(cancel_token_);
     query_context->set_op_context(&op_context);
@@ -433,6 +436,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
                                    std::shared_ptr<milvus::exec::BaseConfig>>(),
                 entity_ttl_physical_time_us_);
 
+            // Pin the sealed published snapshot exactly once for this request.
+            query_context->set_read_snapshot(segment->CaptureReadSnapshot());
+
             if (enable_expr_cache_) {
                 query_context->set_enable_expr_cache(true);
                 query_context->set_enable_sub_expr_cache_write(false);
@@ -489,6 +495,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
         std::unordered_map<std::string,
                            std::shared_ptr<milvus::exec::BaseConfig>>(),
         entity_ttl_physical_time_us_);
+
+    // Pin the sealed published snapshot exactly once for this request.
+    query_context->set_read_snapshot(segment->CaptureReadSnapshot());
 
     query_context->set_search_info(node.search_info_);
     query_context->set_placeholder_group(placeholder_group_);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1024,6 +1024,87 @@ ChunkedSegmentSealedImpl::CaptureRuntimeResourceState() const {
     return state->runtime;
 }
 
+// State-only read view: every access derives purely from the captured
+// PublishedSegmentState. No segment pointer is held — the immutable state
+// carries the field columns, readiness bitsets, and row count that the exec
+// hot loop needs. Each method replicates the exact semantics of the segment
+// method it shadows, including the per-method readiness-bit handling:
+//   - chunk_size / num_chunk_data return 0 when field data is not ready;
+//   - get_chunk_by_offset / num_rows_until_chunk do NOT gate on readiness
+//     (an index-only field has a clear ready bit but may still be resolved).
+class ChunkedSegmentSealedImpl::SealedReadSnapshot
+    : public SegmentReadSnapshot {
+ public:
+    explicit SealedReadSnapshot(
+        std::shared_ptr<const PublishedSegmentState> state)
+        : state_(std::move(state)) {
+        AssertInfo(state_ != nullptr && state_->runtime != nullptr,
+                   "sealed read snapshot must hold a published state with a "
+                   "non-null runtime");
+    }
+
+    int64_t
+    chunk_size(FieldId field_id, int64_t chunk_id) const override {
+        if (!FieldDataReady(field_id)) {
+            return 0;
+        }
+        auto* column = Column(field_id);
+        return column ? column->chunk_row_nums(chunk_id)
+                      : state_->runtime->row_count;
+    }
+
+    int64_t
+    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const override {
+        auto* column = Column(field_id);
+        AssertInfo(column != nullptr,
+                   "field {} must exist when getting rows until chunk",
+                   field_id.get());
+        return column->GetNumRowsUntilChunk(chunk_id);
+    }
+
+    std::pair<int64_t, int64_t>
+    get_chunk_by_offset(FieldId field_id, int64_t offset) const override {
+        auto* column = Column(field_id);
+        AssertInfo(column != nullptr,
+                   "field {} must exist when getting chunk by offset",
+                   field_id.get());
+        return column->GetChunkIDByOffset(offset);
+    }
+
+    int64_t
+    num_chunk_data(FieldId field_id) const override {
+        if (!FieldDataReady(field_id)) {
+            return 0;
+        }
+        auto* column = Column(field_id);
+        return column ? column->num_chunks() : 1;
+    }
+
+    int64_t
+    get_row_count() const override {
+        return state_->runtime->row_count;
+    }
+
+ private:
+    bool
+    FieldDataReady(FieldId field_id) const {
+        return get_bit(state_->field_data_ready_bitset, field_id);
+    }
+
+    const ChunkedColumnInterface*
+    Column(FieldId field_id) const {
+        auto it = state_->runtime->fields.find(field_id);
+        return it == state_->runtime->fields.end() ? nullptr : it->second.get();
+    }
+
+    std::shared_ptr<const PublishedSegmentState> state_;
+};
+
+std::shared_ptr<const SegmentReadSnapshot>
+ChunkedSegmentSealedImpl::CaptureReadSnapshot() const {
+    return std::make_shared<SealedReadSnapshot>(CapturePublishedState());
+}
+
 std::shared_ptr<const ChunkedSegmentSealedImpl::RuntimeResourceState>
 ChunkedSegmentSealedImpl::BuildRuntimeResourceState() {
     auto runtime = std::make_shared<RuntimeResourceState>();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -397,6 +397,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             published_index_has_raw_data;
     };
 
+    // State-only read view over a captured immutable PublishedSegmentState.
+    // Defined out-of-line in ChunkedSegmentSealedImpl.cpp; reads derive purely
+    // from the state (no segment pointer). See CaptureReadSnapshot().
+    class SealedReadSnapshot;
+
     static std::shared_ptr<const RuntimeResourceState>
     BuildRuntimeResourceState();
 
@@ -534,6 +539,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     int64_t
     chunk_size(FieldId field_id, int64_t chunk_id) const override;
+
+    // Capture the current published snapshot once per request. Returns a
+    // state-only SegmentReadSnapshot; nullptr is never returned (sealed
+    // segments always have a published state).
+    std::shared_ptr<const SegmentReadSnapshot>
+    CaptureReadSnapshot() const override;
 
     std::pair<int64_t, int64_t>
     get_chunk_by_offset(FieldId field_id, int64_t offset) const override;

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -85,7 +85,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
                 };
         }
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = NumChunkData(field_id);
     AssertInfo(current_chunk_id < num_chunks,
                "field {} cursor chunk_id {} exceeds num_chunks {}",
                field_id.get(),
@@ -97,7 +97,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     auto chunk_info = pw.get();
     auto chunk_data = chunk_info.data();
     auto chunk_validity = chunk_info.validity();
-    auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
+    auto current_chunk_size = ChunkSize(field_id, current_chunk_id);
     return [=,
             this,
             pw = std::move(pw),
@@ -115,8 +115,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
             pw = segment_->chunk_data<T>(op_ctx_, field_id, current_chunk_id);
             chunk_data = pw.get().data();
             chunk_validity = pw.get().validity();
-            current_chunk_size =
-                segment_->chunk_size(field_id, current_chunk_id);
+            current_chunk_size = ChunkSize(field_id, current_chunk_id);
         }
         if (chunk_validity && !chunk_validity[current_chunk_pos]) {
             current_chunk_pos++;
@@ -154,7 +153,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             };
         }
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = NumChunkData(field_id);
     AssertInfo(current_chunk_id < num_chunks,
                "field {} cursor chunk_id {} exceeds num_chunks {}",
                field_id.get(),
@@ -169,8 +168,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
         auto chunk_info = pw.get();
         auto chunk_data = chunk_info.data();
         auto chunk_validity = chunk_info.validity();
-        auto current_chunk_size =
-            segment_->chunk_size(field_id, current_chunk_id);
+        auto current_chunk_size = ChunkSize(field_id, current_chunk_id);
         return [pw = std::move(pw),
                 this,
                 field_id,
@@ -193,8 +191,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                     op_ctx_, field_id, current_chunk_id);
                 chunk_data = pw.get().data();
                 chunk_validity = pw.get().validity();
-                current_chunk_size =
-                    segment_->chunk_size(field_id, current_chunk_id);
+                current_chunk_size = ChunkSize(field_id, current_chunk_id);
             }
             if (chunk_validity && !chunk_validity[current_chunk_pos]) {
                 current_chunk_pos++;
@@ -206,8 +203,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
     } else {
         auto pw = segment_->chunk_view<std::string_view>(
             op_ctx_, field_id, current_chunk_id);
-        auto current_chunk_size =
-            segment_->chunk_size(field_id, current_chunk_id);
+        auto current_chunk_size = ChunkSize(field_id, current_chunk_id);
         return [=,
                 this,
                 pw = std::move(pw),
@@ -223,8 +219,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                            num_chunks);
                 pw = segment_->chunk_view<std::string_view>(
                     op_ctx_, field_id, current_chunk_id);
-                current_chunk_size =
-                    segment_->chunk_size(field_id, current_chunk_id);
+                current_chunk_size = ChunkSize(field_id, current_chunk_id);
             }
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
@@ -298,7 +293,7 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
                 return raw.value();
             };
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = NumChunkData(field_id);
     AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
                "field {} chunk_id {} exceeds raw data chunks {}",
                field_id.get(),
@@ -336,7 +331,7 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
                 return raw.value();
             };
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = NumChunkData(field_id);
     AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
                "field {} chunk_id {} exceeds raw data chunks {}",
                field_id.get(),

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -126,23 +126,58 @@ class SegmentChunkReader {
                                const FieldId field_id,
                                const int64_t num_chunk,
                                const int64_t batch_size) const {
-        int64_t segment_row_count = segment_->get_row_count();
+        int64_t segment_row_count = RowCount();
         int64_t current_offset =
-            segment_->num_rows_until_chunk(field_id, current_chunk_id) +
-            current_chunk_pos;
+            NumRowsUntilChunk(field_id, current_chunk_id) + current_chunk_pos;
         int64_t target_offset = current_offset + batch_size;
 
         if (target_offset >= segment_row_count) {
             current_chunk_id = num_chunk - 1;
-            current_chunk_pos =
-                segment_row_count -
-                segment_->num_rows_until_chunk(field_id, current_chunk_id);
+            current_chunk_pos = segment_row_count -
+                                NumRowsUntilChunk(field_id, current_chunk_id);
             return;
         }
-        auto [chunk_id, chunk_pos] =
-            segment_->get_chunk_by_offset(field_id, target_offset);
+        auto [chunk_id, chunk_pos] = GetChunkByOffset(field_id, target_offset);
         current_chunk_id = chunk_id;
         current_chunk_pos = chunk_pos;
+    }
+
+    // Bind the request-scoped sealed read snapshot. Borrowed from the owning
+    // QueryContext; valid for the whole ExecuteTask. Null for growing /
+    // non-pinned paths, which fall back to segment access below.
+    void
+    SetSnapshot(const segcore::SegmentReadSnapshot* snapshot) const {
+        snapshot_ = snapshot;
+    }
+
+    int64_t
+    ChunkSize(FieldId field_id, int64_t chunk_id) const {
+        return snapshot_ ? snapshot_->chunk_size(field_id, chunk_id)
+                         : segment_->chunk_size(field_id, chunk_id);
+    }
+
+    int64_t
+    NumRowsUntilChunk(FieldId field_id, int64_t chunk_id) const {
+        return snapshot_ ? snapshot_->num_rows_until_chunk(field_id, chunk_id)
+                         : segment_->num_rows_until_chunk(field_id, chunk_id);
+    }
+
+    std::pair<int64_t, int64_t>
+    GetChunkByOffset(FieldId field_id, int64_t offset) const {
+        return snapshot_ ? snapshot_->get_chunk_by_offset(field_id, offset)
+                         : segment_->get_chunk_by_offset(field_id, offset);
+    }
+
+    int64_t
+    NumChunkData(FieldId field_id) const {
+        return snapshot_ ? snapshot_->num_chunk_data(field_id)
+                         : segment_->num_chunk_data(field_id);
+    }
+
+    int64_t
+    RowCount() const {
+        return snapshot_ ? snapshot_->get_row_count()
+                         : segment_->get_row_count();
     }
 
     void
@@ -177,6 +212,7 @@ class SegmentChunkReader {
 
     const int64_t active_count_;
     const segcore::SegmentInternalInterface* segment_;
+    mutable const segcore::SegmentReadSnapshot* snapshot_{nullptr};
 
  private:
     template <typename T>

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -94,6 +94,31 @@ NextSegmentInstanceUid() {
     return counter.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 
+// Request-scoped read snapshot for sealed segments. Captured exactly once per
+// search/retrieve request while the request read lease is held; it reads the
+// immutable published state without locks or per-chunk re-capture. Growing
+// segments and non-pinned paths return nullptr and fall back to per-call
+// segment access with identical semantics.
+class SegmentReadSnapshot {
+ public:
+    virtual ~SegmentReadSnapshot() = default;
+
+    virtual int64_t
+    chunk_size(FieldId f, int64_t c) const = 0;
+
+    virtual int64_t
+    num_rows_until_chunk(FieldId f, int64_t c) const = 0;
+
+    virtual std::pair<int64_t, int64_t>
+    get_chunk_by_offset(FieldId f, int64_t off) const = 0;
+
+    virtual int64_t
+    num_chunk_data(FieldId f) const = 0;
+
+    virtual int64_t
+    get_row_count() const = 0;
+};
+
 // common interface of SegmentSealed and SegmentGrowing used by C API
 class SegmentInterface {
  public:
@@ -719,6 +744,14 @@ class SegmentInternalInterface : public SegmentInterface {
     // element size in each chunk
     virtual int64_t
     size_per_chunk() const = 0;
+
+    // Capture a request-scoped read snapshot, or return nullptr when the
+    // segment does not use an immutable published snapshot (growing segments).
+    // Called once per request; see SegmentReadSnapshot.
+    virtual std::shared_ptr<const SegmentReadSnapshot>
+    CaptureReadSnapshot() const {
+        return nullptr;
+    }
 
     virtual int64_t
     get_active_count(Timestamp ts) const = 0;

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -1044,6 +1044,84 @@ TEST(OffsetsEvalIndexOnlyCorrectnessTest,
 }
 
 TEST(OffsetsEvalIndexOnlyCorrectnessTest,
+     SealedReadSnapshotMirrorsSegmentReadinessSemantics) {
+    constexpr int64_t kRowCount = 8;
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto value_fid = schema->AddDebugField("value", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kRowCount / 2, 100, 0, 1, 1);
+    auto second = DataGen(schema, kRowCount / 2, 101, 0, 1, 1);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+
+    // Index-only field: raw data dropped, ready bit clear in steady state.
+    std::vector<int64_t> index_values(kRowCount);
+    std::iota(index_values.begin(), index_values.end(), int64_t{0});
+    auto index_valid = std::make_unique<bool[]>(kRowCount);
+    for (int64_t i = 0; i < kRowCount; ++i) {
+        index_valid[i] = true;
+    }
+    auto scalar_index = index::CreateScalarIndexSort<int64_t>();
+    scalar_index->Build(kRowCount, index_values.data(), index_valid.get());
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = value_fid.get();
+    load_index_info.field_type = DataType::INT64;
+    load_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    load_index_info.index_params = GenIndexParams(scalar_index.get());
+    load_index_info.cache_index =
+        CreateTestCacheIndex("snapshot-index-only", std::move(scalar_index));
+    segment->LoadIndex(load_index_info);
+    segment->DropFieldData(value_fid);
+    ASSERT_FALSE(segment->HasFieldData(value_fid));
+
+    // The snapshot must replicate the segment's per-method readiness
+    // semantics: a clear ready bit yields 0 for chunk_size / num_chunk_data,
+    // and get_chunk_by_offset / num_rows_until_chunk do not gate on readiness.
+    auto snapshot = segment->CaptureReadSnapshot();
+    ASSERT_NE(snapshot, nullptr);
+    ASSERT_EQ(segment->num_chunk_data(value_fid), 0);
+    EXPECT_EQ(snapshot->num_chunk_data(value_fid),
+              segment->num_chunk_data(value_fid));
+    ASSERT_EQ(segment->chunk_size(value_fid, 0), 0);
+    EXPECT_EQ(snapshot->chunk_size(value_fid, 0),
+              segment->chunk_size(value_fid, 0));
+
+    // Field with raw data loaded: full parity on every accessor.
+    EXPECT_EQ(snapshot->num_chunk_data(pk_fid),
+              segment->num_chunk_data(pk_fid));
+    EXPECT_EQ(snapshot->chunk_size(pk_fid, 1), segment->chunk_size(pk_fid, 1));
+    EXPECT_EQ(snapshot->num_rows_until_chunk(pk_fid, 1),
+              segment->num_rows_until_chunk(pk_fid, 1));
+    EXPECT_EQ(snapshot->get_chunk_by_offset(pk_fid, 5),
+              segment->get_chunk_by_offset(pk_fid, 5));
+    EXPECT_EQ(snapshot->get_row_count(), segment->get_row_count());
+}
+
+TEST(OffsetsEvalIndexOnlyCorrectnessTest,
+     SealedReadSnapshotRejectsClearedState) {
+    constexpr int64_t kRowCount = 8;
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kRowCount / 2, 100, 0, 1, 1);
+    auto second = DataGen(schema, kRowCount / 2, 101, 0, 1, 1);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+
+    // A cleared state publishes runtime == nullptr; capturing a snapshot must
+    // fail loudly instead of dereferencing the null runtime.
+    segment->ClearData();
+    EXPECT_THROW({ auto snapshot = segment->CaptureReadSnapshot(); },
+                 milvus::SegcoreError);
+}
+
+TEST(OffsetsEvalIndexOnlyCorrectnessTest,
      NullableTimestamptzCallbackHandlesNullData) {
     constexpr int64_t kRowCount = 8;
     auto schema = std::make_shared<Schema>();


### PR DESCRIPTION
Related to #53247

Per-chunk segment metadata reads in the search/query hot loop still re-capture the immutable PublishedSegmentState on every access. After the reopen atomic-publication refactor removed the folly::SharedMutex, each chunk_size / num_rows_until_chunk / get_chunk_by_offset / num_chunk_data / get_row_count call still pays one std::atomic_load on a shared_ptr plus two ref-count RMWs per chunk.

Add a request-scoped SegmentReadSnapshot, captured exactly once in the exec visitor while the request read lease is held and threaded through QueryContext into the expression and chunk-reader layer. Per-chunk metadata reads now hit the pinned immutable state with zero atomics and zero ref-count churn. Growing segments and non-pinned paths fall back to per-call segment access with identical semantics.

A state-only SealedReadSnapshot derives every read purely from the published state (field columns, readiness bitsets, row count) and holds no segment pointer.