### PR TITLE
test: update client cases for storage and sdk changes

### DIFF
--- a/tests/python_client/bulk_insert/test_bulk_insert_api.py
+++ b/tests/python_client/bulk_insert/test_bulk_insert_api.py
@@ -18,10 +18,8 @@ from common.bulk_insert_data import (
     DataField as df,
 )
 from common.common_type import CaseLabel, CheckTasks
-from common.milvus_sys import MilvusSys
 from pymilvus import CollectionSchema, DataType, FieldSchema, Function, FunctionType
 from pymilvus.bulk_writer import BulkFileType, RemoteBulkWriter
-from utils.util_k8s import get_milvus_deploy_tool, get_milvus_instance_name, get_pod_ip_name_pairs
 from utils.util_log import test_log as log
 
 default_vec_only_fields = [df.vec_field]
@@ -130,24 +128,24 @@ def assert_text_lob_bulk_rows(actual_rows, expected_rows):
         assert len(actual_text.encode("utf-8")) == expected_meta["bytes"]
 
 
+def minio_endpoint_from_host(minio_host):
+    endpoint = minio_host or "localhost"
+    if endpoint.startswith("http://"):
+        endpoint = endpoint.removeprefix("http://")
+    elif endpoint.startswith("https://"):
+        endpoint = endpoint.removeprefix("https://")
+    if ":" not in endpoint:
+        endpoint = f"{endpoint}:9000"
+    return endpoint
+
+
 class TestcaseBaseBulkInsert(TestcaseBase):
     @pytest.fixture(scope="function", autouse=True)
-    def init_minio_client(self, host, milvus_ns):
+    def init_minio_client(self, minio_host, minio_bucket):
         Path("/tmp/bulk_insert_data").mkdir(parents=True, exist_ok=True)
         self._connect()
-        self.milvus_ns = milvus_ns
-        self.milvus_sys = MilvusSys(alias="default")
-        self.instance_name = get_milvus_instance_name(self.milvus_ns, host)
-        self.deploy_tool = get_milvus_deploy_tool(self.milvus_ns, self.milvus_sys)
-        minio_label = f"release={self.instance_name}, app=minio"
-        if self.deploy_tool == "milvus-operator":
-            minio_label = f"release={self.instance_name}-minio, app=minio"
-        minio_ip_pod_pair = get_pod_ip_name_pairs(self.milvus_ns, minio_label)
-        ms = MilvusSys()
-        minio_ip = list(minio_ip_pod_pair.keys())[0]
-        minio_port = "9000"
-        self.minio_endpoint = f"{minio_ip}:{minio_port}"
-        self.bucket_name = ms.data_nodes[0]["infos"]["system_configurations"]["minio_bucket_name"]
+        self.minio_endpoint = minio_endpoint_from_host(minio_host)
+        self.bucket_name = minio_bucket
 
     # def teardown_method(self, method):
     #     log.info(("*" * 35) + " teardown " + ("*" * 35))

--- a/tests/python_client/common/external_table_common.py
+++ b/tests/python_client/common/external_table_common.py
@@ -41,20 +41,28 @@ def _minio_address(minio_host):
     return address
 
 
+def _minio_secure(minio_host):
+    return str(minio_host or "").startswith("https://")
+
+
 def get_minio_config(minio_host=None, minio_bucket=None):
+    address = _minio_address(minio_host)
+    external_source_host = os.getenv("MILVUS_EXTERNAL_SOURCE_MINIO_HOST")
     return {
-        "address": _minio_address(minio_host),
+        "address": address,
+        "external_source_address": _minio_address(external_source_host or address),
         "access_key": "minioadmin",
         "secret_key": "minioadmin",
         "bucket": minio_bucket or cf.param_info.param_bucket_name or "milvus-bucket",
-        "secure": str(minio_host or "").startswith("https://"),
+        "secure": _minio_secure(minio_host),
+        "external_source_secure": _minio_secure(external_source_host or minio_host),
     }
 
 
 def build_external_source(cfg, key_prefix):
     """Build a full s3:// URL that Milvus's extfs resolver can use directly."""
     # Trailing slash matters: refresh lists objects under the prefix.
-    return f"s3://{cfg['address']}/{cfg['bucket']}/{key_prefix}/"
+    return f"s3://{cfg.get('external_source_address', cfg['address'])}/{cfg['bucket']}/{key_prefix}/"
 
 
 def _minio_endpoint_url(cfg):
