### PR TITLE
enhance: [cp2.6] apply Knowhere search defaults at query time

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -438,7 +438,8 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 		zap.Int("growingNum", len(growing)),
 	)
 
-	req, err = optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, sealedNum)
+	indexType := sd.collection.GetIndexType(req.GetReq().GetFieldId())
+	req, err = optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, sealedNum, indexType)
 	if err != nil {
 		log.Warn("failed to optimize search params", zap.Error(err))
 		return nil, err

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -226,6 +227,21 @@ func (c *Collection) ID() int64 {
 // GetCCollection returns the CCollection of collection
 func (c *Collection) GetCCollection() *segcore.CCollection {
 	return c.ccollection
+}
+
+func (c *Collection) GetIndexType(fieldID int64) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ccollection == nil || c.ccollection.IndexMeta() == nil {
+		return ""
+	}
+	for _, indexMeta := range c.ccollection.IndexMeta().GetIndexMetas() {
+		if indexMeta.GetFieldID() == fieldID {
+			return common.GetIndexType(indexMeta.GetIndexParams())
+		}
+	}
+	return ""
 }
 
 // Schema returns the schema of collection

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -89,6 +89,16 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 	})
 }
 
+func (s *CollectionManagerSuite) TestGetIndexType() {
+	collection := s.cm.Get(1)
+	s.Require().NotNil(collection)
+	s.Require().NotEmpty(collection.GetCCollection().IndexMeta().GetIndexMetas())
+
+	indexMeta := collection.GetCCollection().IndexMeta().GetIndexMetas()[0]
+	s.Equal(mock_segcore.IndexFaissIVFFlat, collection.GetIndexType(indexMeta.GetFieldID()))
+	s.Empty(collection.GetIndexType(-1))
+}
+
 func (s *CollectionManagerSuite) TestGpuIndexFlagWithCagraAdaptForCPU() {
 	schema := mock_segcore.GenTestCollectionSchema("collection_cagra", schemapb.DataType_Int64, false)
 	vectorFieldID := int64(0)

--- a/internal/util/searchutil/optimizers/query_hook.go
+++ b/internal/util/searchutil/optimizers/query_hook.go
@@ -24,11 +24,16 @@ type QueryHook interface {
 	DeleteTuningConfig(string) error
 }
 
-func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, queryHook QueryHook, numSegments int) (*querypb.SearchRequest, error) {
-	// no hook applied or disabled, just return
-	if queryHook == nil || !paramtable.Get().AutoIndexConfig.Enable.GetAsBool() {
+// OptimizeSearchParams optimizes search parameters using the query hook and applies Knowhere search defaults.
+func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, queryHook QueryHook, numSegments int, indexType string) (*querypb.SearchRequest, error) {
+	useQueryHook := queryHook != nil && paramtable.Get().AutoIndexConfig.Enable.GetAsBool()
+	useKnowhereDefaults := paramtable.Get().KnowhereConfig.Enable.GetAsBool() &&
+		paramtable.Get().KnowhereConfig.HasIndexParams(indexType, paramtable.SearchStage)
+	if !useQueryHook {
 		req.Req.IsTopkReduce = false
 		req.Req.IsRecallEvaluation = false
+	}
+	if !useQueryHook && !useKnowhereDefaults {
 		return req, nil
 	}
 
@@ -57,46 +62,55 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 
 	switch plan.GetNode().(type) {
 	case *planpb.PlanNode_VectorAnns:
-		// use shardNum * segments num in shard to estimate total segment number
-		estSegmentNum := numSegments * int(channelNum)
-		metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
-
-		withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
 		queryInfo := plan.GetVectorAnns().GetQueryInfo()
-		params := map[string]any{
-			common.TopKKey:         queryInfo.GetTopk(),
-			common.SearchParamKey:  queryInfo.GetSearchParams(),
-			common.SegmentNumKey:   estSegmentNum,
-			common.WithFilterKey:   withFilter,
-			common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
-			common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
-			common.CollectionKey:   req.GetReq().GetCollectionID(),
-			common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
+		if useQueryHook {
+			// use shardNum * segments num in shard to estimate total segment number
+			estSegmentNum := numSegments * int(channelNum)
+			metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
+
+			withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
+			params := map[string]any{
+				common.TopKKey:         queryInfo.GetTopk(),
+				common.SearchParamKey:  queryInfo.GetSearchParams(),
+				common.SegmentNumKey:   estSegmentNum,
+				common.WithFilterKey:   withFilter,
+				common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
+				common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
+				common.CollectionKey:   req.GetReq().GetCollectionID(),
+				common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
+			}
+			if withFilter && channelNum > 1 {
+				params[common.ChannelNumKey] = channelNum
+			}
+			if err := queryHook.Run(params); err != nil {
+				log.Warn("failed to execute queryHook", zap.Error(err))
+				return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
+			}
+			finalTopk := params[common.TopKKey].(int64)
+			req.Req.IsTopkReduce = req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk())
+			queryInfo.Topk = finalTopk
+			queryInfo.SearchParams = params[common.SearchParamKey].(string)
+			if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
+				req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
+			} else {
+				req.Req.IsRecallEvaluation = false
+			}
 		}
-		if withFilter && channelNum > 1 {
-			params[common.ChannelNumKey] = channelNum
+
+		if useKnowhereDefaults {
+			merged, err := paramtable.Get().KnowhereConfig.MergeIndexParamsJSON(indexType, paramtable.SearchStage, queryInfo.GetSearchParams())
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("invalid search params: %s", err.Error())
+			}
+			queryInfo.SearchParams = merged
 		}
-		err := queryHook.Run(params)
-		if err != nil {
-			log.Warn("failed to execute queryHook", zap.Error(err))
-			return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
-		}
-		finalTopk := params[common.TopKKey].(int64)
-		isTopkReduce := req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk())
-		queryInfo.Topk = finalTopk
-		queryInfo.SearchParams = params[common.SearchParamKey].(string)
+
 		serializedExprPlan, err := proto.Marshal(&plan)
 		if err != nil {
 			log.Warn("failed to marshal optimized plan", zap.Error(err))
 			return nil, merr.WrapErrParameterInvalid("marshalable search plan", "plan with marshal error", err.Error())
 		}
 		req.Req.SerializedExprPlan = serializedExprPlan
-		req.Req.IsTopkReduce = isTopkReduce
-		if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
-			req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
-		} else {
-			req.Req.IsRecallEvaluation = false
-		}
 		log.Debug("optimized search params done", zap.Any("queryInfo", queryInfo))
 	default:
 		log.Warn("not supported node type", zap.String("nodeType", fmt.Sprintf("%T", plan.GetNode())))

