### PR TITLE
docs(components): fix copy-pasted comments in mix_coord.go

### DIFF
--- a/cmd/components/mix_coord.go
+++ b/cmd/components/mix_coord.go
@@ -35,7 +35,7 @@ type MixCoord struct {
 	svr *mix.Server
 }
 
-// NewRootCoord creates a new RoorCoord
+// NewMixCoord creates a new MixCoord
 func NewMixCoord(ctx context.Context, factory dependency.Factory) (*MixCoord, error) {
 	svr, err := mix.NewServer(ctx, factory)
 	if err != nil {
@@ -67,7 +67,7 @@ func (rc *MixCoord) Stop() error {
 	return exitWhenStopTimeout(rc.svr.Stop, timeout)
 }
 
-// GetComponentStates returns RootCoord's states
+// Health returns MixCoord's current state code
 func (rc *MixCoord) Health(ctx context.Context) commonpb.StateCode {
 	resp, err := rc.svr.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
 	if err != nil {


### PR DESCRIPTION
Two Go doc comments in `cmd/components/mix_coord.go` were pasted from the RootCoord component:

- above `NewMixCoord`: "// NewRootCoord creates a new **RoorCoord**" (wrong name, misspelled)
- above `(*MixCoord).Health`: "// GetComponentStates returns RootCoord's states"

Comments rewritten to describe the functions they sit on. Comments only.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>