### PR TITLE
test: [3.0] fix external refresh, oversized insert and boost-ranker expectations

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -3631,9 +3631,9 @@ class TestMilvusClientExternalTableRefresh(ExternalTableTestBase):
         self, minio_env, external_prefix
     ):
         """
-        target: test MilvusClient external table refresh second concurrent returns existing or rejects (milvus#49231)
-        method: milvus#49231: duplicate refresh must not return a dropped new job_id
-        expected: behavior matches the case assertion.
+        target: verify duplicate external table refresh behavior (milvus#49231)
+        method: submit two back-to-back refreshes and inspect the first job if the second creates a new job
+        expected: reject/reuse while active, or create a new job only after the first job is terminal
         """
         minio_client, cfg = minio_env
         client = self._client()
@@ -3649,14 +3649,30 @@ class TestMilvusClientExternalTableRefresh(ExternalTableTestBase):
         schema = _build_basic_schema(self, client, ext_url)
         self.create_collection(client, collection_name=coll, schema=schema)
         job_first = self.refresh_external_collection(client, collection_name=coll)[0]
-        self.refresh_external_collection(
+        second_result, second_succeeded = self.refresh_external_collection(
             client,
             collection_name=coll,
-            check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100, ct.err_msg: "in progress"},
+            check_task=CheckTasks.check_nothing,
         )
+
         first_progress = self.wait_refresh_progress(client, job_first)
         assert first_progress.state == "RefreshCompleted"
+
+        if second_succeeded:
+            if second_result != job_first:
+                second_progress = self.wait_refresh_progress(client, second_result)
+                assert second_progress.state == "RefreshCompleted", (
+                    f"second refresh job {second_result} ended in {second_progress.state}: {second_progress.reason}"
+                )
+                assert first_progress.end_time <= second_progress.start_time, (
+                    "duplicate refresh jobs overlapped: "
+                    f"first={job_first} (end_time={first_progress.end_time}), "
+                    f"second={second_result} (start_time={second_progress.start_time})"
+                )
+        else:
+            assert second_result.code == 703, second_result
+            assert "in progress" in second_result.message, second_result
+            assert str(job_first) in second_result.message, second_result
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_external_table_list_refresh_jobs(self, minio_env, external_prefix):

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -714,9 +714,9 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_insert_over_resource_limit(self):
         """
-        target: test insert over RPC limitation 64MB (67108864)
-        method: insert excessive data
-        expected: raise exception
+        target: test insert over the materialized message size limit
+        method: insert data whose Proxy-side materialized message exceeds maxInsertSize
+        expected: reject the insert with a parameter-too-large error
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -725,7 +725,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 1. Create collection
         self.create_collection(client, collection_name, default_dim, auto_id=False)
 
-        # 2. Generate row data (150000 rows, which exceeds 64MB RPC limit)
+        # 2. Generate row data whose materialized message exceeds the default 64 MiB maxInsertSize
         rng = np.random.default_rng(seed=19530)
         rows = [
             {
@@ -738,8 +738,14 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         ]
 
         # 3. Verify error on insert
-        error = {ct.err_code: 999, ct.err_msg: "message larger than max"}
-        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
+        error = self.insert(
+            client,
+            collection_name,
+            data=rows,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1102, ct.err_msg: "exceeds maxInsertSize"},
+        )[0]
+        assert error.code == 1102, error
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -714,18 +714,19 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_insert_over_resource_limit(self):
         """
-        target: test insert over the materialized message size limit
-        method: insert data whose Proxy-side materialized message exceeds maxInsertSize
-        expected: reject the insert with a parameter-too-large error
+        target: test insert over the 128 MiB RPC receive limit
+        method: insert data whose vector payload alone exceeds the RPC receive limit
+        expected: reject the insert with a message-size error
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        nb = 150000
+        nb = 300000
 
         # 1. Create collection
         self.create_collection(client, collection_name, default_dim, auto_id=False)
 
-        # 2. Generate row data whose materialized message exceeds the default 64 MiB maxInsertSize
+        # 2. 3.0 leaves maxInsertSize disabled; the float32 vectors alone exceed 128 MiB.
+        assert nb * default_dim * np.dtype(np.float32).itemsize > 128 * 1024 * 1024
         rng = np.random.default_rng(seed=19530)
         rows = [
             {
@@ -738,14 +739,13 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         ]
 
         # 3. Verify error on insert
-        error = self.insert(
+        self.insert(
             client,
             collection_name,
             data=rows,
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1102, ct.err_msg: "exceeds maxInsertSize"},
-        )[0]
-        assert error.code == 1102, error
+            check_items={ct.err_code: 999, ct.err_msg: "message larger than max"},
+        )
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
@@ -809,5 +809,5 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
+            check_items={"err_code": 1100, "err_msg": "parse scorer filter failed"},
         )


### PR DESCRIPTION
pr: #53148
pr: #53101
issue: #53133
issue: #52648
issue: #53083

Backport the external refresh expectation fix from master PR #53148 to 3.0. Accept rejection or reuse while the first refresh is active; when a new job is returned, require successful completion and non-overlapping job timestamps.

Backport the boost-ranker invalid-filter assertion fix from master PR #53101. Match the current `parse scorer filter failed` wording while continuing to require rejection of the invalid filter.

Adapt the oversized insert case to the 3.0 contract: this branch keeps maxInsertSize disabled, so the original 150000-row request succeeds. Increase the request to 300000 rows, whose float32 vectors alone exceed the 128 MiB RPC receive limit, and assert the transport message-size rejection. No server defaults are changed.

Validation:
- Ruff check, Ruff format check, Python compilation, and git diff --check passed.
- The external refresh and oversized insert cases passed against server git_commit 6a8a5e4bdfe with PyMilvus 3.0.1rc74; automatic retries were disabled.
- The boost-ranker invalid-filter case passed in a separate focused E2E run against the same 3.0 deployment and SDK, with automatic retries disabled.
- The external refresh execution covered rejection of the second request with code 703 while the first job was active. Reuse and completed-first-job branches were not exercised by this run.
- Before the 3.0 adaptation, the unmodified backport's insert case failed because the 150000-row request succeeded.