--- a/internal/util/searchutil/optimizers/query_hook.go
+++ b/internal/util/searchutil/optimizers/query_hook.go
@@ -89,6 +89,11 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 			finalTopk := params[common.TopKKey].(int64)
 			req.Req.IsTopkReduce = req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk())
 			queryInfo.Topk = finalTopk
+			if useKnowhereDefaults {
+				if err := paramtable.Get().KnowhereConfig.MergeIndexParamsJSON(indexType, paramtable.SearchStage, params); err != nil {
+					return nil, merr.WrapErrParameterInvalidMsg("invalid search params: %s", err.Error())
+				}
+			}
 			queryInfo.SearchParams = params[common.SearchParamKey].(string)
 			if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
 				req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
@@ -97,12 +102,12 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 			}
 		}
 
-		if useKnowhereDefaults {
-			merged, err := paramtable.Get().KnowhereConfig.MergeIndexParamsJSON(indexType, paramtable.SearchStage, queryInfo.GetSearchParams())
-			if err != nil {
+		if !useQueryHook && useKnowhereDefaults {
+			params := map[string]any{common.SearchParamKey: queryInfo.GetSearchParams()}
+			if err := paramtable.Get().KnowhereConfig.MergeIndexParamsJSON(indexType, paramtable.SearchStage, params); err != nil {
 				return nil, merr.WrapErrParameterInvalidMsg("invalid search params: %s", err.Error())
 			}
-			queryInfo.SearchParams = merged
+			queryInfo.SearchParams = params[common.SearchParamKey].(string)
 		}
 
 		serializedExprPlan, err := proto.Marshal(&plan)

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -72,7 +72,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 50, true, false, `{"param": 2}`)
 
@@ -84,7 +84,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 50, false, true, `{"param": 2}`)
 	})