@@ -78,7 +86,7 @@ def build_external_spec(cfg=None, fmt="parquet", cloud_provider="minio", **extra
             "region": "us-east-1",
             "access_key_id": cfg["access_key"],
             "access_key_value": cfg["secret_key"],
-            "use_ssl": "true" if cfg["secure"] else "false",
+            "use_ssl": "true" if cfg.get("external_source_secure", cfg["secure"]) else "false",
         },
     }
     spec.update(extra)

--- a/tests/python_client/conftest.py
+++ b/tests/python_client/conftest.py
@@ -34,7 +34,12 @@ def pytest_addoption(parser):
     parser.addoption("--password", action="store", default="Milvus", help="password for connection")
     parser.addoption("--db_name", action="store", default="default", help="database name for connection")
     parser.addoption("--secure", action="store", default=False, help="secure for connection")
-    parser.addoption("--milvus_ns", action="store", default="chaos-testing", help="milvus_ns")
+    parser.addoption(
+        "--milvus_ns",
+        action="store",
+        default=os.getenv("MILVUS_NS", os.getenv("MILVUS_HELM_NAMESPACE", "chaos-testing")),
+        help="milvus_ns",
+    )
     parser.addoption("--http_port", action="store", default=19121, help="http's port")
     parser.addoption("--handler", action="store", default="GRPC", help="handler of request")
     parser.addoption("--tag", action="store", default="all", help="only run tests matching the tag.")

--- a/tests/python_client/milvus_client/test_milvus_client_text_lob.py
+++ b/tests/python_client/milvus_client/test_milvus_client_text_lob.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import random
+import tempfile
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -636,6 +637,30 @@ def read_parquet_object(minio_client, bucket, key):
         response.release_conn()
 
 
+def read_vortex_object(minio_client, bucket, key):
+    vortex_io = pytest.importorskip("vortex.io", reason="TEXT LOB Vortex layout inspection requires vortex-data")
+    response = minio_client.get_object(bucket, key)
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".vortex", delete=False) as tmp:
+            tmp.write(response.read())
+            tmp_path = tmp.name
+        try:
+            return vortex_io.read_url(f"file:{tmp_path}").to_arrow_table()
+        except ValueError as e:
+            if "Registry missing encoding" in str(e):
+                pytest.skip(
+                    "installed vortex-data cannot decode Milvus StorageV3 Vortex custom encoding; "
+                    "skip instead of synthesizing TEXT LOB references"
+                )
+            raise
+    finally:
+        response.close()
+        response.release_conn()
+        if tmp_path is not None:
+            os.remove(tmp_path)
+
+
 def bytes_value(value):
     if value is None:
         return None
@@ -691,19 +716,12 @@ def text_reference_values(values):
     return None
 
 
-def read_text_reference_rows(minio_client, bucket, segment_base, content_field_id, id_field_id, expected_ids):
-    data_prefix = object_key(segment_base, "_data")
-    parquet_keys = [key for key in list_minio_keys(minio_client, bucket, data_prefix) if key.endswith(".parquet")]
-    if not parquet_keys:
-        parquet_keys = [key for key in list_minio_keys(minio_client, bucket, segment_base) if key.endswith(".parquet")]
-    assert parquet_keys, f"no parquet reference files found under segment base {segment_base}"
-
+def text_reference_rows_from_tables(tables, content_field_id, id_field_id, expected_ids, layout):
     id_candidates = []
     ref_candidates = []
