### PR TITLE
fix: correct 'faild' typos in user-visible error and log strings

### DIFF
--- a/internal/http/healthz/healthz_handler.go
+++ b/internal/http/healthz/healthz_handler.go
@@ -132,7 +132,7 @@ func writeJSON(w http.ResponseWriter, r *http.Request, resp *HealthResponse) {
 	w.Header().Set(ContentTypeHeader, ContentTypeJSON)
 	bs, err := json.Marshal(resp)
 	if err != nil {
-		mlog.Warn(context.TODO(), "faild to send response", mlog.Err(err))
+		mlog.Warn(context.TODO(), "failed to send response", mlog.Err(err))
 	}
 	w.Write(bs)
 }

--- a/internal/util/credentials/credentials.go
+++ b/internal/util/credentials/credentials.go
@@ -85,7 +85,7 @@ func (c *Credentials) GetGcpCredential(name string) ([]byte, error) {
 
 	decode, err := base64.StdEncoding.DecodeString(jsonByte)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalidMsg("parse gcp credential:%s faild, err: %s", name, err)
+		return nil, merr.WrapErrParameterInvalidMsg("parse gcp credential:%s failed, err: %s", name, err)
 	}
 	return decode, nil
 }

--- a/pkg/eventlog/handler.go
+++ b/pkg/eventlog/handler.go
@@ -66,7 +66,7 @@ func writeJSON(w http.ResponseWriter, r *http.Request, resp *eventLogResponse) {
 	w.Header().Set(ContentTypeHeader, ContentTypeJSON)
 	bs, err := json.Marshal(resp)
 	if err != nil {
-		mlog.Warn(r.Context(), "faild to send response", mlog.Err(err))
+		mlog.Warn(r.Context(), "failed to send response", mlog.Err(err))
 	}
 	w.Write(bs)
 }


### PR DESCRIPTION
Three user-visible strings carried the same misspelling:

- `internal/util/credentials/credentials.go`: the wrapped error returned to users when a GCP credential fails to parse
- `pkg/eventlog/handler.go` + `internal/http/healthz/healthz_handler.go`: "**faild** to send response" log strings

"faild" → "failed" in all three; strings only, no behavior change.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>