@@ -112,7 +112,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SerializedExprPlan: bs,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
 	})
@@ -140,9 +140,41 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				IsTopkReduce:       true,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.NoError(err)
 		suite.verifyQueryInfo(req, 100, false, false, `{"param": 1}`)
+	})
+
+	suite.Run("knowhere_search_defaults", func() {
+		params := paramtable.Get()
+		searchKey := params.KnowhereConfig.IndexParam.KeyPrefix + "TEST_INDEX.search.default_param"
+		params.Save(params.KnowhereConfig.Enable.Key, "true")
+		params.Save(searchKey, "0.5")
+		defer params.Reset(params.KnowhereConfig.Enable.Key)
+		defer params.Remove(searchKey)
+
+		plan := &planpb.PlanNode{
+			Node: &planpb.PlanNode_VectorAnns{
+				VectorAnns: &planpb.VectorANNS{
+					QueryInfo: &planpb.QueryInfo{
+						Topk:         100,
+						SearchParams: `{"request_param":16}`,
+					},
+				},
+			},
+		}
+		bs, err := proto.Marshal(plan)
+		suite.Require().NoError(err)
+
+		req, err := OptimizeSearchParams(ctx, &querypb.SearchRequest{
+			Req: &internalpb.SearchRequest{
+				SerializedExprPlan: bs,
+				IsTopkReduce:       true,
+			},
+		}, nil, 2, "TEST_INDEX")
+		suite.NoError(err)
+		suite.JSONEq(`{"default_param":0.5,"request_param":16}`, suite.getQueryInfo(req).GetSearchParams())
+		suite.False(req.GetReq().GetIsTopkReduce())
 	})
 
 	suite.Run("other_plannode", func() {
@@ -169,7 +201,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 				SerializedExprPlan: bs,
 			},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.NoError(err)
 		suite.Equal(bs, req.GetReq().GetSerializedExprPlan())
 	})
@@ -184,7 +216,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 		_, err := OptimizeSearchParams(ctx, &querypb.SearchRequest{
 			Req:             &internalpb.SearchRequest{},
 			TotalChannelNum: 2,
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.Error(err)
 	})
 
@@ -218,7 +250,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 			Req: &internalpb.SearchRequest{
 				SerializedExprPlan: bs,
 			},
-		}, suite.queryHook, 2)
+		}, suite.queryHook, 2, "")
 		suite.Error(err)
 	})
 }

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -175,8 +175,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 			},
 		}, nil, 2, "TEST_INDEX")
 		suite.NoError(err)
-		suite.JSONEq(`{"default_param":0.5,"request_param":16}`, suite.getQueryInfo(req).GetSearchParams())
-		suite.False(req.GetReq().GetIsTopkReduce())
+		suite.verifyQueryInfo(req, 100, false, false, `{"default_param":0.5,"request_param":16}`)
 
 		mockHook := mock_optimizers.NewMockQueryHook(suite.T())
 		mockHook.EXPECT().Run(mock.Anything).Run(func(params map[string]any) {
@@ -188,7 +187,7 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 			},
 		}, mockHook, 2, "TEST_INDEX")
 		suite.NoError(err)