-    parquet_debug = []
-    for key in parquet_keys:
-        table = read_parquet_object(minio_client, bucket, key)
-        parquet_debug.append({"key": key, "columns": list(table.schema.names), "rows": table.num_rows})
+    table_debug = []
+    for key, table in tables:
+        table_debug.append({"key": key, "columns": list(table.schema.names), "rows": table.num_rows})
         id_candidates.extend(
             (key, name, values)
             for name, values in candidate_columns(table, column_names_for(id_field_id, ID_FIELD), int_values)
@@ -716,23 +734,47 @@ def read_text_reference_rows(minio_client, bucket, segment_base, content_field_i
         )
 
     expected_id_set = set(expected_ids)
-    assert id_candidates, f"no primary-key column found in parquet files: {parquet_debug}"
-    assert ref_candidates, f"no TEXT reference column found in parquet files: {parquet_debug}"
+    assert id_candidates, f"no primary-key column found in {layout} files: {table_debug}"
+    assert ref_candidates, f"no TEXT reference column found in {layout} files: {table_debug}"
 
     id_key, id_name, ids = max(id_candidates, key=lambda candidate: len(expected_id_set & set(candidate[2])))
     assert expected_id_set <= set(ids), (
         f"primary-key column {id_name} from {id_key} does not contain expected ids; "
-        f"expected={expected_id_set}, actual={ids}, parquet={parquet_debug}"
+        f"expected={expected_id_set}, actual={ids}, {layout}={table_debug}"
     )
 
     matching_refs = [candidate for candidate in ref_candidates if len(candidate[2]) == len(ids)]
     assert matching_refs, (
         f"no TEXT reference column has the same row count as primary-key column {id_name} from {id_key}; "
-        f"ref_candidates={[(key, name, len(values)) for key, name, values in ref_candidates]}, parquet={parquet_debug}"
+        f"ref_candidates={[(key, name, len(values)) for key, name, values in ref_candidates]}, {layout}={table_debug}"
     )
     ref_key, ref_name, refs = matching_refs[0]
-    log.info(f"TEXT LOB reference layout: pk={id_key}:{id_name}, text={ref_key}:{ref_name}")
+    log.info(f"TEXT LOB {layout} reference layout: pk={id_key}:{id_name}, text={ref_key}:{ref_name}")
     return {pk: ref for pk, ref in zip(ids, refs) if pk in expected_id_set}
+
+
+def read_text_reference_rows(
+    minio_client,
+    bucket,
+    segment_base,
+    content_field_id,
+    id_field_id,
+    expected_ids,
+):
+    data_prefix = object_key(segment_base, "_data")
+    data_keys = list_minio_keys(minio_client, bucket, data_prefix)
+    parquet_keys = [key for key in data_keys if key.endswith(".parquet")]
+    if not parquet_keys:
+        parquet_keys = [key for key in list_minio_keys(minio_client, bucket, segment_base) if key.endswith(".parquet")]
+
+    if parquet_keys:
+        tables = [(key, read_parquet_object(minio_client, bucket, key)) for key in parquet_keys]
+        return text_reference_rows_from_tables(tables, content_field_id, id_field_id, expected_ids, "parquet")
+
+    vortex_keys = [key for key in data_keys if key.endswith(".vortex")]
+    assert vortex_keys, f"no parquet or vortex reference files found under segment base {segment_base}"
+    tables = [(key, read_vortex_object(minio_client, bucket, key)) for key in vortex_keys]
+    return text_reference_rows_from_tables(tables, content_field_id, id_field_id, expected_ids, "vortex")
 
 
 def classify_text_ref(ref_bytes, expected_text):


### PR DESCRIPTION
issue: #51544

Reopens #51755, whose author has left the project. The branch is rebased onto current master and the conflicts are resolved.

## What changed

- Derive the default Python client test namespace from `MILVUS_NS` or `MILVUS_HELM_NAMESPACE` before falling back to `chaos-testing`.
- Add an optional external-source MinIO endpoint override (`MILVUS_EXTERNAL_SOURCE_MINIO_HOST`) for external table tests, so the client upload endpoint and the server-side `external_source` endpoint can be configured independently.
- Resolve the bulk insert MinIO endpoint from the existing `minio_host` / `minio_bucket` fixtures instead of looking up the MinIO pod IP through the k8s API, so these cases no longer require in-cluster access.
- Extend TEXT LOB layout validation to read Vortex segment data files in addition to the existing parquet layout. The Vortex files are decoded with `vortex-data`; when the installed reader cannot decode Milvus StorageV3's custom encoding the case skips rather than asserting on synthesized references.

## Dropped from the original PR

Two changes from #51755 have since landed on master independently and are not included here:

- The multi-primary-key invalid schema assertion — master already validates at `add_field` time, via the framework's `CheckTasks.err_res` helper rather than `pytest.raises`.
- The `Date` / `Time` / `Decimal` entries in the external table add-field matrix.

## Verification

- `test_text_lob_bulk_import_json_csv_parquet`
- `test_text_lob_inline_vs_lob_object_layout`
- `test_milvus_client_external_table_add_all_supported_field_types`
- `test_milvus_client_xgboost_supports_all_numeric_feature_types`