### PR TITLE
enhance: [3.0] harden schema bump integrity checks (#53222)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -333,7 +333,7 @@ func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() (*schemaBumpPhysi
 	}
 	schema := t.plan.GetSchema()
 
-	functionOutputFields, err := declaredFunctionOutputFields(schema)
+	functionOutputFields, err := validateSchemaBumpIntegrity(schema, existingFields)
 	if err != nil {
 		return nil, err
 	}
@@ -349,28 +349,6 @@ func (t *bumpSchemaVersionCompactionTask) schemaBumpDecision() (*schemaBumpPhysi
 		missingOutputFields:  missingOutputFields,
 		missingFunctions:     missingFunctions,
 	}, nil
-}
-
-// declaredFunctionOutputFields returns the field IDs declared as outputs by the
-// schema's functions. A field marked IsFunctionOutput that no function declares
-// is persisted-schema corruption: fail instead of silently backfilling a
-// non-nullable vector as an ordinary field.
-func declaredFunctionOutputFields(schema *schemapb.CollectionSchema) (map[int64]struct{}, error) {
-	declared := make(map[int64]struct{})
-	for _, functionSchema := range schema.GetFunctions() {
-		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
-			declared[outputFieldID] = struct{}{}
-		}
-	}
-	for _, field := range typeutil.GetAllFieldSchemas(schema) {
-		if field.GetIsFunctionOutput() {
-			if _, hasProducer := declared[field.GetFieldID()]; !hasProducer {
-				return nil, merr.WrapErrDataIntegrityMsg(
-					"function output field %d has no producing function", field.GetFieldID())
-			}
-		}
-	}
-	return declared, nil
 }
 
 // missingFunctionMaterializations derives, from the manifest-backed
@@ -713,7 +691,8 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		}
 	}()
 
-	var totalRows int64
+	var readRows int64
+	var writtenRows int64
 	for {
 		record, err := reader.Next()
 		if err != nil {
@@ -722,6 +701,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			}
 			return nil, err
 		}
+		readRows += int64(record.Len())
 
 		var selection *recordSelection
 		if preMaterializeFilter {
@@ -752,8 +732,22 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			out.Release()
 		}
 
-		totalRows += int64(wrapped.Len())
+		writtenRows += int64(wrapped.Len())
 		cleanupMaterializedRecord(wrapped)