-		suite.JSONEq(`{"default_param":0.8,"hook_param":32}`, suite.getQueryInfo(req).GetSearchParams())
+		suite.verifyQueryInfo(req, 100, false, false, `{"default_param":0.8,"hook_param":32}`)
 	})
 
 	suite.Run("other_plannode", func() {

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -148,8 +148,10 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 	suite.Run("knowhere_search_defaults", func() {
 		params := paramtable.Get()
 		searchKey := params.KnowhereConfig.IndexParam.KeyPrefix + "TEST_INDEX.search.default_param"
+		params.Save(params.AutoIndexConfig.Enable.Key, "true")
 		params.Save(params.KnowhereConfig.Enable.Key, "true")
 		params.Save(searchKey, "0.5")
+		defer params.Reset(params.AutoIndexConfig.Enable.Key)
 		defer params.Reset(params.KnowhereConfig.Enable.Key)
 		defer params.Remove(searchKey)
 
@@ -175,6 +177,18 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 		suite.NoError(err)
 		suite.JSONEq(`{"default_param":0.5,"request_param":16}`, suite.getQueryInfo(req).GetSearchParams())
 		suite.False(req.GetReq().GetIsTopkReduce())
+
+		mockHook := mock_optimizers.NewMockQueryHook(suite.T())
+		mockHook.EXPECT().Run(mock.Anything).Run(func(params map[string]any) {
+			params[common.SearchParamKey] = `{"default_param":0.8,"hook_param":32}`
+		}).Return(nil)
+		req, err = OptimizeSearchParams(ctx, &querypb.SearchRequest{
+			Req: &internalpb.SearchRequest{
+				SerializedExprPlan: bs,
+			},
+		}, mockHook, 2, "TEST_INDEX")
+		suite.NoError(err)
+		suite.JSONEq(`{"default_param":0.8,"hook_param":32}`, suite.getQueryInfo(req).GetSearchParams())
 	})
 
 	suite.Run("other_plannode", func() {

--- a/pkg/util/paramtable/knowhere_param.go
+++ b/pkg/util/paramtable/knowhere_param.go
@@ -161,32 +161,38 @@ func (p *knowhereConfig) HasIndexParams(indexType, stage string) bool {
 	return len(p.getIndexParam(indexType, stage)) > 0
 }
 
-func (p *knowhereConfig) MergeIndexParamsJSON(indexType, stage, rawParams string) (string, error) {
+func (p *knowhereConfig) MergeIndexParamsJSON(indexType, stage string, params map[string]any) error {
 	defaultParams := p.getIndexParam(indexType, stage)
 	if len(defaultParams) == 0 {
-		return rawParams, nil
+		return nil
 	}
+
+	rawParams := params[common.SearchParamKey].(string)
 	if rawParams == "" {
 		rawParams = "{}"
 	}
 
-	params := make(map[string]json.RawMessage)
-	if err := json.Unmarshal([]byte(rawParams), &params); err != nil {
-		return "", err
+	searchParams := make(map[string]json.RawMessage)
+	if err := json.Unmarshal([]byte(rawParams), &searchParams); err != nil {
+		return err
 	}
 	for key, value := range defaultParams {
-		if _, exists := params[key]; exists {
+		if _, exists := searchParams[key]; exists {
 			continue
 		}
 		rawValue := json.RawMessage(value)
 		if !json.Valid(rawValue) {
 			rawValue, _ = json.Marshal(value)
 		}
-		params[key] = rawValue
+		searchParams[key] = rawValue
 	}
 
-	merged, err := json.Marshal(params)
-	return string(merged), err
+	merged, err := json.Marshal(searchParams)
+	if err != nil {
+		return err
+	}
+	params[common.SearchParamKey] = string(merged)
+	return nil
 }
 
 func (p *knowhereConfig) MergeResourceParams(vecFieldSize uint64, stage string, indexParam map[string]string) (map[string]string, error) {

--- a/pkg/util/paramtable/knowhere_param.go
+++ b/pkg/util/paramtable/knowhere_param.go
@@ -1,6 +1,7 @@
 package paramtable
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -154,6 +155,38 @@ func (p *knowhereConfig) MergeIndexParams(indexType string, stage string, indexP
 	}
 
 	return indexParam, nil
+}
+
+func (p *knowhereConfig) HasIndexParams(indexType, stage string) bool {
+	return len(p.getIndexParam(indexType, stage)) > 0
+}
+
+func (p *knowhereConfig) MergeIndexParamsJSON(indexType, stage, rawParams string) (string, error) {
+	defaultParams := p.getIndexParam(indexType, stage)
+	if len(defaultParams) == 0 {
+		return rawParams, nil
+	}
+	if rawParams == "" {
+		rawParams = "{}"
+	}
+
+	params := make(map[string]json.RawMessage)
+	if err := json.Unmarshal([]byte(rawParams), &params); err != nil {
+		return "", err
+	}
+	for key, value := range defaultParams {
+		if _, exists := params[key]; exists {
+			continue
+		}
+		rawValue := json.RawMessage(value)
+		if !json.Valid(rawValue) {
+			rawValue, _ = json.Marshal(value)
+		}
+		params[key] = rawValue
+	}
+
+	merged, err := json.Marshal(params)
+	return string(merged), err
 }
 
 func (p *knowhereConfig) MergeResourceParams(vecFieldSize uint64, stage string, indexParam map[string]string) (map[string]string, error) {

--- a/pkg/util/paramtable/knowhere_param_test.go
+++ b/pkg/util/paramtable/knowhere_param_test.go
@@ -189,6 +189,26 @@ func TestKnowhereConfig_MergeParameter(t *testing.T) {
 	}
 }
 
+func TestKnowhereConfig_MergeIndexParamsJSON(t *testing.T) {
+	bt := NewBaseTable(SkipRemote(true))
+	cfg := &knowhereConfig{}
+	cfg.init(bt)
+
+	bt.Save("knowhere.TEST_INDEX.search.default_number", "0.5")
+	bt.Save("knowhere.TEST_INDEX.search.default_string", "balanced")
+
+	result, err := cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, `{"default_number":0.8,"request_param":16}`)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"default_number":0.8,"default_string":"balanced","request_param":16}`, result)
+
+	result, err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, `{"request_param":16}`)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"default_number":0.5,"default_string":"balanced","request_param":16}`, result)
+
+	_, err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, "invalid")
+	assert.Error(t, err)
+}
+
 func TestKnowhereConfig_MergeWithResource(t *testing.T) {
 	cfg := &knowhereConfig{}
 

--- a/pkg/util/paramtable/knowhere_param_test.go
+++ b/pkg/util/paramtable/knowhere_param_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 )
 
 func TestKnowhereConfig_GetIndexParam(t *testing.T) {
@@ -197,15 +198,18 @@ func TestKnowhereConfig_MergeIndexParamsJSON(t *testing.T) {
 	bt.Save("knowhere.TEST_INDEX.search.default_number", "0.5")
 	bt.Save("knowhere.TEST_INDEX.search.default_string", "balanced")
 
-	result, err := cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, `{"default_number":0.8,"request_param":16}`)
+	params := map[string]any{common.SearchParamKey: `{"default_number":0.8,"request_param":16}`}
+	err := cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, params)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"default_number":0.8,"default_string":"balanced","request_param":16}`, result)
+	assert.JSONEq(t, `{"default_number":0.8,"default_string":"balanced","request_param":16}`, params[common.SearchParamKey].(string))
 
-	result, err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, `{"request_param":16}`)
+	params[common.SearchParamKey] = `{"request_param":16}`
+	err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, params)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"default_number":0.5,"default_string":"balanced","request_param":16}`, result)
+	assert.JSONEq(t, `{"default_number":0.5,"default_string":"balanced","request_param":16}`, params[common.SearchParamKey].(string))
 
-	_, err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, "invalid")
+	params[common.SearchParamKey] = "invalid"
+	err = cfg.MergeIndexParamsJSON("TEST_INDEX", SearchStage, params)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
Cherry-pick of PR https://github.com/milvus-io/milvus/pull/53258 onto the latest 2.6 branch.

pr: #53258

## Summary

- apply configured Knowhere search defaults at query time
- preserve request and QueryHook values
- pass the existing QueryHook params map directly into the in-place merge
- adapt the change to the 2.6 QueryNode API while retaining its native search pipeline

## Tests

Passed the targeted paramtable and search optimizer tests with the required dynamic/test build tags.

The collection package test requires milvus_core, rdkafka, and rocksdb native pkg-config dependencies, which are unavailable on this host.

issue: #53254