### PR TITLE
enhance: expose collection-level QueryNode memory usage

### DIFF
--- a/internal/core/src/monitor/monitor_c.cpp
+++ b/internal/core/src/monitor/monitor_c.cpp
@@ -23,7 +23,7 @@ char*
 GetCoreMetrics() {
     UpdateArrowIOThreadPoolMetrics();
     static_cast<void>(
-        milvus::cachinglayer::monitor::collect_cache_shard_disk_usage_stats());
+        milvus::cachinglayer::monitor::collect_cache_shard_usage_stats());
     auto str = milvus::monitor::getPrometheusClient().GetMetrics();
     auto len = str.length();
     char* res = static_cast<char*>(malloc(len + 1));

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -122,6 +122,7 @@
 #include "prometheus/histogram.h"
 #include "query/PlanImpl.h"
 #include "query/SearchOnSealed.h"
+#include "segcore/CacheMetricAttribution.h"
 #include "segcore/ConcurrentVector.h"
 #include "segcore/DeletedRecord.h"
 #include "segcore/SealedIndexingRecord.h"
@@ -513,6 +514,8 @@ ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
         translator =
             std::make_unique<storagev2translator::TimestampIndexTranslator>(
                 id_, column, num_rows, warmup_policy);
+    translator->meta()->metric_attribution = MetricAttributionFromShard(
+        CaptureLoadInfoSnapshot()->GetInsertChannel());
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
         std::move(translator));
     auto cell_holder =