+	}
+
+	if readRows != t.plan.GetTotalRows() {
+		return nil, merr.WrapErrDataIntegrityMsg(
+			"schema bump full rewrite segment %d read %d rows, expected %d",
+			segment.GetSegmentID(), readRows, t.plan.GetTotalRows(),
+		)
+	}
+	filteredRows := int64(entityFilter.GetDeletedCount() + entityFilter.GetExpiredCount())
+	if writtenRows+filteredRows != readRows {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"schema bump full rewrite segment %d row count mismatch: read %d, wrote %d, filtered %d",
+			segment.GetSegmentID(), readRows, writtenRows, filteredRows,
+		)
 	}
 
 	if err := writer.Close(); err != nil {
@@ -764,16 +758,11 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	// Update per-LOB-file valid_rows for REUSE_ALL fields: rows dropped by
 	// delete/TTL during the rewrite reduce the number of live LOB references.
 	if t.lobContext != nil && t.lobContext.HasReuseAllFields() {
-		inputRows := t.plan.GetTotalRows()
-		deletedRows := inputRows - totalRows
-		if deletedRows < 0 {
-			deletedRows = 0
-		}
-		t.lobContext.SetSegmentRowStats(segment.GetSegmentID(), inputRows, deletedRows)
+		t.lobContext.SetSegmentRowStats(segment.GetSegmentID(), t.plan.GetTotalRows(), filteredRows)
 	}
 
 	insertLogs, statsLog, bm25StatsLogs, manifestPath, expirQuantiles := writer.GetLogs()
-	if totalRows > 0 && manifestPath == "" {
+	if writtenRows > 0 && manifestPath == "" {
 		return nil, merr.WrapErrServiceInternal("schema bump full rewrite produced empty manifest")
 	}
 	statEntries := make([]packed.StatEntry, 0, len(bm25StatsLogs)+1)
@@ -799,7 +788,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 
 	resultSegment := &datapb.CompactionSegment{
 		SegmentID:           newSegmentID,
-		NumOfRows:           totalRows,
+		NumOfRows:           writtenRows,
 		InsertLogs:          sortedInsertLogs,
 		Channel:             segment.GetInsertChannel(),
 		StorageVersion:      segment.GetStorageVersion(),
@@ -825,7 +814,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		return nil, err
 	}
 
-	if totalRows > 0 {
+	if writtenRows > 0 {
 		// Text stats are built explicitly, matching sort compaction.
 		textStatsLogs, err := createTextIndex(t.ctx, t.chunkManager, t.plan, t.compactionParams, segment.GetStorageVersion(), collectionID, segment.GetPartitionID(), newSegmentID, t.plan.GetPlanID(), resultSegment)
 		if err != nil {

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -1064,6 +1064,41 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteDropsExpirQuantile
 	}
 }
 
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRejectsInputRowCountMismatch() {
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+	s.task.plan.TotalRows = 4
+
+	result, err := s.task.Compact()
+	s.Nil(result)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "read 3 rows, expected 4")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRejectsInputRowCountOverrun() {
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+	s.task.plan.TotalRows = 2
+
+	result, err := s.task.Compact()
+	s.Nil(result)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "read 3 rows, expected 2")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRejectsRowConservationMismatch() {
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+	s.task.plan.CollectionTtl = 1
+	selectionPatch := mockey.Mock(selectFullRewriteRecord).Return(&recordSelection{
+		ranges: []rowRange{{start: 0, end: 2}},
+		length: 2,
+	}, nil).Build()
+	defer selectionPatch.UnPatch()
+
+	result, err := s.task.Compact()
+	s.Nil(result)
+	s.ErrorIs(err, merr.ErrServiceInternal)
+	s.ErrorContains(err, "row count mismatch: read 3, wrote 2, filtered 0")
+}
+
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteNormalizesCommitTimestampBeforeWrite() {
 	s.prepareBumpSchemaVersionCompactionWithDroppedField()
 	s.task.plan.GetSegmentBinlogs()[0].CommitTimestamp = 5000
@@ -2017,6 +2052,31 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaBumpPhysicalDiffRejects
 	s.Require().Error(err)
 	s.ErrorIs(err, merr.ErrDataIntegrity)
 	s.ErrorContains(err, "has no producing function")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaBumpRejectsDuplicateFunctionOutputOwnershipBeforeVersionOnly() {
+	s.setupTest()
+	s.task.plan.Schema.Functions = append(s.task.plan.Schema.Functions, &schemapb.FunctionSchema{
+		Name:           "duplicate",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	})
+	existingFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+		102:                   {},
+	}
+	manifestPatch := mockey.Mock(packed.GetManifestFieldIDs).Return(existingFields, nil).Build()
+	defer manifestPatch.UnPatch()
+
+	result, err := s.task.Compact()
+	s.Nil(result)
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "field 102 is declared by both function BM25 and function duplicate")
 }
 
 // TestMaterializationStatsDeltaIgnoresPlanArrays is the regression test for

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -334,20 +334,9 @@ func compactionReadSchema(schema *schemapb.CollectionSchema, existingFields map[
 	}
 	readSchema.Fields = fields
 
-	structFields := make([]*schemapb.StructArrayFieldSchema, 0, len(readSchema.GetStructArrayFields()))
-	for _, structField := range readSchema.GetStructArrayFields() {
-		childFields := make([]*schemapb.FieldSchema, 0, len(structField.GetFields()))
-		for _, field := range structField.GetFields() {
-			if compactionFieldReadable(field, existingFields) {
-				childFields = append(childFields, field)
-			}
-		}
-		if len(childFields) > 0 {
-			structField.Fields = childFields
-			structFields = append(structFields, structField)
-		}
-	}
-	readSchema.StructArrayFields = structFields
+	// StructArray fields are physically indivisible. Keep every child in the
+	// read schema so a partially-present struct cannot be hidden by projection;
+	// schema-bump preflight rejects that state before the reader is opened.
 	return readSchema
 }
 
@@ -361,6 +350,86 @@ func compactionFieldReadable(field *schemapb.FieldSchema, existingFields map[int
 		return true
 	}
 	return !field.GetIsFunctionOutput()
+}
+
+// validateSchemaBumpIntegrity checks the persisted schema against the physical
+// field set during schema-bump preflight. Function output ownership is
+// represented both by FunctionSchema.OutputFieldIds and
+// FieldSchema.IsFunctionOutput, so the two representations must agree and each
+// output field must have exactly one owning function.
+// StructArray fields are physically all-or-nothing and cannot contain function
+// outputs, which are top-level fields by schema contract.
+func validateSchemaBumpIntegrity(schema *schemapb.CollectionSchema, existingFields map[int64]struct{}) (map[int64]struct{}, error) {
+	declaredFunctionOutputs := make(map[int64]struct{})
+	outputOwners := make(map[int64]int)
+	topLevelFields := make(map[int64]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, field := range schema.GetFields() {
+		topLevelFields[field.GetFieldID()] = field
+	}
+
+	for functionIndex, functionSchema := range schema.GetFunctions() {
+		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
+			if ownerIndex, duplicate := outputOwners[outputFieldID]; duplicate {
+				if ownerIndex == functionIndex {
+					return nil, merr.WrapErrDataIntegrityMsg(
+						"function %s declares output field %d more than once",
+						functionSchema.GetName(), outputFieldID)
+				}
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function output field %d is declared by both function %s and function %s",
+					outputFieldID, schema.GetFunctions()[ownerIndex].GetName(), functionSchema.GetName())
+			}
+			outputOwners[outputFieldID] = functionIndex
+			declaredFunctionOutputs[outputFieldID] = struct{}{}
+			field, ok := topLevelFields[outputFieldID]
+			if !ok {
+				if typeutil.GetField(schema, outputFieldID) != nil {
+					return nil, merr.WrapErrDataIntegrityMsg(
+						"function %s output field %d must be a top-level field",
+						functionSchema.GetName(), outputFieldID)
+				}
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function %s output field %d not found in persisted schema",
+					functionSchema.GetName(), outputFieldID)
+			}
+			if !field.GetIsFunctionOutput() {
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function %s output field %d is not marked as a function output",
+					functionSchema.GetName(), outputFieldID)
+			}
+		}
+	}
+
+	for _, field := range schema.GetFields() {
+		if !field.GetIsFunctionOutput() {
+			continue
+		}
+		if _, hasProducer := declaredFunctionOutputs[field.GetFieldID()]; !hasProducer {
+			return nil, merr.WrapErrDataIntegrityMsg(
+				"function output field %d has no producing function", field.GetFieldID())
+		}
+	}
+
+	for _, structField := range schema.GetStructArrayFields() {
+		presentChildren := 0
+		for _, childField := range structField.GetFields() {
+			if childField.GetIsFunctionOutput() {
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"struct array field %d child field %d cannot be a function output",
+					structField.GetFieldID(), childField.GetFieldID())
+			}
+			if _, present := existingFields[childField.GetFieldID()]; present {
+				presentChildren++
+			}
+		}
+		if presentChildren != 0 && presentChildren != len(structField.GetFields()) {
+			return nil, merr.WrapErrDataIntegrityMsg(
+				"struct array field %d is partially present: %d of %d children exist",
+				structField.GetFieldID(), presentChildren, len(structField.GetFields()))
+		}
+	}
+
+	return declaredFunctionOutputs, nil
 }
 
 func filterV1CompactionFieldBinlogs(fieldBinlogs []*datapb.FieldBinlog, readFields map[int64]struct{}) []*datapb.FieldBinlog {

--- a/internal/datanode/compactor/compactor_common_test.go
+++ b/internal/datanode/compactor/compactor_common_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestCompactionSegmentBinlogFieldsUsesChildFields(t *testing.T) {
@@ -65,6 +67,9 @@ func TestCompactionReadSchemaKeepsAbsentOrdinaryDropsMissingFunctionOutputs(t *t
 				},
 			},
 		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "f", OutputFieldIds: []int64{102, 103},
+		}},
 	}
 
 	fieldIDs := func(fields []*schemapb.FieldSchema) []int64 {
@@ -85,6 +90,112 @@ func TestCompactionReadSchemaKeepsAbsentOrdinaryDropsMissingFunctionOutputs(t *t
 
 func TestCompactionReadSchemaNilSchema(t *testing.T) {
 	require.Nil(t, compactionReadSchema(nil, map[int64]struct{}{}))
+}
+
+func TestValidateSchemaBumpIntegrity(t *testing.T) {
+	base := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "input", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "output", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{{
+			FieldID: 200,
+			Name:    "struct",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 201, Name: "child_a", DataType: schemapb.DataType_Int64},
+				{FieldID: 202, Name: "child_b", DataType: schemapb.DataType_Int64},
+			},
+		}},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "f", InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+		}},
+	}
+
+	tests := []struct {
+		name           string
+		mutate         func(*schemapb.CollectionSchema)
+		existingFields map[int64]struct{}
+		wantErr        string
+	}{
+		{name: "valid", existingFields: map[int64]struct{}{201: {}, 202: {}}},
+		{name: "whole struct absent", existingFields: map[int64]struct{}{}},
+		{
+			name: "output declared by multiple functions",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Functions = append(schema.Functions, &schemapb.FunctionSchema{
+					Name: "second", OutputFieldIds: []int64{101},
+				})
+			},
+			wantErr: "field 101 is declared by both function f and function second",
+		},
+		{
+			name: "output duplicated within one function",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Functions[0].OutputFieldIds = []int64{101, 101}
+			},
+			wantErr: "function f declares output field 101 more than once",
+		},
+		{
+			name: "declared output missing marker",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Fields[1].IsFunctionOutput = false
+			},
+			wantErr: "is not marked as a function output",
+		},
+		{
+			name: "marked output missing producer",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Functions = nil
+			},
+			wantErr: "has no producing function",
+		},
+		{
+			name: "declared output missing field",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Fields[1].IsFunctionOutput = false
+				schema.Functions[0].OutputFieldIds = []int64{999}
+			},
+			wantErr: "output field 999 not found in persisted schema",
+		},
+		{
+			name: "struct child marked as function output",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.StructArrayFields[0].Fields[0].IsFunctionOutput = true
+			},
+			wantErr: "child field 201 cannot be a function output",
+		},
+		{
+			name: "function targets struct child",
+			mutate: func(schema *schemapb.CollectionSchema) {
+				schema.Fields[1].IsFunctionOutput = false
+				schema.StructArrayFields[0].Fields[0].IsFunctionOutput = true
+				schema.Functions[0].OutputFieldIds = []int64{201}
+			},
+			wantErr: "output field 201 must be a top-level field",
+		},
+		{
+			name:           "struct partially present",
+			existingFields: map[int64]struct{}{201: {}},
+			wantErr:        "partially present: 1 of 2 children exist",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema := proto.Clone(base).(*schemapb.CollectionSchema)
+			if test.mutate != nil {
+				test.mutate(schema)
+			}
+			outputs, err := validateSchemaBumpIntegrity(schema, test.existingFields)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				require.Contains(t, outputs, int64(101))
+				return
+			}
+			require.ErrorIs(t, err, merr.ErrDataIntegrity)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
 }
 
 func TestDroppedSchemaFieldIDs(t *testing.T) {

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -62,6 +62,21 @@ type RecordMaterializer struct {
 }
 
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
+	// Output ownership is a construction invariant. Validate it before creating
+	// any function runner so corrupted metadata cannot reach the record hot path.
+	outputOwners := make(map[int64]string)
+	for _, functionSchema := range functions {
+		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
+			if owner, ok := outputOwners[outputFieldID]; ok {
+				return nil, merr.WrapErrDataIntegrityMsg(
+					"function output field %d is declared by both function %s and function %s",
+					outputFieldID, owner, functionSchema.GetName(),
+				)
+			}
+			outputOwners[outputFieldID] = functionSchema.GetName()
+		}
+	}
+
 	materializer := &RecordMaterializer{schema: schema}
 	materializedFields := make(map[int64]struct{})
 	for _, functionSchema := range functions {
@@ -366,8 +381,8 @@ func newMinHashFunctionMaterializer(schema *schemapb.CollectionSchema, runner fu
 		if inputField == nil || typeutil.GetField(schema, inputField.GetFieldID()) == nil {
 			return nil, merr.WrapErrFunctionFailedMsg("input field not found in schema")
 		}
-		if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_Text {
-			return nil, merr.WrapErrFunctionFailedMsg("input field data type must be varchar or text for minhash function materialization")
+		if inputField.GetDataType() != schemapb.DataType_VarChar {
+			return nil, merr.WrapErrFunctionFailedMsg("input field data type must be varchar for minhash function materialization; text input requires LOB decoding")
 		}
 		inputFieldIDs = append(inputFieldIDs, inputField.GetFieldID())
 	}
@@ -413,8 +428,8 @@ func newBM25FunctionMaterializer(schema *schemapb.CollectionSchema, runner funct
 		if inputField == nil || typeutil.GetField(schema, inputField.GetFieldID()) == nil {
 			return nil, merr.WrapErrParameterInvalidMsg("input field not found in schema")
 		}
-		if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_Text {
-			return nil, merr.WrapErrParameterInvalidMsg("input field data type must be varchar or text for bm25 function materialization")
+		if inputField.GetDataType() != schemapb.DataType_VarChar {
+			return nil, merr.WrapErrParameterInvalidMsg("input field data type must be varchar for bm25 function materialization; text input requires LOB decoding")
 		}
 		inputFieldIDs = append(inputFieldIDs, inputField.GetFieldID())
 	}

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -498,7 +498,7 @@ func TestBM25FunctionMaterializerMaterializesSparseOutput(t *testing.T) {
 	require.Equal(t, []any{[]string{"hello", "world"}}, runner.inputs)
 }
 
-func TestBM25FunctionMaterializerRejectsBinaryTextInputWithoutLOBDecoding(t *testing.T) {
+func TestBM25FunctionMaterializerRejectsTextInputWithoutLOBDecoding(t *testing.T) {
 	schema, functionSchema, inputField, outputField := materializerBM25Schema()
 	inputField.DataType = schemapb.DataType_Text
 	runner := &materializerTestFunctionRunner{
@@ -511,14 +511,18 @@ func TestBM25FunctionMaterializerRejectsBinaryTextInputWithoutLOBDecoding(t *tes
 		}},
 	}
 	materializer, err := newBM25FunctionMaterializer(schema, runner, []int{0}, false)
-	require.NoError(t, err)
-	defer materializer.Close()
+	require.Nil(t, materializer)
+	require.ErrorContains(t, err, "text input requires LOB decoding")
+	require.Nil(t, runner.inputs)
+}
 
+func TestStringInputsFromRecordRejectsBinaryTextWithoutLOBDecoding(t *testing.T) {
 	input := newBinaryArray(t, [][]byte{[]byte("encoded-lob-ref")})
 	defer input.Release()
-	_, err = materializer.Materialize(&materializerTestRecord{len: 1, columns: map[storage.FieldID]arrow.Array{100: input}})
+
+	_, err := stringInputsFromRecord(
+		&materializerTestRecord{len: 1, columns: map[storage.FieldID]arrow.Array{100: input}}, 100)
 	require.ErrorContains(t, err, "cannot materialize bm25 from text binary values without lob decoding")
-	require.Nil(t, runner.inputs)
 }
 
 func TestBM25FunctionMaterializerMaterializesNullableInputAsNonNullableOutput(t *testing.T) {
@@ -651,6 +655,30 @@ func TestNewRecordMaterializerRejectsPartiallyPresentFunctionOutputs(t *testing.
 	)
 	require.Nil(t, materializer)
 	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+}
+
+func TestNewRecordMaterializerRejectsDuplicateFunctionOutputOwnership(t *testing.T) {
+	functions := []*schemapb.FunctionSchema{
+		{Name: "first", OutputFieldIds: []int64{102}},
+		{Name: "second", OutputFieldIds: []int64{102}},
+	}
+
+	materializer, err := NewRecordMaterializer(&schemapb.CollectionSchema{}, functions, nil)
+	require.Nil(t, materializer)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.ErrorContains(t, err, "field 102")
+	require.ErrorContains(t, err, "first")
+	require.ErrorContains(t, err, "second")
+
+	functions[1].OutputFieldIds = []int64{103}
+	materializer, err = NewRecordMaterializer(
+		&schemapb.CollectionSchema{},
+		functions,
+		map[int64]struct{}{102: {}, 103: {}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, materializer)
+	materializer.Close()
 }
 
 func TestMaterializedRecordReaderReleasesPreviousRecordOnNextAndClose(t *testing.T) {

--- a/internal/datanode/compactor/record_materializer_ut_test.go
+++ b/internal/datanode/compactor/record_materializer_ut_test.go
@@ -98,6 +98,7 @@ func rmSchemaMinHash() *schemapb.CollectionSchema {
 // constructors fires with the right message.
 func TestRMFunctionMaterializerCtorGuards(t *testing.T) {
 	varcharIn := &schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar}
+	textIn := &schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_Text}
 	int64In := &schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_Int64}
 	ghostIn := &schemapb.FieldSchema{FieldID: 999, Name: "ghost", DataType: schemapb.DataType_VarChar}
 
@@ -117,7 +118,11 @@ func TestRMFunctionMaterializerCtorGuards(t *testing.T) {
 		{"bm25-input-wrong-type", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
 			s.Fields[1].DataType = schemapb.DataType_Int64
 			r.inputs = []*schemapb.FieldSchema{int64In}
-		}, "must be varchar or text"},
+		}, "must be varchar"},
+		{"bm25-text-input", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[1].DataType = schemapb.DataType_Text
+			r.inputs = []*schemapb.FieldSchema{textIn}
+		}, "must be varchar"},
 		{"bm25-no-outputs", schemapb.FunctionType_BM25, rmSchemaBM25(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
 			r.schema.OutputFieldIds = nil
 		}, "should have output fields"},
@@ -139,7 +144,11 @@ func TestRMFunctionMaterializerCtorGuards(t *testing.T) {
 		{"minhash-input-wrong-type", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
 			s.Fields[1].DataType = schemapb.DataType_Int64
 			r.inputs = []*schemapb.FieldSchema{int64In}
-		}, "must be varchar or text"},
+		}, "must be varchar"},
+		{"minhash-text-input", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, s *schemapb.CollectionSchema) {
+			s.Fields[1].DataType = schemapb.DataType_Text
+			r.inputs = []*schemapb.FieldSchema{textIn}
+		}, "must be varchar"},
 		{"minhash-no-outputs", schemapb.FunctionType_MinHash, rmSchemaMinHash(), func(r *fakeFunctionRunner, _ *schemapb.CollectionSchema) {
 			r.schema.OutputFieldIds = nil
 		}, "should have output fields"},

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -388,9 +388,11 @@ func GetManifestFieldIDs(manifestPath string, storageConfig *indexpb.StorageConf
 		return nil, err
 	}
 	defer C.loon_manifest_destroy(manifest)
