### PR TITLE
test: pass IVF nprobe through ANN params

### DIFF
--- a/tests/go_client/common/response_checker.go
+++ b/tests/go_client/common/response_checker.go
@@ -264,12 +264,12 @@ func CheckOutputFields(t *testing.T, expFields []string, actualColumns []column.
 
 // CheckSearchResult check search result, check nq, topk, ids, score
 func CheckSearchResult(t *testing.T, actualSearchResults []client.ResultSet, expNq int, expTopK int) {
-	require.Equalf(t, len(actualSearchResults), expNq, fmt.Sprintf("Expected nq=%d, actual SearchResultsLen=%d", expNq, len(actualSearchResults)))
+	require.Equalf(t, expNq, len(actualSearchResults), fmt.Sprintf("Expected nq=%d, actual SearchResultsLen=%d", expNq, len(actualSearchResults)))
 	require.Len(t, actualSearchResults, expNq)
 	for _, actualSearchResult := range actualSearchResults {
-		require.Equalf(t, actualSearchResult.ResultCount, expTopK, fmt.Sprintf("Expected topK=%d, actual ResultCount=%d", expTopK, actualSearchResult.ResultCount))
-		require.Equalf(t, actualSearchResult.IDs.Len(), expTopK, fmt.Sprintf("Expected topK=%d, actual IDsLen=%d", expTopK, actualSearchResult.IDs.Len()))
-		require.Equalf(t, len(actualSearchResult.Scores), expTopK, fmt.Sprintf("Expected topK=%d, actual ScoresLen=%d", expTopK, len(actualSearchResult.Scores)))
+		require.Equalf(t, expTopK, actualSearchResult.ResultCount, fmt.Sprintf("Expected topK=%d, actual ResultCount=%d", expTopK, actualSearchResult.ResultCount))
+		require.Equalf(t, expTopK, actualSearchResult.IDs.Len(), fmt.Sprintf("Expected topK=%d, actual IDsLen=%d", expTopK, actualSearchResult.IDs.Len()))
+		require.Equalf(t, expTopK, len(actualSearchResult.Scores), fmt.Sprintf("Expected topK=%d, actual ScoresLen=%d", expTopK, len(actualSearchResult.Scores)))
 	}
 }
 

--- a/tests/go_client/testcases/index_test.go
+++ b/tests/go_client/testcases/index_test.go
@@ -1005,10 +1005,12 @@ func TestCreateIndexVanillaFaissGeneric(t *testing.T) {
 	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
 
 	queryVec := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
+	annParam := index.NewCustomAnnParam()
+	annParam.WithExtraParam("nprobe", 64)
 	searchRes, err := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, common.DefaultLimit, queryVec).
 		WithANNSField(common.DefaultFloatVecFieldName).
 		// nprobe=nlist (IVF64) scans all lists so topK results are returned deterministically (#50392)
-		WithSearchParam("nprobe", "64").
+		WithAnnParam(annParam).
 		WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
 	common.CheckSearchResult(t, searchRes, common.DefaultNq, common.DefaultLimit)


### PR DESCRIPTION
## What changed

- Pass `nprobe=64` through `CustomAnnParam`/`WithAnnParam` in `TestCreateIndexVanillaFaissGeneric`.
- Correct expected/actual ordering in `CheckSearchResult` assertions.

## Why

`WithSearchParam("nprobe", "64")` adds a top-level search request key, while the proxy reads algorithm-specific search parameters from the `params` JSON. As a result, the intended nprobe value was ignored and the FAISS IVF search could return fewer than topK results when a probed list contained fewer candidates.

Using `WithAnnParam` serializes `nprobe` into the ANN params JSON. Setting nprobe equal to the IVF nlist scans all 64 lists and makes the topK assertion deterministic.

## Verification

- `GO_CLIENT_SKIP_EXTERNAL_TABLE_DEPS_INSTALL=1 go test -c -o /tmp/milvus-testcases-pr-50392.test ./testcases`
- Target E2E passed 10/10 against standalone `master-20260908-bf65725be6`: `go test ./testcases -run "^TestCreateIndexVanillaFaissGeneric$" -count=10`
- go_client golangci-lint: `0 issues`
- Full `make static-check` was attempted but its environment setup requires LLVM 14-18, which is not installed locally.

Fixes #50392