@@ -585,6 +588,8 @@ ChunkedSegmentSealedImpl::BuildPkIndexSlot(
     std::unique_ptr<cachinglayer::Translator<storagev2translator::PkIndexCell>>
         translator = std::make_unique<storagev2translator::PkIndexTranslator>(
             id_, column, data_type, is_sorted_by_pk_);
+    translator->meta()->metric_attribution = MetricAttributionFromShard(
+        CaptureLoadInfoSnapshot()->GetInsertChannel());
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
         std::move(translator));
     if (eager) {
@@ -2762,6 +2767,9 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                         translator = std::make_unique<
                             storagev2translator::TimestampIndexTranslator>(
                             id_, column, num_rows, info.warmup_policy);
+                    translator->meta()->metric_attribution =
+                        MetricAttributionFromShard(
+                            segment_load_info.GetInsertChannel());
                     auto slot =
                         cachinglayer::Manager::GetInstance().CreateCacheSlot(
                             std::move(translator));
@@ -6815,6 +6823,8 @@ ChunkedSegmentSealedImpl::generate_interim_index(
                         dim,
                         is_sparse,
                         field_meta.get_data_type());
+            translator->meta()->metric_attribution = MetricAttributionFromShard(
+                snapshot->load_info->GetInsertChannel());
 
             auto interim_index_cache_slot =
                 milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
@@ -8585,6 +8595,9 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                     translator = std::make_unique<
                         storagev2translator::TimestampIndexTranslator>(
                         id_, column, num_rows, "");
+                translator->meta()->metric_attribution =
+                    MetricAttributionFromShard(
+                        segment_load_info.GetInsertChannel());
                 auto slot =
                     cachinglayer::Manager::GetInstance().CreateCacheSlot(
                         std::move(translator));

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -39,6 +39,7 @@
 
 #include "NamedType/named_type_impl.hpp"
 #include "cachinglayer/CacheSlot.h"
+#include "cachinglayer/Metrics.h"
 #include "common/Consts.h"
 #include "common/LoadInfo.h"
 #include "common/Schema.h"
@@ -71,6 +72,7 @@
 #include "segcore/search_result_export_c.h"
 #include "segcore/Types.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
+#include "segcore/storagev2translator/SystemIndexTranslator.h"
 #include "segcore/storagev1translator/ChunkTranslator.h"
 #include "storage/FileManager.h"
 #include "storage/Types.h"
@@ -299,17 +301,25 @@ TEST(ChunkedSegmentSealedStorageV2,
 class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
  protected:
     segcore::SegmentSealedUPtr
-    CreateSegment(bool is_sorted_by_pk) {
+    CreateSegment(bool is_sorted_by_pk, const std::string& shard = "") {
         auto seg = segcore::CreateSealedSegment(
             schema_,
             nullptr,
             -1,
             segcore::SegcoreConfig::default_config(),
             is_sorted_by_pk);
+        if (!shard.empty()) {
+            proto::segcore::SegmentLoadInfo proto;
+            proto.set_insert_channel(shard);
+            proto.set_storageversion(2);
+            proto.set_num_of_rows(RowCount());
+            seg->SetLoadInfo(std::move(proto));
+        }
         seg->AddFieldDataInfoForSealed(load_info_);
         for (auto& [id, info] : load_info_.field_infos) {
             LoadFieldDataInfo load_field_info;
             load_field_info.storage_version = 2;
+            load_field_info.shard = shard;
             load_field_info.field_infos.emplace(id, info);
             seg->LoadFieldData(load_field_info);
         }
@@ -1449,4 +1459,42 @@ TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnSortedSegment) {
         ASSERT_EQ(pk_result->scalars().long_data().data(0), 0);
         ASSERT_EQ(pk_result->scalars().long_data().data(1), 42);
     }
+}
+
+TEST_P(TestChunkSegmentStorageV2, SystemIndexMemoryUsageByShard) {
+    constexpr auto kShard = "by-dev-rootcoord-dml_0_987654322v0";
+    const auto memory_usage = [&](cachinglayer::CellDataType type) {
+        return cachinglayer::monitor::cache_shard_usage_bytes_value(
+            type, kShard, cachinglayer::StorageType::MEMORY);
+    };
+    auto tracked_segment = CreateSegment(false, kShard);
+    auto* segment_impl =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(tracked_segment.get());
+    ASSERT_NE(segment_impl, nullptr);
+    PkType existing_pk =
+        GetParam() ? PkType(std::string("test42")) : PkType(int64_t(42));
+    ASSERT_TRUE(segment_impl->Contain(existing_pk));
+    {
+        auto runtime = segment_impl->TestGetPublishedStateSnapshot()->runtime;
+        ASSERT_NE(runtime->pk_index_slot, nullptr);
+        ASSERT_NE(runtime->timestamp_index_slot, nullptr);
+        auto pk = cachinglayer::SemiInlineGet(
+            runtime->pk_index_slot->PinCells(nullptr, {0}));
+        auto timestamp = cachinglayer::SemiInlineGet(
+            runtime->timestamp_index_slot->PinCells(nullptr, {0}));
+        ASSERT_NE(pk->get_cell_of(0), nullptr);
+        ASSERT_NE(timestamp->get_cell_of(0), nullptr);
+        auto pk_memory = pk->get_cell_of(0)->CellByteSize().memory_bytes;
+        auto timestamp_memory =
+            timestamp->get_cell_of(0)->CellByteSize().memory_bytes;
+        EXPECT_GT(pk_memory, 0);
+        EXPECT_GT(timestamp_memory, 0);
+        EXPECT_EQ(memory_usage(cachinglayer::CellDataType::OTHER), pk_memory);
+        EXPECT_EQ(memory_usage(cachinglayer::CellDataType::SCALAR_INDEX),
+                  timestamp_memory);
+    }
+    tracked_segment.reset();
+    EXPECT_EQ(memory_usage(cachinglayer::CellDataType::OTHER), std::nullopt);
+    EXPECT_EQ(memory_usage(cachinglayer::CellDataType::SCALAR_INDEX),
+              std::nullopt);
 }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -49,6 +49,7 @@
 #include "common/FieldDataInterface.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
+#include "common/PrometheusClient.h"
 #include "common/Schema.h"
 #include "common/Span.h"
 #include "common/Types.h"
@@ -688,6 +689,33 @@ SegmentGrowingImpl::UpdateResourceTracking() {
 }
 
 void
+SegmentGrowingImpl::UpdateCollectionMemoryUsage(int64_t collection_id,
+                                                int64_t memory_bytes) {
+    if (collection_id <= 0 || memory_bytes == 0) {
+        return;
+    }
+    static auto& family =
+        prometheus::BuildGauge()
+            .Name("internal_growing_segment_memory_usage_bytes")
+            .Help("Growing segment memory usage by collection in bytes.")
+            .Register(milvus::monitor::getPrometheusClient().GetRegistry());
+    static std::mutex mutex;
+    static std::map<int64_t, prometheus::Gauge*> metrics;
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = metrics.find(collection_id);
+    if (it == metrics.end()) {
+        auto& gauge =
+            family.Add({{"collection_id", std::to_string(collection_id)}});
+        it = metrics.emplace(collection_id, &gauge).first;
+    }
+    it->second->Increment(memory_bytes);
+    if (it->second->Value() == 0) {
+        family.Remove(it->second);
+        metrics.erase(it);
+    }
+}
+
+void
 SegmentGrowingImpl::UpdateResourceTracking(const Schema& schema) {
     auto new_resource = EstimateSegmentResourceUsage(schema);
 
@@ -706,6 +734,17 @@ SegmentGrowingImpl::UpdateResourceTracking(const Schema& schema) {
             new_resource, fmt::format("growing_segment_{}_charge", id_));
     }
 
+    auto collection_id = load_info_.collectionid();
+    if (collection_id != tracked_collection_id_) {
+        UpdateCollectionMemoryUsage(tracked_collection_id_,
+                                    -old_resource.memory_bytes);
+        UpdateCollectionMemoryUsage(collection_id, new_resource.memory_bytes);
+    } else {
+        UpdateCollectionMemoryUsage(
+            collection_id,
+            new_resource.memory_bytes - old_resource.memory_bytes);
+    }
+    tracked_collection_id_ = collection_id;
     tracked_resource_ = new_resource;
 }
 
@@ -970,12 +1009,12 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         insert_record_.insert_pk(pks[i], reserved_offset + i);
     }
 