+	return manifestFieldIDsFromColumnGroups(manifestPath, &manifest.column_groups)
+}
 
+func manifestFieldIDsFromColumnGroups(manifestPath string, cgroups *C.LoonColumnGroups) (map[int64]struct{}, error) {
 	fields := make(map[int64]struct{})
-	cgroups := &manifest.column_groups
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
 		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
@@ -398,13 +400,21 @@ func GetManifestFieldIDs(manifestPath string, storageConfig *indexpb.StorageConf
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))
 	for i := range cgArray {
 		cg := &cgArray[i]
-		if cg.columns == nil {
+		if cg.num_of_columns == 0 {
+			mlog.RatedWarn(context.TODO(), 1, "manifest contains an empty column group",
+				mlog.String("manifestPath", manifestPath),
+				mlog.Int("columnGroupIndex", i))
 			continue
 		}
+		if cg.columns == nil {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"columns array is nil but num_of_columns is %d in column group %d", cg.num_of_columns, i)
+		}
 		columns := unsafe.Slice(cg.columns, int(cg.num_of_columns))
-		for _, column := range columns {
+		for j, column := range columns {
 			if column == nil {
-				continue
+				return nil, merr.WrapErrServiceInternalMsg(
+					"nil column name in column group %d at index %d", i, j)
 			}
 			columnName := C.GoString(column)
 			fieldID, err := strconv.ParseInt(columnName, 10, 64)

--- a/internal/storagev2/packed/manifest_ffi_testutil.go
+++ b/internal/storagev2/packed/manifest_ffi_testutil.go
@@ -1,0 +1,62 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+// +build test
+
+package packed
+
+/*
+#cgo pkg-config: milvus_core milvus-storage
+#include <stdint.h>
+#include <stdlib.h>
+#include "milvus-storage/ffi_c.h"
+*/
+import "C"
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+func testManifestFieldIDsFromColumns(columnNames []*string, numColumns int) (map[int64]struct{}, error) {
+	var group C.LoonColumnGroup
+	group.num_of_columns = C.uint32_t(numColumns)
+
+	var cColumns []*C.char
+	if columnNames != nil {
+		columnSlots := len(columnNames)
+		if columnSlots == 0 {
+			columnSlots = 1
+		}
+		cColumns = make([]*C.char, columnSlots)
+		for i, columnName := range columnNames {
+			if columnName == nil {
+				continue
+			}
+			cColumns[i] = C.CString(*columnName)
+			defer C.free(unsafe.Pointer(cColumns[i]))
+		}
+		group.columns = (**C.char)(unsafe.Pointer(&cColumns[0]))
+	}
+
+	var groups C.LoonColumnGroups
+	groups.column_group_array = &group
+	groups.num_of_column_groups = 1
+	fields, err := manifestFieldIDsFromColumnGroups("test-manifest", &groups)
+	runtime.KeepAlive(cColumns)
+	return fields, err
+}

--- a/internal/storagev2/packed/packed_writer_ffi_test.go
+++ b/internal/storagev2/packed/packed_writer_ffi_test.go
@@ -59,6 +59,40 @@ func TestGetManifestFieldIDs_InvalidManifestPath(t *testing.T) {
 	assert.Nil(t, fields)
 }
 
+func TestManifestFieldIDsFromColumnGroupsValidatesShape(t *testing.T) {
+	fieldID := "100"
+	tests := []struct {
+		name        string
+		columns     []*string
+		numColumns  int
+		wantFieldID bool
+		wantErr     string
+	}{
+		{name: "nil empty array", columns: nil, numColumns: 0},
+		{name: "non-nil empty array", columns: []*string{}, numColumns: 0},
+		{name: "positive count with nil array", columns: nil, numColumns: 1, wantErr: "columns array is nil"},
+		{name: "nil column element", columns: []*string{nil}, numColumns: 1, wantErr: "nil column name"},
+		{name: "valid column", columns: []*string{&fieldID}, numColumns: 1, wantFieldID: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fields, err := testManifestFieldIDsFromColumns(test.columns, test.numColumns)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				assert.Nil(t, fields)
+				return
+			}
+			require.NoError(t, err)
+			if test.wantFieldID {
+				assert.Contains(t, fields, int64(100))
+			} else {
+				assert.Empty(t, fields)
+			}
+		})
+	}
+}
+
 func TestGetManifestFieldIDs_InvalidColumnName(t *testing.T) {
 	paramtable.Init()
 	pt := paramtable.Get()


### PR DESCRIPTION
issue: #51649
pr: #53222

## Summary
- Cherry-pick the schema-bump integrity hardening from master PR #53222 to 3.0.
- Preserve the complete production and regression-test patch without 3.0-specific adaptations.
- The cherry-pick applied cleanly and has the same stable patch ID as the master commit.