-    // step 5: update the resource usage
-    UpdateResourceTracking(*schema);
-
-    // step 6: update small indexes
+    // step 5: publish the inserted rows
     insert_record_.ack_responder_.AddSegment(reserved_offset,
                                              reserved_offset + num_rows);
+
+    // step 6: update the resource usage
+    UpdateResourceTracking(*schema);
 }
 
 void
@@ -1476,6 +1515,7 @@ SegmentGrowingImpl::LoadDeletedRecord(const LoadDeletedRecordInfo& info) {
 
     // step 2: push delete info to delete_record
     deleted_record_.LoadPush(pks, timestamps);
+    UpdateResourceTracking(*schema);
 }
 
 cachinglayer::PinWrapper<SpanBase>
@@ -3064,6 +3104,7 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     if (manifest_path != "") {
         LoadColumnsGroups(manifest_path);
         FillAbsentFields();
+        UpdateResourceTracking();
         return;
     }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -484,6 +484,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
                 tracked_resource_,
                 fmt::format("growing_segment_{}_destructor", id_));
         }
+        UpdateCollectionMemoryUsage(tracked_collection_id_,
+                                    -tracked_resource_.memory_bytes);
     }
 
     void
@@ -813,6 +815,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
     UpdateResourceTracking(const Schema& schema);
 
  private:
+    static void
+    UpdateCollectionMemoryUsage(int64_t collection_id, int64_t memory_bytes);
+
     void
     AddTexts(FieldId field_id,
              const std::string* texts,
@@ -927,6 +932,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     // Tracked resource usage for refund-then-charge pattern
     // This stores the last estimated resource usage that was charged to the cache manager
     ResourceUsage tracked_resource_{};
+    int64_t tracked_collection_id_{0};
     // Mutex to protect tracked_resource_ updates (refund-then-charge must be atomic)
     mutable std::mutex resource_tracking_mutex_;
 

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -37,6 +37,7 @@
 #include "common/EasyAssert.h"
 #include "common/Geometry.h"
 #include "common/IndexMeta.h"
+#include "common/PrometheusClient.h"
 #include "common/QueryResult.h"
 #include "common/Schema.h"
 #include "common/Types.h"
@@ -73,6 +74,25 @@ using namespace milvus::segcore;
 using namespace milvus;
 
 namespace {
+
+std::optional<double>
+GrowingCollectionMemoryUsage(int64_t collection_id) {
+    for (const auto& family :
+         milvus::monitor::getPrometheusClient().GetRegistry().Collect()) {
+        if (family.name != "internal_growing_segment_memory_usage_bytes") {
+            continue;
+        }
+        for (const auto& metric : family.metric) {
+            for (const auto& label : metric.label) {
+                if (label.name == "collection_id" &&
+                    label.value == std::to_string(collection_id)) {
+                    return metric.gauge.value;
+                }
+            }
+        }
+    }
+    return std::nullopt;
+}
 
 void
 AddStorageV3SystemFields(const SchemaPtr& schema) {
@@ -2060,6 +2080,10 @@ TEST(Growing, ResourceIncrementsWithMoreInserts) {
     schema->set_primary_field_id(pk_fid);
 
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    constexpr int64_t kCollectionID = 987654323;
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(kCollectionID);
+    segment->SetLoadInfo(load_info);
     auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
     ASSERT_NE(segment_impl, nullptr);
 
@@ -2073,6 +2097,8 @@ TEST(Growing, ResourceIncrementsWithMoreInserts) {
                     dataset1.timestamps_.data(),
                     dataset1.raw_);
     auto resource1 = segment_impl->EstimateSegmentResourceUsage();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID),
+              resource1.memory_bytes);
 
     // Second insert
     const int64_t N2 = 500;
@@ -2087,6 +2113,29 @@ TEST(Growing, ResourceIncrementsWithMoreInserts) {
 
     // Resource should increase after second insert
     EXPECT_GT(resource2.memory_bytes, resource1.memory_bytes);
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID),
+              resource2.memory_bytes);
+
+    auto other = CreateGrowingSegment(schema, empty_index_meta);
+    other->SetLoadInfo(load_info);
+    auto offset = other->PreInsert(N1);
+    other->Insert(offset,
+                  N1,
+                  dataset1.row_ids_.data(),
+                  dataset1.timestamps_.data(),
+                  dataset1.raw_);
+    auto* other_impl = dynamic_cast<SegmentGrowingImpl*>(other.get());
+    ASSERT_NE(other_impl, nullptr);
+    auto other_resource = other_impl->EstimateSegmentResourceUsage();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID),
+              resource2.memory_bytes + other_resource.memory_bytes);
+    segment.reset();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID),
+              other_resource.memory_bytes);
+    load_info.clear_collectionid();
+    other->SetLoadInfo(load_info);
+    other.reset();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID), std::nullopt);
 }
 
 TEST(Growing, ResourceTrackingAfterDelete) {
@@ -2098,6 +2147,9 @@ TEST(Growing, ResourceTrackingAfterDelete) {
     schema->set_primary_field_id(pk_fid);
 
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(987654324);
+    segment->SetLoadInfo(load_info);
     auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
     ASSERT_NE(segment_impl, nullptr);
 
@@ -2124,6 +2176,10 @@ TEST(Growing, ResourceTrackingAfterDelete) {
     // Resource estimation should still work after delete
     auto resource_after_delete = segment_impl->EstimateSegmentResourceUsage();
     EXPECT_GT(resource_after_delete.memory_bytes, 0);
+    EXPECT_EQ(GrowingCollectionMemoryUsage(987654324),
+              resource_after_delete.memory_bytes);
+    segment.reset();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(987654324), std::nullopt);
 }
 
 TEST(Growing, ConcurrentInsertResourceTracking) {
@@ -2134,9 +2190,14 @@ TEST(Growing, ConcurrentInsertResourceTracking) {
     auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
     schema->set_primary_field_id(pk_fid);
 
+    constexpr int64_t kCollectionID = 987654325;
     auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(kCollectionID);
+    segment->SetLoadInfo(load_info);
     auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
     ASSERT_NE(segment_impl, nullptr);
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID), std::nullopt);
 
     const int num_threads = 4;
     const int64_t rows_per_thread = 100;
@@ -2169,6 +2230,30 @@ TEST(Growing, ConcurrentInsertResourceTracking) {
     // Verify resource estimation is consistent and positive
     auto resource = segment_impl->EstimateSegmentResourceUsage();
     EXPECT_GT(resource.memory_bytes, 0);
+    // Concurrent estimates may be published out of order.
+    auto memory_usage = GrowingCollectionMemoryUsage(kCollectionID);
+    ASSERT_TRUE(memory_usage.has_value());
+    EXPECT_GT(memory_usage.value(), 0);
+    EXPECT_LE(memory_usage.value(), resource.memory_bytes);
+
+    // The next serial insert must publish the current estimate.
+    auto dataset =
+        DataGen(schema, rows_per_thread, 42 + num_threads, total_rows);
+    auto offset = segment->PreInsert(rows_per_thread);
+    ASSERT_EQ(offset, total_rows);
+    segment->Insert(offset,
+                    rows_per_thread,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    EXPECT_EQ(segment->get_row_count(), total_rows + rows_per_thread);
+    auto updated_resource = segment_impl->EstimateSegmentResourceUsage();
+    EXPECT_GT(updated_resource.memory_bytes, resource.memory_bytes);
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID),
+              updated_resource.memory_bytes);
+
+    segment.reset();
+    EXPECT_EQ(GrowingCollectionMemoryUsage(kCollectionID), std::nullopt);
 }
 
 TEST(Growing, NullableVectorInsertBuildsMonotonicOffsetMapping) {

--- a/internal/querynodev2/metrics_info.go
+++ b/internal/querynodev2/metrics_info.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -31,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -329,4 +334,54 @@ func getSystemInfoMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest, 
 	metricsinfo.FillDeployMetricsWithEnv(&nodeInfos.SystemInfo)
 
 	return metricsinfo.MarshalComponentInfos(nodeInfos)
+}
+
+// appendQueryNodeCollectionMemoryUsage aggregates sealed and growing memory from the current core scrape.
+// It leaves the source metrics unchanged and does not retain usage between scrapes.
+func appendQueryNodeCollectionMemoryUsage(nodeID string, families map[string]*dto.MetricFamily) {
+	usage := make(map[int64]float64)
+	for _, metric := range families["internal_cache_shard_memory_usage_bytes"].GetMetric() {
+		for _, label := range metric.GetLabel() {
+			if label.GetName() != "shard" {
+				continue
+			}
+			_, collectionID, _, err := funcutil.ParseVChannel(label.GetValue())
+			if err == nil && collectionID > 0 {
+				usage[collectionID] += metric.GetGauge().GetValue()
+			}
+			break
+		}
+	}
+	for _, metric := range families["internal_growing_segment_memory_usage_bytes"].GetMetric() {
+		for _, label := range metric.GetLabel() {
+			if label.GetName() != "collection_id" {
+				continue
+			}
+			collectionID, err := strconv.ParseInt(label.GetValue(), 10, 64)
+			if err == nil && collectionID > 0 {
+				usage[collectionID] += metric.GetGauge().GetValue()
+			}
+			break
+		}
+	}
+	if len(usage) == 0 {
+		return
+	}
+
+	name := "milvus_querynode_collection_memory_usage_bytes"
+	family := &dto.MetricFamily{
+		Name: proto.String(name),
+		Help: proto.String("Collection memory usage in bytes."),
+		Type: dto.MetricType_GAUGE.Enum(),
+	}
+	for collectionID, memoryBytes := range usage {
+		family.Metric = append(family.Metric, &dto.Metric{
+			Label: []*dto.LabelPair{
+				{Name: proto.String("collection_id"), Value: proto.String(strconv.FormatInt(collectionID, 10))},
+				{Name: proto.String("node_id"), Value: proto.String(nodeID)},
+			},
+			Gauge: &dto.Gauge{Value: proto.Float64(memoryBytes)},
+		})
+	}
+	families[name] = family
 }

--- a/internal/querynodev2/metrics_info_test.go
+++ b/internal/querynodev2/metrics_info_test.go
@@ -17,12 +17,17 @@
 package querynodev2
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -166,4 +171,95 @@ func TestStreamingQuotaMetrics(t *testing.T) {
 	local.EXPECT().GetMetricsIfLocal(mock.Anything).Return(nil, errors.New("test"))
 	m = getStreamingQuotaMetrics()
 	assert.Nil(t, m)
+}
+
+func TestAppendQueryNodeCollectionMemoryUsage(t *testing.T) {
+	const nodeID = "101"
+	const source = "internal_cache_shard_memory_usage_bytes"
+	const growing = "internal_growing_segment_memory_usage_bytes"
+	const target = "milvus_querynode_collection_memory_usage_bytes"
+	const header = "# TYPE " + source + " gauge\n"
+	tests := []struct {
+		name     string
+		text     string
+		expected map[string]float64
+	}{
+		{
+			name: "sum data types and shards by collection",
+			text: header +
+				source + "{data_type=\"scalar_field\",shard=\"channel_1001v0\"} 128\n" +
+				source + "{data_type=\"vector_index\",shard=\"channel_1001v0\"} 256\n" +
+				source + "{data_type=\"vector_field\",shard=\"channel_1001v1\"} 512\n" +
+				source + "{data_type=\"other\",shard=\"channel_1002v0\"} 32\n" +
+				"# TYPE internal_cache_shard_disk_usage_bytes gauge\n" +
+				"internal_cache_shard_disk_usage_bytes{shard=\"channel_1001v0\"} 4096\n",
+			expected: map[string]float64{"1001": 896, "1002": 32},
+		},
+		{
+			name:     "single shard",
+			text:     header + source + "{shard=\"channel_1001v0\"} 64\n",
+			expected: map[string]float64{"1001": 64},
+		},
+		{
+			name: "sum sealed and growing memory",
+			text: header + source + "{shard=\"channel_1001v0\"} 128\n" +
+				"# TYPE " + growing + " gauge\n" +
+				growing + "{collection_id=\"1001\"} 512\n" +
+				growing + "{collection_id=\"1002\"} 32\n",
+			expected: map[string]float64{"1001": 640, "1002": 32},
+		},
+		{
+			name: "growing without sealed memory",
+			text: "# TYPE " + growing + " gauge\n" +
+				growing + "{collection_id=\"1001\"} 64\n" +
+				growing + "{collection_id=\"0\"} 128\n" +
+				growing + "{collection_id=\"invalid\"} 256\n",
+			expected: map[string]float64{"1001": 64},
+		},
+		{
+			name: "skip unknown attribution and retain attributed zero",
+			text: header +
+				source + "{shard=\"invalid\"} 1\n" +
+				source + "{shard=\"channel_0v0\"} 2\n" +
+				source + "{shard=\"channel_-1v0\"} 4\n" +
+				source + "{shard=\"channel_9223372036854775808v0\"} 8\n" +
+				source + "{collection_id=\"1001\"} 16\n" +
+				source + "{shard=\"channel_1001v0\"} 0\n",
+			expected: map[string]float64{"1001": 0},
+		},
+		{name: "no source samples"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var parser expfmt.TextParser
+			families, err := parser.TextToMetricFamilies(strings.NewReader(test.text))
+			require.NoError(t, err)
+			original := make(map[string]*dto.MetricFamily, len(families))
+			for name, family := range families {
+				original[name] = proto.Clone(family).(*dto.MetricFamily)
+			}
+			appendQueryNodeCollectionMemoryUsage(nodeID, families)
+			if len(test.expected) == 0 {
+				require.NotContains(t, families, target)
+			} else {
+				family := families[target]
+				require.NotNil(t, family)
+				require.Equal(t, dto.MetricType_GAUGE, family.GetType())
+				require.Len(t, family.GetMetric(), len(test.expected))
+				actual := make(map[string]float64)
+				for _, metric := range family.GetMetric() {
+					require.Len(t, metric.GetLabel(), 2)
+					require.Equal(t, "collection_id", metric.Label[0].GetName())
+					require.Equal(t, "node_id", metric.Label[1].GetName())
+					require.Equal(t, nodeID, metric.Label[1].GetValue())
+					actual[metric.Label[0].GetValue()] = metric.GetGauge().GetValue()
+				}
+				require.Equal(t, test.expected, actual)
+			}
+			for name, family := range original {
+				require.True(t, proto.Equal(family, families[name]), name)
+			}
+		})
+	}
 }

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -38,6 +38,7 @@ import (
 	"sync"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -452,6 +453,10 @@ func (node *QueryNode) Start() error {
 			fmt.Sprint(node.GetNodeID()),
 			segments.CollectPoolStats,
 		)
+		nodeID := fmt.Sprint(node.GetNodeID())
+		metrics.SetCoreMetricsProcessor(func(families map[string]*dto.MetricFamily) {
+			appendQueryNodeCollectionMemoryUsage(nodeID, families)
+		})
 
 		registry.GetInMemoryResolver().RegisterQueryNode(node.GetNodeID(), node)
 		mlog.Info(node.ctx, "query node start successfully",
@@ -497,6 +502,7 @@ func (node *QueryNode) hasOtherActiveQueryNode() (bool, error) {
 // Stop mainly stop QueryNode's query service, historical loop and streaming loop.
 func (node *QueryNode) Stop() error {
 	node.stopOnce.Do(func() {
+		defer metrics.SetCoreMetricsProcessor(nil)
 		mlog.Info(node.ctx, "Query node stop...")
 		err := node.session.GoingStop()
 		if err != nil {

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -44,6 +44,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
 
@@ -163,6 +164,7 @@ func (r *CRegistry) Gather() (res []*dto.MetricFamily, err error) {
 		return res, err
 	}
 
+	metrics.ProcessCoreMetrics(out1)
 	maps.Copy(out, out1)
 
 	// Add jemalloc stats metrics

--- a/internal/util/metrics/milvus_registry_test.go
+++ b/internal/util/metrics/milvus_registry_test.go
@@ -22,7 +22,12 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pkgmetrics "github.com/milvus-io/milvus/pkg/v3/metrics"
 )
 
 func TestMilvusRegistryGather_NilGoRegistry(t *testing.T) {
@@ -46,4 +51,42 @@ func TestMilvusRegistryGather_NilCRegistry(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Greater(t, len(res), 0)
+}
+
+func TestCRegistryGatherCoreMetricsProcessor(t *testing.T) {
+	const name = "test_core_metrics_processor"
+	calls := 0
+	pkgmetrics.SetCoreMetricsProcessor(func(families map[string]*dto.MetricFamily) {
+		calls++
+		families[name] = &dto.MetricFamily{
+			Name: proto.String(name),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{
+				{Gauge: &dto.Gauge{Value: proto.Float64(42)}},
+			},
+		}
+	})
+	t.Cleanup(func() { pkgmetrics.SetCoreMetricsProcessor(nil) })
+
+	registry := NewCRegistry()
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	found := false
+	for _, family := range families {
+		if family.GetName() == name {
+			require.Len(t, family.GetMetric(), 1)
+			assert.Equal(t, float64(42), family.Metric[0].GetGauge().GetValue())
+			found = true
+		}
+	}
+	require.True(t, found)
+
+	pkgmetrics.SetCoreMetricsProcessor(nil)
+	families, err = registry.Gather()
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	for _, family := range families {
+		require.NotEqual(t, name, family.GetName())
+	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,8 +19,10 @@ package metrics
 import (
 	// #nosec
 	_ "net/http/pprof"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 const (
@@ -219,6 +221,9 @@ var (
 		})
 
 	metricRegisterer prometheus.Registerer
+
+	coreMetricsProcessorMu sync.RWMutex
+	coreMetricsProcessor   func(map[string]*dto.MetricFamily)
 )
 
 // GetRegisterer returns the global prometheus registerer
@@ -240,4 +245,22 @@ func Register(r prometheus.Registerer) {
 	r.MustRegister(ThreadNum)
 	r.MustRegister(ThreadCPUActiveNumByPool)
 	metricRegisterer = r
+}
+
+// SetCoreMetricsProcessor sets the synchronous processor for each core metrics scrape.
+// Passing nil disables processing. The processor must support concurrent scrapes.
+func SetCoreMetricsProcessor(processor func(map[string]*dto.MetricFamily)) {
+	coreMetricsProcessorMu.Lock()
+	defer coreMetricsProcessorMu.Unlock()
+	coreMetricsProcessor = processor
+}
+
+// ProcessCoreMetrics processes the current scrape without retaining its metric families.
+func ProcessCoreMetrics(families map[string]*dto.MetricFamily) {
+	coreMetricsProcessorMu.RLock()
+	processor := coreMetricsProcessor
+	coreMetricsProcessorMu.RUnlock()
+	if processor != nil {
+		processor(families)
+	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -572,4 +573,49 @@ func vecVariableLabels(expr ast.Expr, labelIdentByValue map[string]string) (map[
 		}
 	}
 	return labels, true
+}
+
+func TestCoreMetricsProcessor(t *testing.T) {
+	coreMetricsProcessorMu.RLock()
+	original := coreMetricsProcessor
+	coreMetricsProcessorMu.RUnlock()
+	t.Cleanup(func() { SetCoreMetricsProcessor(original) })
+
+	families := map[string]*dto.MetricFamily{"source": {}}
+	SetCoreMetricsProcessor(nil)
+	ProcessCoreMetrics(families)
+	require.Len(t, families, 1)
+
+	calls := 0
+	SetCoreMetricsProcessor(func(snapshot map[string]*dto.MetricFamily) {
+		calls++
+		require.Same(t, families["source"], snapshot["source"])
+		snapshot["derived"] = &dto.MetricFamily{}
+		// Registration must not be locked while the processor runs.
+		SetCoreMetricsProcessor(nil)
+	})
+	ProcessCoreMetrics(families)
+	require.Contains(t, families, "derived")
+	ProcessCoreMetrics(families)
+	require.Equal(t, 1, calls)
+
+	group := &errgroup.Group{}
+	group.Go(func() error {
+		for i := 0; i < 100; i++ {
+			SetCoreMetricsProcessor(func(snapshot map[string]*dto.MetricFamily) {
+				snapshot["derived"] = &dto.MetricFamily{}
+			})
+			SetCoreMetricsProcessor(nil)
+		}
+		return nil
+	})
+	for i := 0; i < 4; i++ {
+		group.Go(func() error {
+			for j := 0; j < 100; j++ {
+				ProcessCoreMetrics(make(map[string]*dto.MetricFamily))
+			}
+			return nil
+		})
+	}
+	require.NoError(t, group.Wait())
 }


### PR DESCRIPTION
## Summary

- Add `milvus_querynode_collection_memory_usage_bytes{node_id, collection_id}`
  for collection-level memory reporting.
- Aggregate sealed cache memory across data types and shards using collection
  IDs derived from vchannel labels.
- Add shard attribution for system and interim indexes.
- Track growing collection memory using
  `EstimateSegmentResourceUsage().memory_bytes` through resource updates
  and segment destruction.
- Aggregate both sources through a synchronous core metrics processor
  registered by QueryNode.

issue: #53265.

Depends on zilliztech/milvus-common#129.

## Dependency

The PR remains in draft while the corresponding milvus-common Conan package
is being prepared. The dependency reference will be updated when the package
is available.

Local validation used the modified milvus-common build.

## Testing

- Add sealed shard-memory and growing collection-memory lifecycle tests.
- Add collection aggregation and core metrics processor tests.
- Focused Go tests and the complete `pkg/metrics` race run passed locally.
- C++ main suite: 8,352 passed, 21 skipped, and 5 failures associated with
  DiskANN being disabled in the local build.
- JSON stats: 80 passed.

Full Go runs encountered dynamic-library, permission, and etcd errors.
QueryNode and CRegistry race runs failed during process startup.
One C++ batch encountered a teardown crash after completing its test cases;
the cause remains undetermined.