### PR TITLE
fix: [hotfix-2.6.23] optimize strict group-by iterator filtering

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -475,6 +475,9 @@ queryCoord:
 
 # Related configuration of queryNode, used to run hybrid search between vector and scalar data.
 queryNode:
+  groupBy:
+    strictGroupAcceptanceThreshold: 0.1 # Recreate a strict group iterator only below this acceptance ratio [0,1]. Zero disables the optimization.
+    strictGroupProbeCandidates: 100 # Positive consumer candidate budget after locking strict groups, not a backend graph visit budget.
   stats:
     publishInterval: 1000 # The interval that query node publishes the node statistics information, including segment status, cpu usage, memory usage, health status, etc. Unit: ms.
   segcore:

--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -22,6 +22,10 @@
 #include "knowhere/comp/index_param.h"
 
 const int64_t INVALID_FIELD_ID = -1;
+inline constexpr char kStrictGroupAcceptanceThreshold[] =
+    "strict_group_acceptance_threshold";
+inline constexpr char kStrictGroupProbeCandidates[] =
+    "strict_group_probe_candidates";
 const int64_t INVALID_SEG_OFFSET = -1;
 const int64_t INVALID_ARRAY_INDEX = -1;
 const milvus::PkType INVALID_PK;  // of std::monostate if not set.

--- a/internal/core/src/common/QueryInfo.h
+++ b/internal/core/src/common/QueryInfo.h
@@ -35,6 +35,8 @@ struct SearchInfo {
     int64_t topk_{0};
     int64_t group_size_{1};
     bool strict_group_size_{false};
+    double strict_group_acceptance_threshold_{0.1};
+    int64_t strict_group_probe_candidates_{100};
     int64_t round_decimal_{0};
     FieldId field_id_;
     MetricType metric_type_;

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <cstring>
 #include <memory>
 #include <map>
 #include <limits>
+#include <functional>
 #include <string>
 #include <queue>
 #include <utility>
@@ -232,6 +234,9 @@ struct VectorIterator {
 };
 
 struct SearchResult {
+    using VectorIteratorRecreateFn =
+        std::function<void(const BitsetView&, SearchResult&)>;
+
     SearchResult() = default;
 
     int64_t
@@ -288,6 +293,88 @@ struct SearchResult {
         return view;
     }
 
+    void
+    SetVectorIteratorRecreator(const BitsetView& base_filter,
+                               VectorIteratorRecreateFn recreate_fn) {
+        vector_iterator_base_filter_.reset();
+        vector_iterator_base_filter_view_ = base_filter;
+        // The execution pipeline shares its input column. Direct low-level
+        // callers without an owner retain the original defensive-copy contract.
+        if (!vector_iterator_filter_owner_) {
+            GetVectorIteratorBaseFilter();
+        }
+        vector_iterator_recreate_fn_ = std::move(recreate_fn);
+    }
+
+    void
+    ClearVectorIteratorRecreator() {
+        vector_iterator_recreate_fn_ = {};
+        vector_iterator_base_filter_view_ = {};
+        vector_iterator_base_filter_.reset();
+        vector_iterator_filter_owner_.reset();
+    }
+
+    bool
+    CanRecreateVectorIterator() const {
+        return allow_vector_iterator_recreation_ &&
+               static_cast<bool>(vector_iterator_recreate_fn_);
+    }
+
+    const TargetBitmap*
+    GetVectorIteratorBaseFilter() {
+        const auto& base_filter = vector_iterator_base_filter_view_;
+        if (!vector_iterator_base_filter_ && !base_filter.empty()) {
+            auto copied_filter =
+                std::make_unique<TargetBitmap>(base_filter.size(), false);
+            if (!base_filter.has_out_ids()) {
+                std::memcpy(copied_filter->data(),
+                            base_filter.data(),
+                            base_filter.byte_size());
+            } else {
+                for (size_t i = 0; i < base_filter.size(); ++i) {
+                    (*copied_filter)[i] = base_filter.test(i);
+                }
+            }
+            vector_iterator_base_filter_ = std::move(copied_filter);
+            vector_iterator_base_filter_view_ =
+                BitsetView(*vector_iterator_base_filter_);
+        }
+        return vector_iterator_base_filter_.get();
+    }
+
+    // The returned SearchResult owns every bitmap and raw chunk buffer used by
+    // its iterators. Keep it alive while consuming the batch, then release it
+    // before recreating the next batch.
+    std::optional<std::unique_ptr<SearchResult>>
+    RecreateVectorIterators(TargetBitmap additional_filter) {
+        if (!CanRecreateVectorIterator()) {
+            return std::nullopt;
+        }
+        GetVectorIteratorBaseFilter();
+        if (vector_iterator_base_filter_ != nullptr &&
+            vector_iterator_base_filter_->size() != additional_filter.size()) {
+            return std::nullopt;
+        }
+
+        auto combined_filter = std::move(additional_filter);
+        if (vector_iterator_base_filter_ != nullptr) {
+            combined_filter |= *vector_iterator_base_filter_;
+        }
+
+        auto recreated_result = std::make_unique<SearchResult>();
+        recreated_result->allow_vector_iterator_recreation_ = false;
+        auto combined_view =
+            recreated_result->PinBitset(std::move(combined_filter));
+        vector_iterator_recreate_fn_(combined_view, *recreated_result);
+        if (!recreated_result->vector_iterators_.has_value()) {
+            // The combined filter may exclude every row. The provider ran
+            // successfully, but there is no iterator to assemble.
+            recreated_result->vector_iterators_ =
+                std::vector<std::shared_ptr<VectorIterator>>{};
+        }
+        return recreated_result;
+    }
+
  public:
     int64_t total_nq_;
     int64_t unity_topK_;
@@ -321,6 +408,15 @@ struct SearchResult {
     // record the storage usage in search
     StorageCost search_storage_cost_;
     std::vector<TargetBitmapPtr> pinned_bitsets_{};
+
+    // Recreates the original vector iterator with an additional logical-row
+    // exclusion bitmap. The callback re-enters the same sealed/growing search
+    // provider so offset mapping and backend selection stay centralized there.
+    VectorIteratorRecreateFn vector_iterator_recreate_fn_{};
+    TargetBitmapPtr vector_iterator_base_filter_{};
+    BitsetView vector_iterator_base_filter_view_{};
+    std::shared_ptr<const void> vector_iterator_filter_owner_{};
+    bool allow_vector_iterator_recreation_{true};
 
     bool element_level_{false};
     std::vector<int32_t> element_indices_;

--- a/internal/core/src/exec/operator/GroupByNode.cpp
+++ b/internal/core/src/exec/operator/GroupByNode.cpp
@@ -79,7 +79,8 @@ PhyGroupByNode::GetOutput() {
                                     *segment_,
                                     search_result.seg_offsets_,
                                     search_result.distances_,
-                                    search_result.topk_per_nq_prefix_sum_);
+                                    search_result.topk_per_nq_prefix_sum_,
+                                    &search_result);
         search_result.group_by_values_ = std::move(group_by_values);
         search_result.group_size_ = search_info_.group_size_;
         AssertInfo(search_result.seg_offsets_.size() ==

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -93,6 +93,13 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
             search_result.total_nq_ = nq;
             search_result.unity_topK_ = search_info.topk_;
         } catch (const std::runtime_error& e) {
+            // The optional recreation caller classifies preparation failures.
+            // Do not disguise typed cancellation/corruption errors as an
+            // Unsupported backend and accidentally make them recoverable.
+            if (!search_result.allow_vector_iterator_recreation_ &&
+                dynamic_cast<const SegcoreError*>(&e) != nullptr) {
+                throw;
+            }
             std::string operator_type = "";
             if (search_info.group_by_field_id_.has_value()) {
                 operator_type = "group_by";

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -21,6 +21,7 @@
 #include "fmt/format.h"
 
 #include "monitor/Monitor.h"
+#include "query/Utils.h"
 namespace milvus {
 namespace exec {
 
@@ -141,6 +142,11 @@ PhyVectorSearchNode::GetOutput() {
 
     // Single search + metrics path
     milvus::SearchResult search_result;
+    if (query::CanUseStrictGroupFilteredIterator(search_info_, num_queries) &&
+        !search_view.empty()) {
+        // Keep the source bitmap alive through GroupBy without an N-bit copy.
+        search_result.vector_iterator_filter_owner_ = col_input;
+    }
     auto op_context = query_context_->get_op_context();
     segment_->vector_search(search_info_,
                             src_data,

--- a/internal/core/src/exec/operator/groupby/GroupMembership.cpp
+++ b/internal/core/src/exec/operator/groupby/GroupMembership.cpp
@@ -1,0 +1,270 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/operator/groupby/GroupMembership.h"
+
+#include <algorithm>
+#include <memory>
+#include <unordered_set>
+
+#include "index/ScalarIndex.h"
+#include "segcore/SegmentChunkReader.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/Utils.h"
+
+namespace milvus::exec {
+namespace {
+
+template <typename T>
+using GroupKey = std::optional<T>;
+
+bool
+IsEligible(const TargetBitmap* base_filter, size_t offset) {
+    return base_filter == nullptr || !(*base_filter)[offset];
+}
+
+void
+ApplyBaseFilter(TargetBitmap& membership, const TargetBitmap* base_filter) {
+    if (base_filter == nullptr) {
+        return;
+    }
+    membership -= *base_filter;
+}
+
+template <typename T>
+std::optional<TargetBitmap>
+BuildIndexMembership(const segcore::PinnedIndexView& pinned_indexes,
+                     size_t row_count,
+                     const std::vector<GroupKey<T>>& groups,
+                     const TargetBitmap* base_filter) {
+    if (pinned_indexes.empty()) {
+        return std::nullopt;
+    }
+
+    // Avoid vector<bool>: ScalarIndex<bool>::In needs a contiguous bool array.
+    auto values = std::make_unique<T[]>(groups.size());
+    size_t value_count = 0;
+    bool include_null = false;
+    for (const auto& group : groups) {
+        if (group.has_value()) {
+            values[value_count++] = *group;
+        } else {
+            include_null = true;
+        }
+    }
+    TargetBitmap membership;
+    membership.reserve(row_count);
+    size_t remaining = row_count;
+    for (auto& pinned_index : pinned_indexes) {
+        auto scalar_index =
+            dynamic_cast<const index::ScalarIndex<T>*>(pinned_index.get());
+        if (scalar_index == nullptr) {
+            return std::nullopt;
+        }
+        auto* mutable_index = const_cast<index::ScalarIndex<T>*>(scalar_index);
+        auto chunk_membership =
+            value_count > 0 ? mutable_index->In(value_count, values.get())
+                            : TargetBitmap(mutable_index->Count(), false);
+        if (include_null) {
+            auto matches = mutable_index->IsNull();
+            if (matches.size() != chunk_membership.size()) {
+                return std::nullopt;
+            }
+            chunk_membership |= matches;
+        }
+
+        auto append_size = std::min(remaining, chunk_membership.size());
+        membership.append(chunk_membership, 0, append_size);
+        remaining -= append_size;
+        if (remaining == 0) {
+            break;
+        }
+    }
+    if (membership.size() != row_count) {
+        return std::nullopt;
+    }
+    ApplyBaseFilter(membership, base_filter);
+    return membership;
+}
+
+template <typename T, typename Visitor>
+bool
+ScanRawField(milvus::OpContext* op_ctx,
+             const segcore::SegmentInternalInterface& segment,
+             FieldId field_id,
+             size_t row_count,
+             Visitor&& visitor) {
+    segcore::CheckCancellation(op_ctx,
+                               segment.get_segment_id(),
+                               field_id.get(),
+                               "strict group membership");
+    if (!segment.HasFieldData(field_id)) {
+        return false;
+    }
+    if (row_count == 0) {
+        return true;
+    }
+    if (auto growing =
+            dynamic_cast<const segcore::SegmentGrowingImpl*>(&segment)) {
+        auto values = growing->get_insert_record().get_data<T>(field_id);
+        auto valid = growing->get_insert_record().is_valid_data_exist(field_id)
+                         ? growing->get_insert_record().get_valid_data(field_id)
+                         : nullptr;
+        for (size_t offset = 0; offset < row_count; ++offset) {
+            if ((offset & 1023) == 0) {
+                segcore::CheckCancellation(op_ctx,
+                                           segment.get_segment_id(),
+                                           field_id.get(),
+                                           "strict group membership");
+            }
+            if (valid && !valid->is_valid(offset)) {
+                visitor(offset, GroupKey<T>(std::nullopt));
+                continue;
+            }
+            if constexpr (std::is_same_v<T, std::string>) {
+                if (values->is_mmap()) {
+                    visitor(
+                        offset,
+                        GroupKey<T>(std::string(values->view_element(offset))));
+                    continue;
+                }
+            }
+            visitor(offset, GroupKey<T>(static_cast<T>((*values)[offset])));
+        }
+        return true;
+    }
+    auto raw_chunk_count = segment.num_chunk_data(field_id);
+    if (raw_chunk_count == 0 ||
+        segment.num_rows_until_chunk(field_id, 0) != 0) {
+        return false;
+    }
+    size_t raw_row_count = 0;
+    for (int64_t chunk = 0; chunk < raw_chunk_count; ++chunk) {
+        raw_row_count += segment.chunk_size(field_id, chunk);
+    }
+    if (raw_row_count < row_count) {
+        // A partially indexed field may only retain raw data for a suffix of
+        // the segment. Do not reinterpret that suffix as logical offset zero.
+        return false;
+    }
+
+    int64_t chunk_id = 0;
+    int64_t chunk_pos = 0;
+    segcore::SegmentChunkReader reader(op_ctx, &segment, row_count);
+    auto accessor =
+        reader.GetMultipleChunkDataAccessor(segment.GetFieldDataType(field_id),
+                                            field_id,
+                                            chunk_id,
+                                            chunk_pos,
+                                            segcore::PinnedIndexView{});
+    for (size_t offset = 0; offset < row_count; ++offset) {
+        if ((offset & 1023) == 0) {
+            segcore::CheckCancellation(op_ctx,
+                                       segment.get_segment_id(),
+                                       field_id.get(),
+                                       "strict group membership");
+        }
+        auto value = accessor();
+        if (value.has_value()) {
+            visitor(offset, GroupKey<T>(segcore::get_from_variant<T>(value)));
+        } else {
+            visitor(offset, GroupKey<T>(std::nullopt));
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+template <typename T>
+std::optional<TargetBitmap>
+BuildGroupMembership(milvus::OpContext* op_ctx,
+                     const segcore::SegmentInternalInterface& segment,
+                     FieldId field_id,
+                     int64_t row_count,
+                     const std::vector<GroupKey<T>>& groups,
+                     const TargetBitmap* base_filter) {
+    if (row_count < 0 ||
+        (base_filter != nullptr &&
+         base_filter->size() != static_cast<size_t>(row_count))) {
+        return std::nullopt;
+    }
+    auto count = static_cast<size_t>(row_count);
+    // Match phase one's raw-first access policy. Do not pin an unused index.
+    if (segment.HasFieldData(field_id)) {
+        std::unordered_set<GroupKey<T>> target_groups(groups.begin(),
+                                                      groups.end());
+        TargetBitmap membership(count, false);
+        auto scanned = ScanRawField<T>(
+            op_ctx, segment, field_id, count, [&](size_t offset, auto group) {
+                if (IsEligible(base_filter, offset) &&
+                    target_groups.find(group) != target_groups.end()) {
+                    membership[offset] = true;
+                }
+            });
+        if (scanned) {
+            return membership;
+        }
+    }
+    auto indexes = segment.PinIndex(op_ctx, field_id);
+    return BuildIndexMembership<T>(indexes, count, groups, base_filter);
+}
+
+template std::optional<TargetBitmap>
+BuildGroupMembership<bool>(milvus::OpContext*,
+                           const segcore::SegmentInternalInterface&,
+                           FieldId,
+                           int64_t,
+                           const std::vector<std::optional<bool>>&,
+                           const TargetBitmap*);
+template std::optional<TargetBitmap>
+BuildGroupMembership<int8_t>(milvus::OpContext*,
+                             const segcore::SegmentInternalInterface&,
+                             FieldId,
+                             int64_t,
+                             const std::vector<std::optional<int8_t>>&,
+                             const TargetBitmap*);
+template std::optional<TargetBitmap>
+BuildGroupMembership<int16_t>(milvus::OpContext*,
+                              const segcore::SegmentInternalInterface&,
+                              FieldId,
+                              int64_t,
+                              const std::vector<std::optional<int16_t>>&,
+                              const TargetBitmap*);
+template std::optional<TargetBitmap>
+BuildGroupMembership<int32_t>(milvus::OpContext*,
+                              const segcore::SegmentInternalInterface&,
+                              FieldId,
+                              int64_t,
+                              const std::vector<std::optional<int32_t>>&,
+                              const TargetBitmap*);
+template std::optional<TargetBitmap>
+BuildGroupMembership<int64_t>(milvus::OpContext*,
+                              const segcore::SegmentInternalInterface&,
+                              FieldId,
+                              int64_t,
+                              const std::vector<std::optional<int64_t>>&,
+                              const TargetBitmap*);
+template std::optional<TargetBitmap>
+BuildGroupMembership<std::string>(
+    milvus::OpContext*,
+    const segcore::SegmentInternalInterface&,
+    FieldId,
+    int64_t,
+    const std::vector<std::optional<std::string>>&,
+    const TargetBitmap*);
+
+}  // namespace milvus::exec

--- a/internal/core/src/exec/operator/groupby/GroupMembership.h
+++ b/internal/core/src/exec/operator/groupby/GroupMembership.h
@@ -1,0 +1,40 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "common/OpContext.h"
+#include "common/Types.h"
+#include "segcore/SegmentInterface.h"
+
+namespace milvus::exec {
+
+// `base_filter` uses vector-search semantics: one means invalid. The returned
+// membership bitmap uses scalar-index semantics: one means that the eligible
+// row belongs to one of the requested groups.
+template <typename T>
+std::optional<TargetBitmap>
+BuildGroupMembership(milvus::OpContext* op_ctx,
+                     const segcore::SegmentInternalInterface& segment,
+                     FieldId field_id,
+                     int64_t row_count,
+                     const std::vector<std::optional<T>>& groups,
+                     const TargetBitmap* base_filter);
+
+}  // namespace milvus::exec

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.cpp
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.cpp
@@ -14,12 +14,370 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "SearchGroupByOperator.h"
+
+#include <chrono>
+#include <limits>
+
+#include "common/Tracer.h"
 #include "common/Consts.h"
-#include "query/Utils.h"
 #include "common/JsonUtils.h"
+#include "exec/operator/groupby/GroupMembership.h"
+#include "fmt/format.h"
+#include "monitor/Monitor.h"
+#include "query/Utils.h"
 
 namespace milvus {
 namespace exec {
+
+namespace {
+
+enum class StrictGroupPhase2FallbackReason {
+    None,
+    MissingRecreator,
+    InvalidRowCount,
+    Phase1Exhausted,
+    Phase2NotNeeded,
+    MembershipUnavailable,
+    ProbeAcceptanceHigh,
+    RecreateUnavailable,
+    RecreatedExhausted,
+};
+
+enum class StrictGroupDecision { NotEvaluated, AcceptanceHigh, AcceptanceLow };
+
+const char*
+DecisionName(StrictGroupDecision decision) {
+    switch (decision) {
+        case StrictGroupDecision::NotEvaluated:
+            return "not_evaluated";
+        case StrictGroupDecision::AcceptanceHigh:
+            return "acceptance_high";
+        case StrictGroupDecision::AcceptanceLow:
+            return "acceptance_low";
+    }
+    return "unknown";
+}
+
+struct StrictGroupPhase2Stats {
+    bool attempted = false;
+    bool used = false;
+    size_t phase1_candidates = 0;
+    size_t phase2_candidates = 0;
+    size_t probe_candidates = 0;
+    size_t probe_accepted = 0;
+    size_t probe_group_hits = 0;
+    size_t original_remaining_candidates = 0;
+    StrictGroupDecision decision = StrictGroupDecision::NotEvaluated;
+    size_t batch_count = 0;
+    uint64_t membership_build_us = 0;
+    uint64_t bitmap_build_us = 0;
+    StrictGroupPhase2FallbackReason fallback_reason =
+        StrictGroupPhase2FallbackReason::None;
+};
+
+struct StrictGroupPhase2Context {
+    milvus::OpContext* op_ctx;
+    const segcore::SegmentInternalInterface& segment;
+    FieldId group_by_field_id;
+    SearchResult* search_result;
+    bool eligible;
+    double acceptance_threshold;
+    int64_t probe_candidates;
+};
+
+const char*
+FallbackReasonName(StrictGroupPhase2FallbackReason reason) {
+    switch (reason) {
+        case StrictGroupPhase2FallbackReason::None:
+            return "none";
+        case StrictGroupPhase2FallbackReason::MissingRecreator:
+            return "missing_recreator";
+        case StrictGroupPhase2FallbackReason::InvalidRowCount:
+            return "invalid_row_count";
+        case StrictGroupPhase2FallbackReason::Phase1Exhausted:
+            return "phase1_exhausted";
+        case StrictGroupPhase2FallbackReason::Phase2NotNeeded:
+            return "phase2_not_needed";
+        case StrictGroupPhase2FallbackReason::MembershipUnavailable:
+            return "membership_unavailable";
+        case StrictGroupPhase2FallbackReason::ProbeAcceptanceHigh:
+            return "probe_acceptance_high";
+        case StrictGroupPhase2FallbackReason::RecreateUnavailable:
+            return "recreate_unavailable";
+        case StrictGroupPhase2FallbackReason::RecreatedExhausted:
+            return "recreated_exhausted";
+    }
+    return "unknown";
+}
+
+void
+RecordStrictGroupPhase2Stats(const StrictGroupPhase2Stats& stats) {
+    if (!stats.attempted) {
+        return;
+    }
+    milvus::monitor::internal_core_strict_group_phase2_phase1_candidates
+        .Observe(stats.phase1_candidates);
+    milvus::monitor::internal_core_strict_group_phase2_phase2_candidates
+        .Observe(stats.phase2_candidates);
+    milvus::monitor::internal_core_strict_group_phase2_batch_count.Observe(
+        stats.batch_count);
+    milvus::monitor::internal_core_strict_group_phase2_probe_candidates.Observe(
+        stats.probe_candidates);
+    milvus::monitor::internal_core_strict_group_phase2_probe_accepted.Observe(
+        stats.probe_accepted);
+    milvus::monitor::internal_core_strict_group_phase2_probe_group_hits.Observe(
+        stats.probe_group_hits);
+    milvus::monitor::
+        internal_core_strict_group_phase2_original_remaining_candidates.Observe(
+            stats.original_remaining_candidates);
+    milvus::monitor::internal_core_strict_group_phase2_membership_build_latency
+        .Observe(stats.membership_build_us / 1000.0);
+    milvus::monitor::internal_core_strict_group_phase2_bitmap_build_latency
+        .Observe(stats.bitmap_build_us / 1000.0);
+    if (stats.probe_candidates > 0) {
+        milvus::monitor::internal_core_strict_group_phase2_acceptance_ratio
+            .Observe(static_cast<double>(stats.probe_accepted) /
+                     stats.probe_candidates);
+    }
+    tracer::AddEvent(fmt::format(
+        "strict_group_phase2: used={}, fallback={}, phase1_candidates={}, "
+        "phase2_candidates={}, probe_candidates={}, probe_accepted={}, "
+        "probe_group_hits={}, "
+        "original_remaining_candidates={}, decision={}, batches={}, "
+        "membership_ms={:.3f}, "
+        "bitmap_ms={:.3f}",
+        stats.used,
+        FallbackReasonName(stats.fallback_reason),
+        stats.phase1_candidates,
+        stats.phase2_candidates,
+        stats.probe_candidates,
+        stats.probe_accepted,
+        stats.probe_group_hits,
+        stats.original_remaining_candidates,
+        DecisionName(stats.decision),
+        stats.batch_count,
+        stats.membership_build_us / 1000.0,
+        stats.bitmap_build_us / 1000.0));
+}
+
+template <typename T, typename StopPredicate>
+size_t
+ConsumeGroupByIteratorUntil(
+    const std::shared_ptr<VectorIterator>& iterator,
+    const std::shared_ptr<DataGetter<T>>& data_getter,
+    GroupByMap<T>& group_map,
+    GroupByResultCollector<T>& collector,
+    StopPredicate&& should_stop,
+    size_t max_candidates = std::numeric_limits<size_t>::max(),
+    size_t* accepted = nullptr,
+    size_t* locked_group_hits = nullptr) {
+    size_t candidates = 0;
+    while (candidates < max_candidates && !should_stop() &&
+           iterator->HasNext()) {
+        auto offset_dis_pair = iterator->Next();
+        ++candidates;
+        AssertInfo(
+            offset_dis_pair.has_value(),
+            "Wrong state! iterator cannot return valid result whereas it "
+            "still tells hasNext, terminate groupBy operation");
+        auto offset = offset_dis_pair->first;
+        auto distance = offset_dis_pair->second;
+        if (collector.IsAcceptedOffset(offset)) {
+            continue;
+        }
+        auto group = data_getter->Get(offset);
+        if (locked_group_hits != nullptr && group_map.Contains(group)) {
+            ++*locked_group_hits;
+        }
+        if (group_map.Push(group)) {
+            collector.Add(offset, distance, std::move(group));
+            if (accepted != nullptr) {
+                ++*accepted;
+            }
+        }
+    }
+    return candidates;
+}
+
+template <typename T>
+bool
+TryStrictGroupFilteredPhase2(const std::shared_ptr<VectorIterator>& iterator,
+                             const std::shared_ptr<DataGetter<T>>& data_getter,
+                             GroupByMap<T>& group_map,
+                             GroupByResultCollector<T>& collector,
+                             const StrictGroupPhase2Context* context) {
+    if (context == nullptr || !context->eligible ||
+        context->search_result == nullptr) {
+        return false;
+    }
+
+    StrictGroupPhase2Stats stats;
+    stats.attempted = true;
+    auto finish = [&] { RecordStrictGroupPhase2Stats(stats); };
+    if (!context->search_result->CanRecreateVectorIterator()) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::MissingRecreator;
+        finish();
+        return false;
+    }
+    if (context->search_result->total_data_cnt_ < 0) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::InvalidRowCount;
+        finish();
+        return false;
+    }
+
+    stats.phase1_candidates = ConsumeGroupByIteratorUntil(
+        iterator, data_getter, group_map, collector, [&] {
+            return group_map.IsGroupCapacityReached();
+        });
+
+    if (!group_map.IsGroupCapacityReached()) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::Phase1Exhausted;
+        finish();
+        return true;
+    }
+    if (group_map.IsGroupResEnough()) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::Phase2NotNeeded;
+        finish();
+        return true;
+    }
+
+    // Probe once, using consumer candidates rather than backend graph visits.
+    stats.probe_candidates = ConsumeGroupByIteratorUntil(
+        iterator,
+        data_getter,
+        group_map,
+        collector,
+        [&] { return group_map.IsGroupResEnough(); },
+        context->probe_candidates,
+        &stats.probe_accepted,
+        &stats.probe_group_hits);
+    stats.phase1_candidates += stats.probe_candidates;
+    if (group_map.IsGroupResEnough() || !iterator->HasNext()) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::Phase2NotNeeded;
+        finish();
+        return true;
+    }
+
+    auto continue_original = [&] {
+        stats.original_remaining_candidates = ConsumeGroupByIteratorUntil(
+            iterator, data_getter, group_map, collector, [&] {
+                return group_map.IsGroupResEnough();
+            });
+        finish();
+        return true;
+    };
+    // Equality keeps the original iterator; never re-evaluate this decision later.
+    if (static_cast<double>(stats.probe_accepted) / stats.probe_candidates >=
+        context->acceptance_threshold) {
+        stats.decision = StrictGroupDecision::AcceptanceHigh;
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::ProbeAcceptanceHigh;
+        return continue_original();
+    }
+
+    std::vector<std::optional<T>> unfinished_groups;
+    for (const auto& group : group_map.GetGroupOrder()) {
+        if (!group_map.IsGroupFull(group)) {
+            unfinished_groups.emplace_back(group);
+        }
+    }
+    AssertInfo(!unfinished_groups.empty(),
+               "strict group phase2 has no unfinished group");
+
+    stats.decision = StrictGroupDecision::AcceptanceLow;
+
+    auto prepare = [&]() -> std::optional<std::unique_ptr<SearchResult>> {
+        auto membership_start = std::chrono::steady_clock::now();
+        auto membership = BuildGroupMembership<T>(
+            context->op_ctx,
+            context->segment,
+            context->group_by_field_id,
+            context->search_result->total_data_cnt_,
+            unfinished_groups,
+            context->search_result->GetVectorIteratorBaseFilter());
+        stats.membership_build_us =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - membership_start)
+                .count();
+        if (!membership.has_value()) {
+            stats.fallback_reason =
+                StrictGroupPhase2FallbackReason::MembershipUnavailable;
+            return std::nullopt;
+        }
+
+        auto bitmap_start = std::chrono::steady_clock::now();
+        membership->flip();
+        collector.ExcludeAcceptedOffsets(*membership);
+        stats.bitmap_build_us =
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - bitmap_start)
+                .count();
+        return context->search_result->RecreateVectorIterators(
+            std::move(*membership));
+    };
+    std::optional<std::unique_ptr<SearchResult>> recreated;
+    try {
+        recreated = prepare();
+    } catch (const std::exception& error) {
+        LOG_WARN("strict group iterator preparation failed: {}", error.what());
+        throw;
+    }
+    if (!recreated.has_value()) {
+        if (stats.fallback_reason == StrictGroupPhase2FallbackReason::None) {
+            stats.fallback_reason =
+                StrictGroupPhase2FallbackReason::RecreateUnavailable;
+        }
+        return continue_original();
+    }
+    auto& batch_result = **recreated;
+    AssertInfo(batch_result.vector_iterators_.has_value(),
+               "strict group recreated result has no iterator container");
+    AssertInfo(batch_result.vector_iterators_->size() <= 1,
+               "strict group expected at most one iterator, got {}",
+               batch_result.vector_iterators_->size());
+    collector.EnableOffsetDeduplication();
+    stats.used = true;
+    stats.batch_count = 1;
+    if (!batch_result.vector_iterators_->empty()) {
+        stats.phase2_candidates = ConsumeGroupByIteratorUntil(
+            batch_result.vector_iterators_->front(),
+            data_getter,
+            group_map,
+            collector,
+            [&] { return group_map.IsGroupResEnough(); });
+    }
+    context->search_result->search_storage_cost_ +=
+        batch_result.search_storage_cost_;
+    if (!group_map.IsGroupResEnough()) {
+        stats.fallback_reason =
+            StrictGroupPhase2FallbackReason::RecreatedExhausted;
+        return continue_original();
+    }
+    finish();
+    return true;
+}
+
+}  // namespace
+
+template <typename T>
+void
+GroupIteratorsByType(
+    const std::vector<std::shared_ptr<VectorIterator>>& iterators,
+    int64_t topK,
+    int64_t group_size,
+    bool strict_group_size,
+    const std::shared_ptr<DataGetter<T>>& data_getter,
+    std::vector<GroupByValueType>& group_by_values,
+    std::vector<int64_t>& seg_offsets,
+    std::vector<float>& distances,
+    const knowhere::MetricType& metrics_type,
+    std::vector<size_t>& topk_per_nq_prefix_sum,
+    const StrictGroupPhase2Context* context = nullptr);
 
 void
 SearchGroupBy(milvus::OpContext* op_ctx,
@@ -29,7 +387,13 @@ SearchGroupBy(milvus::OpContext* op_ctx,
               const segcore::SegmentInternalInterface& segment,
               std::vector<int64_t>& seg_offsets,
               std::vector<float>& distances,
-              std::vector<size_t>& topk_per_nq_prefix_sum) {
+              std::vector<size_t>& topk_per_nq_prefix_sum,
+              SearchResult* search_result) {
+    Defer clear_recreator([&] {
+        if (search_result != nullptr) {
+            search_result->ClearVectorIteratorRecreator();
+        }
+    });
     //1. get search meta
     FieldId group_by_field_id = search_info.group_by_field_id_.value();
     auto data_type = segment.GetFieldDataType(group_by_field_id);
@@ -39,6 +403,14 @@ SearchGroupBy(milvus::OpContext* op_ctx,
     distances.reserve(max_total_size);
     group_by_values.reserve(max_total_size);
     topk_per_nq_prefix_sum.reserve(iterators.size() + 1);
+    StrictGroupPhase2Context phase2_context{
+        op_ctx,
+        segment,
+        group_by_field_id,
+        search_result,
+        query::CanUseStrictGroupFilteredIterator(search_info, iterators.size()),
+        search_info.strict_group_acceptance_threshold_,
+        search_info.strict_group_probe_candidates_};
     switch (data_type) {
         case DataType::INT8: {
             auto dataGetter =
@@ -52,7 +424,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                          seg_offsets,
                                          distances,
                                          search_info.metric_type_,
-                                         topk_per_nq_prefix_sum);
+                                         topk_per_nq_prefix_sum,
+                                         &phase2_context);
             break;
         }
         case DataType::INT16: {
@@ -67,7 +440,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                           seg_offsets,
                                           distances,
                                           search_info.metric_type_,
-                                          topk_per_nq_prefix_sum);
+                                          topk_per_nq_prefix_sum,
+                                          &phase2_context);
             break;
         }
         case DataType::INT32: {
@@ -82,7 +456,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                           seg_offsets,
                                           distances,
                                           search_info.metric_type_,
-                                          topk_per_nq_prefix_sum);
+                                          topk_per_nq_prefix_sum,
+                                          &phase2_context);
             break;
         }
         case DataType::INT64: {
@@ -97,7 +472,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                           seg_offsets,
                                           distances,
                                           search_info.metric_type_,
-                                          topk_per_nq_prefix_sum);
+                                          topk_per_nq_prefix_sum,
+                                          &phase2_context);
             break;
         }
         case DataType::TIMESTAMPTZ: {
@@ -112,7 +488,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                           seg_offsets,
                                           distances,
                                           search_info.metric_type_,
-                                          topk_per_nq_prefix_sum);
+                                          topk_per_nq_prefix_sum,
+                                          &phase2_context);
             break;
         }
         case DataType::BOOL: {
@@ -127,7 +504,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                        seg_offsets,
                                        distances,
                                        search_info.metric_type_,
-                                       topk_per_nq_prefix_sum);
+                                       topk_per_nq_prefix_sum,
+                                       &phase2_context);
             break;
         }
         case DataType::VARCHAR: {
@@ -142,7 +520,8 @@ SearchGroupBy(milvus::OpContext* op_ctx,
                                               seg_offsets,
                                               distances,
                                               search_info.metric_type_,
-                                              topk_per_nq_prefix_sum);
+                                              topk_per_nq_prefix_sum,
+                                              &phase2_context);
             break;
         }
         case DataType::JSON: {
@@ -318,6 +697,19 @@ SearchGroupBy(milvus::OpContext* op_ctx,
 
 template <typename T>
 void
+GroupIteratorResult(const std::shared_ptr<VectorIterator>& iterator,
+                    int64_t topK,
+                    int64_t group_size,
+                    bool strict_group_size,
+                    const std::shared_ptr<DataGetter<T>>& data_getter,
+                    std::vector<GroupByValueType>& group_by_values,
+                    std::vector<int64_t>& offsets,
+                    std::vector<float>& distances,
+                    const knowhere::MetricType& metrics_type,
+                    const StrictGroupPhase2Context* context);
+
+template <typename T>
+void
 GroupIteratorsByType(
     const std::vector<std::shared_ptr<VectorIterator>>& iterators,
     int64_t topK,
@@ -328,7 +720,8 @@ GroupIteratorsByType(
     std::vector<int64_t>& seg_offsets,
     std::vector<float>& distances,
     const knowhere::MetricType& metrics_type,
-    std::vector<size_t>& topk_per_nq_prefix_sum) {
+    std::vector<size_t>& topk_per_nq_prefix_sum,
+    const StrictGroupPhase2Context* context) {
     topk_per_nq_prefix_sum.push_back(0);
     for (auto& iterator : iterators) {
         GroupIteratorResult<T>(iterator,
@@ -339,7 +732,8 @@ GroupIteratorsByType(
                                group_by_values,
                                seg_offsets,
                                distances,
-                               metrics_type);
+                               metrics_type,
+                               context);
         topk_per_nq_prefix_sum.push_back(seg_offsets.size());
     }
 }
@@ -354,41 +748,25 @@ GroupIteratorResult(const std::shared_ptr<VectorIterator>& iterator,
                     std::vector<GroupByValueType>& group_by_values,
                     std::vector<int64_t>& offsets,
                     std::vector<float>& distances,
-                    const knowhere::MetricType& metrics_type) {
-    //1.
-    GroupByMap<T> groupMap(topK, group_size, strict_group_size);
+                    const knowhere::MetricType& metrics_type,
+                    const StrictGroupPhase2Context* context) {
+    GroupByMap<T> group_map(topK, group_size, strict_group_size);
+    GroupByResultCollector<T> collector;
 
-    //2. do iteration until fill the whole map or run out of all data
-    //note it may enumerate all data inside a segment and can block following
-    //query and search possibly
-    std::vector<std::tuple<int64_t, float, std::optional<T>>> res;
-    while (iterator->HasNext() && !groupMap.IsGroupResEnough()) {
-        auto offset_dis_pair = iterator->Next();
-        AssertInfo(
-            offset_dis_pair.has_value(),
-            "Wrong state! iterator cannot return valid result whereas it still"
-            "tells hasNext, terminate groupBy operation");
-        auto offset = offset_dis_pair.value().first;
-        auto dis = offset_dis_pair.value().second;
-        std::optional<T> row_data = data_getter->Get(offset);
-        if (groupMap.Push(row_data)) {
-            res.emplace_back(offset, dis, row_data);
-        }
+    auto handled_by_filtered_phase2 =
+        strict_group_size &&
+        TryStrictGroupFilteredPhase2(
+            iterator, data_getter, group_map, collector, context);
+    if (!handled_by_filtered_phase2) {
+        // Do iteration until fill the whole map or run out of all data. It may
+        // enumerate every row in a segment and block following work.
+        ConsumeGroupByIteratorUntil(
+            iterator, data_getter, group_map, collector, [&] {
+                return group_map.IsGroupResEnough();
+            });
     }
 
-    //3. sorted based on distances and metrics
-    auto customComparator = [&](const auto& lhs, const auto& rhs) {
-        return milvus::query::dis_closer(
-            std::get<1>(lhs), std::get<1>(rhs), metrics_type);
-    };
-    std::sort(res.begin(), res.end(), customComparator);
-
-    //4. save groupBy results
-    for (auto iter = res.begin(); iter != res.end(); ++iter) {
-        offsets.emplace_back(std::get<0>(*iter));
-        distances.emplace_back(std::get<1>(*iter));
-        group_by_values.emplace_back(std::move(std::get<2>(*iter)));
-    }
+    collector.SortAndAppend(metrics_type, group_by_values, offsets, distances);
 }
 
 }  // namespace exec

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.h
@@ -16,13 +16,19 @@
 
 #pragma once
 
+#include <algorithm>
 #include <optional>
+#include <tuple>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/Json.h"
 #include "common/JsonUtils.h"
 #include "common/QueryInfo.h"
+#include "common/QueryResult.h"
 #include "common/Types.h"
 #include "exec/expression/Expr.h"
 #include "knowhere/index/index_node.h"
@@ -323,26 +329,16 @@ SearchGroupBy(milvus::OpContext* op_ctx,
               const segcore::SegmentInternalInterface& segment,
               std::vector<int64_t>& seg_offsets,
               std::vector<float>& distances,
-              std::vector<size_t>& topk_per_nq_prefix_sum);
-
-template <typename T>
-void
-GroupIteratorsByType(
-    const std::vector<std::shared_ptr<VectorIterator>>& iterators,
-    int64_t topK,
-    int64_t group_size,
-    bool strict_group_size,
-    const std::shared_ptr<DataGetter<T>>& data_getter,
-    std::vector<GroupByValueType>& group_by_values,
-    std::vector<int64_t>& seg_offsets,
-    std::vector<float>& distances,
-    const knowhere::MetricType& metrics_type,
-    std::vector<size_t>& topk_per_nq_prefix_sum);
+              std::vector<size_t>& topk_per_nq_prefix_sum,
+              SearchResult* search_result = nullptr);
 
 template <typename T>
 struct GroupByMap {
+    using GroupKey = std::optional<T>;
+
  private:
-    std::unordered_map<std::optional<T>, int> group_map_{};
+    std::unordered_map<GroupKey, int> group_map_{};
+    std::vector<GroupKey> group_order_{};
     int group_capacity_{0};
     int group_size_{0};
     int enough_group_count_{0};
@@ -356,30 +352,76 @@ struct GroupByMap {
           group_size_(group_size),
           strict_group_size_(strict_group_size){};
     bool
-    IsGroupResEnough() {
-        bool enough = false;
+    IsGroupResEnough() const {
         if (strict_group_size_) {
-            enough = group_map_.size() == group_capacity_ &&
-                     enough_group_count_ == group_capacity_;
-        } else {
-            enough = group_map_.size() == group_capacity_;
+            return IsGroupCapacityReached() &&
+                   enough_group_count_ == group_capacity_;
         }
-        return enough;
+        return IsGroupCapacityReached();
     }
+
     bool
-    Push(const std::optional<T>& t) {
-        if (group_map_.size() >= group_capacity_ &&
-            group_map_.find(t) == group_map_.end()) {
-            return false;
+    IsGroupCapacityReached() const {
+        return group_map_.size() == static_cast<size_t>(group_capacity_);
+    }
+
+    size_t
+    GetGroupCount() const {
+        return group_map_.size();
+    }
+
+    int
+    GetEnoughGroupCount() const {
+        return enough_group_count_;
+    }
+
+    const std::vector<GroupKey>&
+    GetGroupOrder() const {
+        return group_order_;
+    }
+
+    bool
+    Contains(const GroupKey& group) const {
+        return group_map_.find(group) != group_map_.end();
+    }
+
+    int
+    GetGroupResultCount(const GroupKey& group) const {
+        auto it = group_map_.find(group);
+        return it == group_map_.end() ? 0 : it->second;
+    }
+
+    int
+    GetRemainingGroupSize(const GroupKey& group) const {
+        return std::max(0, group_size_ - GetGroupResultCount(group));
+    }
+
+    bool
+    IsGroupFull(const GroupKey& group) const {
+        auto it = group_map_.find(group);
+        return it != group_map_.end() && it->second >= group_size_;
+    }
+
+    bool
+    Push(const GroupKey& group) {
+        auto it = group_map_.find(group);
+        if (it == group_map_.end()) {
+            if (group_map_.size() >= static_cast<size_t>(group_capacity_)) {
+                return false;
+            }
+            it = group_map_.emplace(group, 0).first;
+            group_order_.emplace_back(group);
         }
-        if (group_map_[t] >= group_size_) {
+
+        if (it->second >= group_size_) {
             //we ignore following input no matter the distance as knowhere::iterator doesn't guarantee
             //strictly increase/decreasing distance output
             //but this should not be a very serious influence to overall recall rate
             return false;
         }
-        group_map_[t] += 1;
-        if (group_map_[t] >= group_size_) {
+
+        it->second += 1;
+        if (it->second >= group_size_) {
             enough_group_count_ += 1;
         }
         return true;
@@ -387,15 +429,76 @@ struct GroupByMap {
 };
 
 template <typename T>
-void
-GroupIteratorResult(const std::shared_ptr<VectorIterator>& iterator,
-                    int64_t topK,
-                    int64_t group_size,
-                    bool strict_group_size,
-                    const std::shared_ptr<DataGetter<T>>& data_getter,
-                    std::vector<int64_t>& offsets,
-                    std::vector<float>& distances,
-                    const knowhere::MetricType& metrics_type);
+class GroupByResultCollector {
+ public:
+    using GroupKey = std::optional<T>;
+    using Result = std::tuple<int64_t, float, GroupKey>;
+
+    void
+    Add(int64_t offset, float distance, GroupKey group) {
+        results_.emplace_back(offset, distance, std::move(group));
+        if (accepted_offsets_) {
+            accepted_offsets_->insert(offset);
+        }
+    }
+
+    void
+    EnableOffsetDeduplication() {
+        accepted_offsets_.emplace();
+        accepted_offsets_->reserve(results_.size());
+        for (const auto& result : results_) {
+            accepted_offsets_->insert(std::get<0>(result));
+        }
+    }
+
+    bool
+    IsAcceptedOffset(int64_t offset) const {
+        return accepted_offsets_ && accepted_offsets_->count(offset) != 0;
+    }
+
+    size_t
+    Size() const {
+        return results_.size();
+    }
+
+    // Other groups (including full groups) are already excluded by membership.
+    // Accepted rows are the only consumed rows that could otherwise reappear.
+    void
+    ExcludeAcceptedOffsets(TargetBitmap& invalid) const {
+        for (const auto& result : results_) {
+            const auto offset = std::get<0>(result);
+            AssertInfo(
+                offset >= 0 && static_cast<size_t>(offset) < invalid.size(),
+                "group-by result offset {} exceeds row count {}",
+                offset,
+                invalid.size());
+            invalid[offset] = true;
+        }
+    }
+
+    void
+    SortAndAppend(const knowhere::MetricType& metrics_type,
+                  std::vector<GroupByValueType>& group_by_values,
+                  std::vector<int64_t>& offsets,
+                  std::vector<float>& distances) {
+        auto comparator = [&](const auto& lhs, const auto& rhs) {
+            return milvus::query::dis_closer(
+                std::get<1>(lhs), std::get<1>(rhs), metrics_type);
+        };
+        std::sort(results_.begin(), results_.end(), comparator);
+
+        for (auto& result : results_) {
+            offsets.emplace_back(std::get<0>(result));
+            distances.emplace_back(std::get<1>(result));
+            group_by_values.emplace_back(std::move(std::get<2>(result)));
+        }
+        results_.clear();
+    }
+
+ private:
+    std::vector<Result> results_;
+    std::optional<std::unordered_set<int64_t>> accepted_offsets_;
+};
 
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperatorTest.cpp
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperatorTest.cpp
@@ -1,0 +1,1102 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "common/PrometheusClient.h"
+#include "exec/operator/groupby/GroupMembership.h"
+#include "exec/operator/groupby/SearchGroupByOperator.h"
+#include "common/Consts.h"
+#include "index/ScalarIndexSort.h"
+#include "index/VectorMemIndex.h"
+#include "exec/operator/Utils.h"
+#include "monitor/Monitor.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/cachinglayer_test_utils.h"
+#include "test_utils/storage_test_utils.h"
+
+namespace milvus::exec {
+
+namespace {
+
+class CountingScalarIndex : public index::ScalarIndexSort<int64_t> {
+ public:
+    size_t in_calls = 0;
+    size_t in_values = 0;
+    size_t null_calls = 0;
+
+    const TargetBitmap
+    In(size_t n, const int64_t* values) override {
+        ++in_calls;
+        in_values += n;
+        return index::ScalarIndexSort<int64_t>::In(n, values);
+    }
+
+    const TargetBitmap
+    IsNull() override {
+        ++null_calls;
+        return index::ScalarIndexSort<int64_t>::IsNull();
+    }
+};
+
+class SequenceIterator final : public knowhere::IndexNode::iterator {
+ public:
+    explicit SequenceIterator(std::vector<std::pair<int64_t, float>> values)
+        : values_(std::move(values)) {
+    }
+
+    std::pair<int64_t, float>
+    Next() override {
+        return values_.at(position_++);
+    }
+
+    bool
+    HasNext() override {
+        return position_ < values_.size();
+    }
+
+ private:
+    std::vector<std::pair<int64_t, float>> values_;
+    size_t position_{0};
+};
+
+std::shared_ptr<VectorIterator>
+MakeSequenceVectorIterator(
+    const std::vector<std::pair<int64_t, float>>& candidates,
+    const BitsetView& invalid = {},
+    bool empty_leading_chunk = false) {
+    std::vector<std::pair<int64_t, float>> eligible;
+    eligible.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+        if (invalid.empty() || !invalid.test(candidate.first)) {
+            eligible.emplace_back(candidate);
+        }
+    }
+    auto iterator = std::make_shared<VectorIterator>(
+        /*chunk_count=*/empty_leading_chunk ? 2 : 1,
+        /*offset_mapping=*/nullptr);
+    if (empty_leading_chunk) {
+        iterator->AddIterator(std::make_shared<SequenceIterator>(
+            std::vector<std::pair<int64_t, float>>{}));
+    }
+    iterator->AddIterator(std::make_shared<SequenceIterator>(eligible));
+    iterator->seal();
+    return iterator;
+}
+
+}  // namespace
+
+TEST(VectorIteratorFilteredChunksTest, EmptyLeadingChunkKeepsSuccessors) {
+    VectorIterator iterator(2, nullptr);
+    iterator.AddIterator(std::make_shared<SequenceIterator>(
+        std::vector<std::pair<int64_t, float>>{}));
+    iterator.AddIterator(std::make_shared<SequenceIterator>(
+        std::vector<std::pair<int64_t, float>>{{3, 1.0F}, {4, 2.0F}}));
+    iterator.seal();
+    ASSERT_TRUE(iterator.HasNext());
+    EXPECT_EQ(iterator.Next()->first, 3);
+    ASSERT_TRUE(iterator.HasNext());
+    EXPECT_EQ(iterator.Next()->first, 4);
+    EXPECT_FALSE(iterator.HasNext());
+}
+
+TEST(StrictGroupFilteredIteratorEligibilityTest,
+     RequiresStrictMultiResultSingleQueryRowLevelSearch) {
+    SearchInfo eligible;
+    eligible.topk_ = 10;
+    eligible.group_size_ = 3;
+    eligible.strict_group_size_ = true;
+    EXPECT_TRUE(query::CanUseStrictGroupFilteredIterator(eligible, 1));
+
+    auto disabled = eligible;
+    disabled.strict_group_acceptance_threshold_ = 0;
+    EXPECT_FALSE(query::CanUseStrictGroupFilteredIterator(disabled, 1));
+
+    auto non_strict = eligible;
+    non_strict.strict_group_size_ = false;
+    EXPECT_FALSE(query::CanUseStrictGroupFilteredIterator(non_strict, 1));
+
+    auto single_result_group = eligible;
+    single_result_group.group_size_ = 1;
+    EXPECT_FALSE(
+        query::CanUseStrictGroupFilteredIterator(single_result_group, 1));
+
+    auto empty_topk = eligible;
+    empty_topk.topk_ = 0;
+    EXPECT_FALSE(query::CanUseStrictGroupFilteredIterator(empty_topk, 1));
+    EXPECT_FALSE(query::CanUseStrictGroupFilteredIterator(eligible, 2));
+
+    auto element_level = eligible;
+    element_level.array_offsets_ = std::make_shared<ArrayOffsetsSealed>();
+    EXPECT_FALSE(query::CanUseStrictGroupFilteredIterator(element_level, 1));
+}
+
+TEST(StrictGroupPhase2ExecutorTest,
+     LocksGroupsAndRecreatesOneFilteredIterator) {
+    constexpr int64_t kRowCount = 120;
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto group_field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+    auto data = segcore::DataGen(schema,
+                                 kRowCount,
+                                 /*seed=*/42,
+                                 /*ts_offset=*/0,
+                                 /*repeat_count=*/4);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, data);
+    auto group_values = data.get_col<int64_t>(group_field);
+
+    std::unordered_map<int64_t, std::vector<int64_t>> rows_by_group;
+    for (int64_t offset = 0; offset < kRowCount; ++offset) {
+        rows_by_group[group_values[offset]].emplace_back(offset);
+    }
+    std::vector<int64_t> locked_groups;
+    for (const auto& [group, rows] : rows_by_group) {
+        if (rows.size() >= 3) {
+            locked_groups.emplace_back(group);
+            if (locked_groups.size() == 2) {
+                break;
+            }
+        }
+    }
+    ASSERT_EQ(locked_groups.size(), 2);
+
+    std::vector<std::pair<int64_t, float>> candidates;
+    candidates.emplace_back(rows_by_group[locked_groups[0]][0], 0.0F);
+    candidates.emplace_back(rows_by_group[locked_groups[1]][0], 1.0F);
+    for (int64_t offset = 0; offset < kRowCount; ++offset) {
+        if (group_values[offset] != locked_groups[0] &&
+            group_values[offset] != locked_groups[1]) {
+            candidates.emplace_back(offset,
+                                    static_cast<float>(candidates.size()));
+        }
+    }
+    for (auto group : locked_groups) {
+        for (auto offset : rows_by_group[group]) {
+            if (offset != candidates[0].first &&
+                offset != candidates[1].first) {
+                candidates.emplace_back(offset,
+                                        static_cast<float>(candidates.size()));
+            }
+        }
+    }
+
+    SearchResult search_result;
+    search_result.total_nq_ = 1;
+    search_result.total_data_cnt_ = kRowCount;
+    search_result.vector_iterators_ =
+        std::vector<std::shared_ptr<VectorIterator>>{
+            MakeSequenceVectorIterator(candidates)};
+
+    int recreate_count = 0;
+    TargetBitmap observed_filter;
+    search_result.SetVectorIteratorRecreator(
+        BitsetView{},
+        [&](const BitsetView& invalid, SearchResult& recreated_result) {
+            ++recreate_count;
+            observed_filter = TargetBitmap(invalid.size(), false);
+            for (size_t i = 0; i < invalid.size(); ++i) {
+                observed_filter[i] = invalid.test(i);
+            }
+            recreated_result.vector_iterators_ =
+                std::vector<std::shared_ptr<VectorIterator>>{
+                    MakeSequenceVectorIterator(candidates, invalid, true)};
+        });
+
+    SearchInfo search_info;
+    search_info.topk_ = 2;
+    search_info.group_size_ = 3;
+    search_info.strict_group_size_ = true;
+    search_info.group_by_field_id_ = group_field;
+    search_info.metric_type_ = knowhere::metric::L2;
+    std::vector<GroupByValueType> output_groups;
+    std::vector<int64_t> offsets;
+    std::vector<float> distances;
+    std::vector<size_t> prefix_sum;
+    const auto before_candidates =
+        milvus::monitor::internal_core_strict_group_phase2_phase1_candidates
+            .Collect()
+            .histogram;
+    const auto before_latency =
+        milvus::monitor::
+            internal_core_strict_group_phase2_membership_build_latency.Collect()
+                .histogram;
+    const auto before_phase2 =
+        milvus::monitor::internal_core_strict_group_phase2_phase2_candidates
+            .Collect()
+            .histogram;
+    const auto before_bitmap =
+        milvus::monitor::internal_core_strict_group_phase2_bitmap_build_latency
+            .Collect()
+            .histogram;
+    const auto before_ratio =
+        milvus::monitor::internal_core_strict_group_phase2_acceptance_ratio
+            .Collect()
+            .histogram;
+    const auto started = std::chrono::steady_clock::now();
+    SearchGroupBy(nullptr,
+                  *search_result.vector_iterators_,
+                  search_info,
+                  output_groups,
+                  *segment,
+                  offsets,
+                  distances,
+                  prefix_sum,
+                  &search_result);
+
+    const auto elapsed_ms = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - started)
+                                .count();
+    ASSERT_EQ(recreate_count, 1);
+    ASSERT_EQ(observed_filter.size(), kRowCount);
+    const auto after_candidates =
+        milvus::monitor::internal_core_strict_group_phase2_phase1_candidates
+            .Collect()
+            .histogram;
+    const auto after_latency =
+        milvus::monitor::
+            internal_core_strict_group_phase2_membership_build_latency.Collect()
+                .histogram;
+    EXPECT_EQ(after_candidates.sample_count - before_candidates.sample_count,
+              1);
+    EXPECT_EQ(after_candidates.sample_sum - before_candidates.sample_sum, 102);
+    EXPECT_EQ(after_latency.sample_count - before_latency.sample_count, 1);
+    EXPECT_GE(after_latency.sample_sum - before_latency.sample_sum, 0);
+    EXPECT_LE(after_latency.sample_sum - before_latency.sample_sum, elapsed_ms);
+    const auto after_phase2 =
+        milvus::monitor::internal_core_strict_group_phase2_phase2_candidates
+            .Collect()
+            .histogram;
+    const auto after_bitmap =
+        milvus::monitor::internal_core_strict_group_phase2_bitmap_build_latency
+            .Collect()
+            .histogram;
+    const auto after_ratio =
+        milvus::monitor::internal_core_strict_group_phase2_acceptance_ratio
+            .Collect()
+            .histogram;
+    EXPECT_EQ(after_phase2.sample_count - before_phase2.sample_count, 1);
+    // Five candidates accept four rows; one belongs to a now-full group.
+    EXPECT_EQ(after_phase2.sample_sum - before_phase2.sample_sum, 5);
+    EXPECT_EQ(after_bitmap.sample_count - before_bitmap.sample_count, 1);
+    EXPECT_LE(after_bitmap.sample_sum - before_bitmap.sample_sum, elapsed_ms);
+    EXPECT_EQ(after_ratio.sample_count - before_ratio.sample_count, 1);
+    EXPECT_EQ(after_ratio.sample_sum - before_ratio.sample_sum, 0);
+    EXPECT_FALSE(search_result.CanRecreateVectorIterator());
+    EXPECT_EQ(offsets.size(), 6);
+    EXPECT_EQ(prefix_sum, (std::vector<size_t>{0, 6}));
+    EXPECT_TRUE(observed_filter[candidates[0].first]);
+    EXPECT_TRUE(observed_filter[candidates[1].first]);
+    std::unordered_map<int64_t, size_t> output_counts;
+    for (auto offset : offsets) {
+        ++output_counts[group_values[offset]];
+    }
+    EXPECT_EQ(output_counts[locked_groups[0]], 3);
+    EXPECT_EQ(output_counts[locked_groups[1]], 3);
+    for (int64_t offset = 0; offset < kRowCount; ++offset) {
+        auto belongs_to_locked_group =
+            group_values[offset] == locked_groups[0] ||
+            group_values[offset] == locked_groups[1];
+        if (!belongs_to_locked_group) {
+            EXPECT_TRUE(observed_filter[offset]);
+        }
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, EasyQuotaDoesNotRecreate) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    auto data = segcore::DataGen(schema, 1000, 42, 0, 1000);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, data);
+    auto values = data.get_col<int64_t>(field);
+    std::vector<std::pair<int64_t, float>> candidates;
+    for (int64_t i = 0; i < 1000; ++i) {
+        if (values[i] == values[0]) {
+            candidates.emplace_back(i, static_cast<float>(i));
+        }
+    }
+    ASSERT_GE(candidates.size(), 2);
+    SearchResult result;
+    result.total_nq_ = 1;
+    result.total_data_cnt_ = 1000;
+    result.vector_iterators_ = std::vector<std::shared_ptr<VectorIterator>>{
+        MakeSequenceVectorIterator(candidates)};
+    auto filter_owner = std::make_shared<TargetBitmap>(1000, false);
+    std::weak_ptr<TargetBitmap> weak_filter = filter_owner;
+    result.vector_iterator_filter_owner_ = filter_owner;
+    result.SetVectorIteratorRecreator(
+        BitsetView(*filter_owner), [](auto&, auto&) {
+            ADD_FAILURE() << "easy quota must use the original iterator";
+        });
+    EXPECT_EQ(result.vector_iterator_base_filter_, nullptr);
+    filter_owner.reset();
+    SearchInfo info;
+    info.topk_ = 1;
+    info.group_size_ = 2;
+    info.strict_group_size_ = true;
+    info.group_by_field_id_ = field;
+    info.metric_type_ = knowhere::metric::L2;
+    std::vector<GroupByValueType> groups;
+    std::vector<int64_t> offsets;
+    std::vector<float> distances;
+    std::vector<size_t> prefix;
+    SearchGroupBy(nullptr,
+                  *result.vector_iterators_,
+                  info,
+                  groups,
+                  *segment,
+                  offsets,
+                  distances,
+                  prefix,
+                  &result);
+    EXPECT_EQ(offsets.size(), 2);
+    EXPECT_TRUE(weak_filter.expired());
+    EXPECT_EQ(result.vector_iterator_base_filter_, nullptr);
+    EXPECT_FALSE(result.CanRecreateVectorIterator());
+}
+
+namespace {
+
+void
+CheckProbeScenario(
+    const std::vector<int64_t>& labels,
+    size_t candidate_count,
+    int64_t topk,
+    int64_t group_size,
+    int expected_recreates,
+    size_t expected_rows,
+    std::optional<ErrorCode> recreate_error = std::nullopt,
+    milvus::OpContext* op_ctx = nullptr,
+    folly::CancellationSource* cancel_on_recreate = nullptr,
+    std::optional<double> threshold = std::nullopt,
+    std::optional<std::vector<int64_t>> recreated_offsets = std::nullopt,
+    int64_t probe_budget = 100) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    auto data = segcore::DataGen(schema, labels.size());
+    for (auto& column : *data.raw_->mutable_fields_data()) {
+        if (column.field_id() == field.get()) {
+            auto* values = column.mutable_scalars()->mutable_long_data();
+            for (size_t i = 0; i < labels.size(); ++i) {
+                values->set_data(i, labels[i]);
+            }
+        }
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema, data);
+    std::vector<std::pair<int64_t, float>> candidates;
+    for (size_t i = 0; i < candidate_count; ++i) {
+        candidates.emplace_back(i, static_cast<float>(i));
+    }
+    SearchResult result;
+    result.total_nq_ = 1;
+    result.total_data_cnt_ = labels.size();
+    result.vector_iterators_ = std::vector<std::shared_ptr<VectorIterator>>{
+        MakeSequenceVectorIterator(candidates)};
+    int recreated = 0;
+    result.SetVectorIteratorRecreator(
+        BitsetView{}, [&](const BitsetView& invalid, SearchResult& batch) {
+            ++recreated;
+            if (cancel_on_recreate != nullptr) {
+                cancel_on_recreate->requestCancellation();
+            }
+            if (recreate_error.has_value()) {
+                throw SegcoreError(*recreate_error,
+                                   "injected preparation failure");
+            }
+            // Locking consumes at least topk candidates, followed by a full
+            // configured probe. This prefix must not be returned again.
+            for (int64_t i = 0; i < topk + probe_budget; ++i) {
+                EXPECT_TRUE(invalid.test(i)) << i;
+            }
+            EXPECT_FALSE(invalid.test(labels.size() - 1));
+            auto fresh_candidates = candidates;
+            if (recreated_offsets) {
+                fresh_candidates.clear();
+                for (auto offset : *recreated_offsets) {
+                    fresh_candidates.emplace_back(offset,
+                                                  static_cast<float>(offset));
+                }
+            }
+            batch.vector_iterators_ =
+                std::vector<std::shared_ptr<VectorIterator>>{
+                    MakeSequenceVectorIterator(
+                        fresh_candidates, invalid, true)};
+        });
+    SearchInfo info;
+    info.topk_ = topk;
+    info.group_size_ = group_size;
+    info.strict_group_size_ = true;
+    info.group_by_field_id_ = field;
+    info.metric_type_ = knowhere::metric::L2;
+    info.search_params_ = knowhere::Json::object();
+    info.strict_group_acceptance_threshold_ = threshold.value_or(0.1);
+    info.strict_group_probe_candidates_ = probe_budget;
+    std::vector<GroupByValueType> groups;
+    std::vector<int64_t> offsets;
+    std::vector<float> distances;
+    std::vector<size_t> prefix;
+    SearchGroupBy(op_ctx,
+                  *result.vector_iterators_,
+                  info,
+                  groups,
+                  *segment,
+                  offsets,
+                  distances,
+                  prefix,
+                  &result);
+    EXPECT_EQ(recreated, expected_recreates);
+    EXPECT_EQ(offsets.size(), expected_rows);
+    EXPECT_EQ(
+        std::unordered_set<int64_t>(offsets.begin(), offsets.end()).size(),
+        offsets.size());
+    EXPECT_FALSE(result.CanRecreateVectorIterator());
+}
+
+}  // namespace
+
+TEST(StrictGroupPhase2ExecutorTest, ProbeBoundaryAndOnlyOneDecision) {
+    for (int accepted : {9, 10, 11}) {
+        SCOPED_TRACE(accepted);
+        std::vector<int64_t> labels(300, 2);
+        labels[0] = 1;
+        for (int i = 1; i <= accepted; ++i) {
+            labels[i] = 1;
+        }
+        // Do not re-evaluate even if the next window has no useful hits.
+        for (size_t i = 201; i < labels.size(); ++i) {
+            labels[i] = 1;
+        }
+        CheckProbeScenario(
+            labels, labels.size(), 1, 20, accepted < 10 ? 1 : 0, 20);
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, FullGroupHitsAreNotAcceptedProbeRows) {
+    std::vector<int64_t> labels(120, 1);
+    labels[0] = 0;
+    for (size_t i = 2; i < 102; ++i) {
+        labels[i] = 0;
+    }
+    // All 100 candidates hit locked groups, but only two fill a quota.
+    // Acceptance is 2%, so recreate regardless of group-hit rate.
+    CheckProbeScenario(labels, labels.size(), 2, 3, 1, 6);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, ConfigurableProbeBudget) {
+    for (int64_t budget : {1, 17, 100, 250}) {
+        std::vector<int64_t> labels(budget + 4, 99);
+        labels[0] = labels[budget + 1] = labels[budget + 2] =
+            labels[budget + 3] = 1;
+        auto before =
+            milvus::monitor::internal_core_strict_group_phase2_probe_candidates
+                .Collect()
+                .histogram.sample_sum;
+        CheckProbeScenario(labels,
+                           labels.size(),
+                           1,
+                           3,
+                           1,
+                           3,
+                           std::nullopt,
+                           nullptr,
+                           nullptr,
+                           0.1,
+                           std::nullopt,
+                           budget);
+        auto after =
+            milvus::monitor::internal_core_strict_group_phase2_probe_candidates
+                .Collect()
+                .histogram.sample_sum;
+        EXPECT_EQ(after - before, budget);
+    }
+    // With T=10, accepting one row is exactly 10%, not 1%.
+    std::vector<int64_t> labels(14, 99);
+    labels[0] = labels[1] = labels[11] = labels[12] = labels[13] = 1;
+    for (double threshold : {0.1, 0.2}) {
+        CheckProbeScenario(labels,
+                           labels.size(),
+                           1,
+                           3,
+                           threshold == 0.1 ? 0 : 1,
+                           3,
+                           std::nullopt,
+                           nullptr,
+                           nullptr,
+                           threshold,
+                           std::nullopt,
+                           10);
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, ConfigurableAcceptanceThreshold) {
+    for (double threshold : {0.0, 0.01, 0.1, 0.5, 1.0}) {
+        for (int accepted : {0, 1, 2, 9, 10, 11, 49, 50, 51, 100}) {
+            SCOPED_TRACE(threshold);
+            SCOPED_TRACE(accepted);
+            std::vector<int64_t> labels(400, 2);
+            labels[0] = 1;
+            std::fill(labels.begin() + 1, labels.begin() + 1 + accepted, 1);
+            std::fill(labels.begin() + 201, labels.end(), 1);
+            CheckProbeScenario(labels,
+                               labels.size(),
+                               1,
+                               150,
+                               accepted / 100.0 < threshold ? 1 : 0,
+                               150,
+                               std::nullopt,
+                               nullptr,
+                               nullptr,
+                               threshold);
+        }
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, RemainingQuotaDoesNotAffectDecision) {
+    for (int quota : {3, 6, 7, 8, 100}) {
+        std::vector<int64_t> labels(300, 2);
+        labels[0] = labels[1] = 1;
+        std::fill(labels.begin() + 101, labels.end(), 1);
+        // A=1 triggers recreation even when only one row remains.
+        CheckProbeScenario(labels, labels.size(), 1, quota, 1, quota);
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, NonzeroLowAcceptance) {
+    std::vector<int64_t> labels(250, 99);
+    for (int i = 0; i < 50; ++i) {
+        labels[i] = i;
+        labels[150 + 2 * i] = labels[151 + 2 * i] = i;
+    }
+    labels[50] = 0;
+    // A=1 out of 100 triggers recreation.
+    CheckProbeScenario(labels, labels.size(), 50, 3, 1, 150);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, ZeroAcceptanceWithFullGroupHits) {
+    std::vector<int64_t> labels(106, 0);
+    labels[3] = labels[104] = labels[105] = 1;
+    // Group zero is full before locking group one. A=0 still recreates even
+    // though all 100 probe candidates hit the full locked group (H=100).
+    CheckProbeScenario(labels, labels.size(), 2, 3, 1, 6);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, ProbeExhaustionDoesNotRecreate) {
+    std::vector<int64_t> labels(120, 2);
+    labels[0] = 1;
+    CheckProbeScenario(labels, 50, 1, 3, 0, 1);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, PreparationExceptionsPropagate) {
+    std::vector<int64_t> labels(104, 99);
+    labels[0] = labels[102] = labels[103] = 1;
+    for (auto code : {ErrorCode::Unsupported,
+                      ErrorCode::FileReadFailed,
+                      ErrorCode::KnowhereError,
+                      ErrorCode::MemAllocateFailed,
+                      ErrorCode::FollyCancel,
+                      ErrorCode::FollyOtherException,
+                      ErrorCode::UnexpectedError,
+                      ErrorCode::DataFormatBroken}) {
+        EXPECT_THROW(
+            CheckProbeScenario(labels, labels.size(), 1, 3, 1, 3, code),
+            SegcoreError);
+    }
+    folly::CancellationSource source;
+    milvus::OpContext op_ctx(source.getToken());
+    EXPECT_THROW(CheckProbeScenario(labels,
+                                    labels.size(),
+                                    1,
+                                    3,
+                                    1,
+                                    3,
+                                    ErrorCode::Unsupported,
+                                    &op_ctx,
+                                    &source),
+                 SegcoreError);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, ExhaustedRecreatedIteratorResumesOriginal) {
+    std::vector<int64_t> labels(106, 99);
+    labels[0] = labels[102] = labels[103] = labels[104] = labels[105] = 1;
+    // The fresh iterator may return nothing, or return 103 before the original
+    // reaches 102,103,104. Duplicate 103 must not consume the final quota.
+    for (auto fresh : {std::vector<int64_t>{},
+                       std::vector<int64_t>{103},
+                       std::vector<int64_t>{103, 103}}) {
+        CheckProbeScenario(labels,
+                           labels.size(),
+                           1,
+                           4,
+                           1,
+                           4,
+                           std::nullopt,
+                           nullptr,
+                           nullptr,
+                           0.1,
+                           fresh);
+    }
+}
+
+TEST(GroupMembershipTest, RawScansHonorCancellation) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    constexpr size_t rows = 4096;
+    auto data = segcore::DataGen(schema, rows);
+    auto sealed = CreateSealedWithFieldDataLoaded(schema, data);
+    auto growing = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto offset = growing->PreInsert(rows);
+    growing->Insert(
+        offset, rows, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
+    folly::CancellationSource source;
+    milvus::OpContext ctx(source.getToken());
+    source.requestCancellation();
+    for (const auto* segment :
+         {dynamic_cast<const segcore::SegmentInternalInterface*>(sealed.get()),
+          dynamic_cast<const segcore::SegmentInternalInterface*>(
+              growing.get())}) {
+        ASSERT_NE(segment, nullptr);
+        try {
+            BuildGroupMembership<int64_t>(
+                &ctx, *segment, field, rows, {int64_t(1)}, nullptr);
+            FAIL() << "cancelled membership scan completed";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::FollyCancel);
+        }
+    }
+}
+
+TEST(GroupMembershipTest, CancellationDuringRawScanStopsBeforeNextChunk) {
+    // Cancel when the accessor reaches chunk 1, after chunk 0 was consumed.
+    // No timing or thread scheduling dependency: the next periodic check must
+    // throw before chunk 2 is pinned.
+    class CancellingSegment : public segcore::ChunkedSegmentSealedImpl {
+     public:
+        CancellingSegment(SchemaPtr schema, folly::CancellationSource& source)
+            : ChunkedSegmentSealedImpl(schema,
+                                       empty_index_meta,
+                                       segcore::SegcoreConfig::default_config(),
+                                       991),
+              source_(source),
+              values_(2048, 1) {
+        }
+        bool
+        HasFieldData(FieldId) const override {
+            return true;
+        }
+        int64_t
+        num_chunk_data(FieldId) const override {
+            return 4;
+        }
+        int64_t
+        size_per_chunk() const override {
+            return 2048;
+        }
+        int64_t
+        chunk_size(FieldId, int64_t) const override {
+            return 2048;
+        }
+        int64_t
+        num_rows_until_chunk(FieldId, int64_t id) const override {
+            return id * 2048;
+        }
+        mutable int pins = 0;
+
+     protected:
+        PinWrapper<SpanBase>
+        chunk_data_impl(milvus::OpContext*,
+                        FieldId,
+                        int64_t chunk) const override {
+            ++pins;
+            if (chunk == 1) {
+                source_.requestCancellation();
+            }
+            return PinWrapper<SpanBase>(
+                SpanBase(values_.data(), 2048, sizeof(int64_t)));
+        }
+
+     private:
+        folly::CancellationSource& source_;
+        std::vector<int64_t> values_;
+    };
+    auto schema = std::make_shared<Schema>();
+    auto field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(field);
+    folly::CancellationSource source;
+    milvus::OpContext ctx(source.getToken());
+    CancellingSegment segment(schema, source);
+    try {
+        BuildGroupMembership<int64_t>(
+            &ctx, segment, field, 8192, {int64_t(1)}, nullptr);
+        FAIL() << "membership continued after cancellation";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyCancel);
+    }
+    EXPECT_EQ(segment.pins, 2);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, SharedBaseFilterIsLazyAndReleased) {
+    SearchResult result;
+    auto owner = std::make_shared<TargetBitmap>(1000, false);
+    (*owner)[17] = true;
+    std::weak_ptr<TargetBitmap> weak_owner = owner;
+    result.vector_iterator_filter_owner_ = owner;
+    result.SetVectorIteratorRecreator(
+        BitsetView(*owner), [](const BitsetView& filter, SearchResult&) {
+            EXPECT_TRUE(filter.test(17));
+            EXPECT_TRUE(filter.test(33));
+        });
+    EXPECT_EQ(result.vector_iterator_base_filter_, nullptr);
+    owner.reset();
+    EXPECT_FALSE(weak_owner.expired());
+    TargetBitmap extra(1000, false);
+    extra[33] = true;
+    auto recreated = result.RecreateVectorIterators(std::move(extra));
+    ASSERT_TRUE(recreated.has_value());
+    EXPECT_NE(result.vector_iterator_base_filter_, nullptr);
+    result.ClearVectorIteratorRecreator();
+    EXPECT_TRUE(weak_owner.expired());
+    EXPECT_FALSE(result.CanRecreateVectorIterator());
+    EXPECT_EQ(result.GetVectorIteratorBaseFilter(), nullptr);
+}
+
+TEST(StrictGroupPhase2ExecutorTest, BackendPreparationPreservesTypedErrors) {
+    class FailingIndex : public index::VectorMemIndex<float> {
+     public:
+        FailingIndex()
+            : VectorMemIndex(
+                  DataType::NONE,
+                  "FLAT",
+                  knowhere::metric::L2,
+                  knowhere::Version::GetCurrentVersion().VersionNumber()) {
+        }
+        ErrorCode error = ErrorCode::FollyCancel;
+        knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
+        VectorIterators(const DatasetPtr,
+                        const knowhere::Json&,
+                        const BitsetView&) const override {
+            throw SegcoreError(error, "injected backend preparation failure");
+        }
+    } index;
+    SearchInfo info;
+    info.group_by_field_id_ = FieldId(100);
+    info.topk_ = 1;
+    info.metric_type_ = knowhere::metric::L2;
+    for (bool original : {false, true}) {
+        SearchResult result;
+        result.allow_vector_iterator_recreation_ = original;
+        for (auto code : {ErrorCode::FollyCancel,
+                          ErrorCode::FollyOtherException,
+                          ErrorCode::DataFormatBroken,
+                          ErrorCode::Unsupported}) {
+            index.error = code;
+            try {
+                PrepareVectorIteratorsFromIndex(
+                    info, 1, nullptr, result, BitsetView{}, index);
+                FAIL() << "backend must throw";
+            } catch (const SegcoreError& error) {
+                EXPECT_EQ(error.get_error_code(),
+                          original ? ErrorCode::Unsupported : code);
+            }
+        }
+    }
+}
+
+TEST(StrictGroupPhase2ExecutorTest, FilledAtProbeBoundaryDoesNotRecreate) {
+    std::vector<int64_t> labels(120, 2);
+    labels[0] = labels[100] = 1;
+    CheckProbeScenario(labels, labels.size(), 1, 2, 0, 2);
+}
+
+TEST(GroupMembershipTest, GrowingMmapStringUsesElementView) {
+    auto& config = storage::MmapManager::GetInstance().GetMmapConfig();
+    const bool previous = config.GetEnableGrowingMmap();
+    config.SetEnableGrowingMmap(true);
+    auto restore = std::shared_ptr<void>(
+        nullptr, [&](void*) { config.SetEnableGrowingMmap(previous); });
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto field = schema->AddDebugField("group", DataType::VARCHAR);
+    schema->set_primary_field_id(pk);
+    auto data = segcore::DataGen(schema, 100, 42, 0, 4);
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto offset = segment->PreInsert(100);
+    segment->Insert(
+        offset, 100, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
+    auto values = data.get_col<std::string>(field);
+    auto* growing = dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing, nullptr);
+    ASSERT_TRUE(
+        growing->get_insert_record().get_data<std::string>(field)->is_mmap());
+    std::vector<std::optional<std::string>> groups{values[0]};
+    auto membership = BuildGroupMembership<std::string>(
+        nullptr, *growing, field, 100, groups, nullptr);
+    ASSERT_TRUE(membership.has_value());
+    auto bitmap = std::move(membership);
+    ASSERT_TRUE(bitmap.has_value());
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ((*bitmap)[i], values[i] == values[0]);
+    }
+}
+
+TEST(GroupByMapTest, StrictTracksLockedGroupsAndRemainingQuota) {
+    GroupByMap<int64_t> groups(/*group_capacity=*/2,
+                               /*group_size=*/3,
+                               /*strict_group_size=*/true);
+
+    EXPECT_TRUE(groups.Push(7));
+    EXPECT_TRUE(groups.Push(7));
+    EXPECT_TRUE(groups.Push(7));
+    EXPECT_TRUE(groups.IsGroupFull(7));
+    EXPECT_EQ(groups.GetRemainingGroupSize(7), 0);
+    EXPECT_EQ(groups.GetEnoughGroupCount(), 1);
+    EXPECT_FALSE(groups.IsGroupCapacityReached());
+    EXPECT_FALSE(groups.IsGroupResEnough());
+
+    EXPECT_TRUE(groups.Push(8));
+    EXPECT_TRUE(groups.IsGroupCapacityReached());
+    EXPECT_FALSE(groups.IsGroupResEnough());
+    EXPECT_EQ(groups.GetGroupResultCount(8), 1);
+    EXPECT_EQ(groups.GetRemainingGroupSize(8), 2);
+
+    EXPECT_FALSE(groups.Push(9));
+    EXPECT_FALSE(groups.Contains(9));
+    EXPECT_EQ(groups.GetGroupCount(), 2);
+
+    EXPECT_TRUE(groups.Push(8));
+    EXPECT_TRUE(groups.Push(8));
+    EXPECT_TRUE(groups.IsGroupResEnough());
+    EXPECT_EQ(groups.GetEnoughGroupCount(), 2);
+    EXPECT_FALSE(groups.Push(7));
+
+    ASSERT_EQ(groups.GetGroupOrder().size(), 2);
+    EXPECT_EQ(groups.GetGroupOrder()[0], std::optional<int64_t>(7));
+    EXPECT_EQ(groups.GetGroupOrder()[1], std::optional<int64_t>(8));
+}
+
+TEST(GroupByMapTest, NonStrictStopsWhenCapacityIsReached) {
+    GroupByMap<int64_t> groups(/*group_capacity=*/2,
+                               /*group_size=*/3,
+                               /*strict_group_size=*/false);
+
+    EXPECT_TRUE(groups.Push(1));
+    EXPECT_TRUE(groups.Push(1));
+    EXPECT_FALSE(groups.IsGroupResEnough());
+    EXPECT_TRUE(groups.Push(2));
+    EXPECT_TRUE(groups.IsGroupResEnough());
+    EXPECT_EQ(groups.GetRemainingGroupSize(1), 1);
+    EXPECT_EQ(groups.GetRemainingGroupSize(2), 2);
+}
+
+TEST(GroupByMapTest, NullIsTrackedAsAStableGroupKey) {
+    GroupByMap<int64_t> groups(/*group_capacity=*/2,
+                               /*group_size=*/2,
+                               /*strict_group_size=*/true);
+
+    EXPECT_TRUE(groups.Push(std::nullopt));
+    EXPECT_TRUE(groups.Contains(std::nullopt));
+    EXPECT_EQ(groups.GetGroupResultCount(std::nullopt), 1);
+    ASSERT_EQ(groups.GetGroupOrder().size(), 1);
+    EXPECT_FALSE(groups.GetGroupOrder()[0].has_value());
+}
+
+TEST(GroupByResultCollectorTest, SortsAndAppendsByMetric) {
+    {
+        GroupByResultCollector<int64_t> collector;
+        collector.Add(10, 0.8F, 1);
+        collector.Add(20, 0.2F, 2);
+
+        std::vector<GroupByValueType> groups;
+        std::vector<int64_t> offsets;
+        std::vector<float> distances;
+        collector.SortAndAppend(
+            knowhere::metric::L2, groups, offsets, distances);
+
+        EXPECT_EQ(offsets, (std::vector<int64_t>{20, 10}));
+        EXPECT_EQ(distances, (std::vector<float>{0.2F, 0.8F}));
+        EXPECT_EQ(groups.size(), 2);
+        EXPECT_EQ(collector.Size(), 0);
+    }
+
+    {
+        GroupByResultCollector<int64_t> collector;
+        collector.Add(10, 0.8F, 1);
+        collector.Add(20, 0.2F, 2);
+
+        std::vector<GroupByValueType> groups;
+        std::vector<int64_t> offsets;
+        std::vector<float> distances;
+        collector.SortAndAppend(
+            knowhere::metric::IP, groups, offsets, distances);
+
+        EXPECT_EQ(offsets, (std::vector<int64_t>{10, 20}));
+        EXPECT_EQ(distances, (std::vector<float>{0.8F, 0.2F}));
+        EXPECT_EQ(groups.size(), 2);
+        EXPECT_EQ(collector.Size(), 0);
+    }
+}
+
+TEST(GroupMembershipTest, ScalarIndexAndRawFieldProduceIdenticalMembership) {
+    constexpr int64_t kRowCount = 120;
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto group_field =
+        schema->AddDebugField("nullable_group", DataType::INT64, true);
+    schema->set_primary_field_id(pk_field);
+    auto data = segcore::DataGen(schema,
+                                 kRowCount,
+                                 /*seed=*/42,
+                                 /*ts_offset=*/0,
+                                 /*repeat_count=*/4);
+
+    auto raw_segment = CreateSealedWithFieldDataLoaded(schema, data);
+    auto index_segment =
+        segcore::CreateSealedSegment(schema, empty_index_meta, 7001);
+    LoadGeneratedDataIntoSegment(
+        data, index_segment.get(), false, {group_field.get()});
+
+    auto values = data.get_col<int64_t>(group_field);
+    auto valid = data.get_col_valid(group_field);
+    auto scalar_index = std::make_unique<CountingScalarIndex>();
+    auto* counters = scalar_index.get();
+    scalar_index->Build(kRowCount, values.data(), valid.data());
+    segcore::LoadIndexInfo load_info;
+    load_info.field_id = group_field.get();
+    load_info.field_type = DataType::INT64;
+    load_info.index_params = GenIndexParams(scalar_index.get());
+    load_info.cache_index =
+        CreateTestCacheIndex("group-membership", std::move(scalar_index));
+    index_segment->LoadIndex(load_info);
+
+    TargetBitmap base_filter(kRowCount, false);
+    base_filter[1] = true;  // filtered null
+    base_filter[4] = true;  // filtered value group
+    base_filter[117] = true;
+    std::vector<std::optional<int64_t>> groups{
+        std::nullopt, values[0], values[4], values[20]};
+
+    auto raw = BuildGroupMembership<int64_t>(
+        nullptr, *raw_segment, group_field, kRowCount, groups, &base_filter);
+    auto indexed = BuildGroupMembership<int64_t>(
+        nullptr, *index_segment, group_field, kRowCount, groups, &base_filter);
+    ASSERT_TRUE(raw.has_value());
+    ASSERT_TRUE(indexed.has_value());
+    EXPECT_EQ(counters->in_calls, 1);
+    EXPECT_EQ(counters->in_values, 3);
+    EXPECT_EQ(counters->null_calls, 1);
+    // Both sources present: phase two must use raw data, like phase one.
+    LoadGeneratedDataIntoSegment(
+        data,
+        index_segment.get(),
+        false,
+        {pk_field.get(), RowFieldID.get(), TimestampFieldID.get()});
+    ASSERT_TRUE(index_segment->HasFieldData(group_field));
+    auto both = BuildGroupMembership<int64_t>(
+        nullptr, *index_segment, group_field, kRowCount, groups, &base_filter);
+    ASSERT_TRUE(both.has_value());
+    EXPECT_EQ(counters->in_calls, 1);
+    EXPECT_EQ(counters->null_calls, 1);
+    // The union bitmap owns its bits and no longer needs the source column.
+    raw_segment->DropFieldData(group_field);
+    auto raw_bitmap = std::move(raw);
+    auto index_bitmap = std::move(indexed);
+    ASSERT_TRUE(raw_bitmap.has_value());
+    ASSERT_TRUE(index_bitmap.has_value());
+    ASSERT_EQ(raw_bitmap->size(), index_bitmap->size());
+    for (size_t i = 0; i < raw_bitmap->size(); ++i) {
+        EXPECT_EQ((*raw_bitmap)[i], (*index_bitmap)[i]) << "offset " << i;
+        EXPECT_EQ((*raw_bitmap)[i], (*both)[i]) << "offset " << i;
+        if (base_filter[i]) {
+            EXPECT_FALSE((*raw_bitmap)[i]);
+        }
+    }
+}
+
+TEST(GroupMembershipTest, RawStringBoolAndNullGroupsRespectBaseFilter) {
+    constexpr int64_t kRowCount = 40;
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto string_field =
+        schema->AddDebugField("nullable_string", DataType::VARCHAR, true);
+    auto bool_field = schema->AddDebugField("bool_group", DataType::BOOL);
+    schema->set_primary_field_id(pk_field);
+    auto data = segcore::DataGen(schema,
+                                 kRowCount,
+                                 /*seed=*/99,
+                                 /*ts_offset=*/0,
+                                 /*repeat_count=*/4);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, data);
+    TargetBitmap base_filter(kRowCount, false);
+    base_filter[0] = true;
+    base_filter[3] = true;
+    base_filter[10] = true;
+
+    auto strings = data.get_col<std::string>(string_field);
+    auto valid = data.get_col_valid(string_field);
+    std::vector<std::optional<std::string>> string_groups{
+        std::nullopt, strings[0], strings[8]};
+    auto string_membership = BuildGroupMembership<std::string>(nullptr,
+                                                               *segment,
+                                                               string_field,
+                                                               kRowCount,
+                                                               string_groups,
+                                                               &base_filter);
+    ASSERT_TRUE(string_membership.has_value());
+    auto string_bitmap = std::move(string_membership);
+    ASSERT_TRUE(string_bitmap.has_value());
+
+    for (size_t i = 0; i < kRowCount; ++i) {
+        std::optional<std::string> value =
+            valid[i] ? std::optional<std::string>(strings[i]) : std::nullopt;
+        auto found =
+            std::find(string_groups.begin(), string_groups.end(), value);
+        auto expected = !base_filter[i] && found != string_groups.end();
+        EXPECT_EQ((*string_bitmap)[i], expected) << "offset " << i;
+    }
+
+    std::vector<std::optional<bool>> bool_groups{false, true};
+    auto bool_membership = BuildGroupMembership<bool>(
+        nullptr, *segment, bool_field, kRowCount, bool_groups, &base_filter);
+    ASSERT_TRUE(bool_membership.has_value());
+    auto bool_bitmap = std::move(bool_membership);
+    ASSERT_TRUE(bool_bitmap.has_value());
+    EXPECT_EQ(bool_bitmap->count(), kRowCount - base_filter.count());
+}
+
+TEST(GroupMembershipTest, RejectsMismatchedFilterSize) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    auto group_field = schema->AddDebugField("group", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+    auto data = segcore::DataGen(schema, 10);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, data);
+    TargetBitmap wrong_size(9, false);
+
+    auto membership = BuildGroupMembership<int64_t>(
+        nullptr, *segment, group_field, 10, {0}, &wrong_size);
+    EXPECT_FALSE(membership.has_value());
+}
+
+}  // namespace milvus::exec

--- a/internal/core/src/monitor/Monitor.cpp
+++ b/internal/core/src/monitor/Monitor.cpp
@@ -192,6 +192,32 @@ std::map<std::string, std::string> gisCoarseRatioLabels{
     {"type", "gis_coarse_ratio"}};
 std::map<std::string, std::string> gisRefineRatioLabels{
     {"type", "gis_refine_ratio"}};
+std::map<std::string, std::string> strictGroupPhase1CandidatesLabels{
+    {"type", "phase1_candidates"}};
+std::map<std::string, std::string> strictGroupPhase2CandidatesLabels{
+    {"type", "phase2_candidates"}};
+std::map<std::string, std::string> strictGroupBatchCountLabels{
+    {"type", "batch_count"}};
+std::map<std::string, std::string> strictGroupProbeCandidatesLabels{
+    {"type", "probe_candidates"}};
+std::map<std::string, std::string> strictGroupProbeAcceptedLabels{
+    {"type", "probe_accepted"}};
+std::map<std::string, std::string> strictGroup_probe_group_hits_Labels{
+    {"type", "probe_group_hits"}};
+std::map<std::string, std::string>
+    strictGroup_original_remaining_candidates_Labels{
+        {"type", "original_remaining_candidates"}};
+std::map<std::string, std::string> strictGroupMembershipBuildLatencyLabels{
+    {"type", "membership_build_latency"}};
+std::map<std::string, std::string> strictGroupBitmapBuildLatencyLabels{
+    {"type", "bitmap_build_latency"}};
+std::map<std::string, std::string> strictGroupAcceptanceRatioLabels{
+    {"type", "probe_acceptance_ratio"}};
+
+const prometheus::Histogram::BucketBoundaries strictGroupCountBuckets = {
+    1,      2,       4,       8,        16,       32,       64,
+    128,    256,     512,     1024,     4096,     16384,    65536,
+    262144, 1048576, 4194304, 16777216, 67108864, 268435456};
 
 DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_search_latency,
                                    "[cpp]latency(us) of search on segment")
@@ -242,6 +268,58 @@ DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(internal_core_gis_refine_ratio,
                                          internal_core_search_latency,
                                          gisRefineRatioLabels,
                                          ratioBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_strict_group_phase2_count,
+                                   "[cpp]strict group filtered iterator counts")
+DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_strict_group_phase2_ratio,
+                                   "[cpp]strict group filtered iterator ratios")
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_phase1_candidates,
+    internal_core_strict_group_phase2_count,
+    strictGroupPhase1CandidatesLabels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_phase2_candidates,
+    internal_core_strict_group_phase2_count,
+    strictGroupPhase2CandidatesLabels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_batch_count,
+    internal_core_strict_group_phase2_count,
+    strictGroupBatchCountLabels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_probe_candidates,
+    internal_core_strict_group_phase2_count,
+    strictGroupProbeCandidatesLabels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_probe_accepted,
+    internal_core_strict_group_phase2_count,
+    strictGroupProbeAcceptedLabels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_probe_group_hits,
+    internal_core_strict_group_phase2_count,
+    strictGroup_probe_group_hits_Labels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_original_remaining_candidates,
+    internal_core_strict_group_phase2_count,
+    strictGroup_original_remaining_candidates_Labels,
+    strictGroupCountBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_membership_build_latency,
+    internal_core_search_latency,
+    strictGroupMembershipBuildLatencyLabels)
+DEFINE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_bitmap_build_latency,
+    internal_core_search_latency,
+    strictGroupBitmapBuildLatencyLabels)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(
+    internal_core_strict_group_phase2_acceptance_ratio,
+    internal_core_strict_group_phase2_ratio,
+    strictGroupAcceptanceRatioLabels,
+    ratioBuckets)
 // mmap metrics
 std::map<std::string, std::string> mmapAllocatedSpaceAnonLabel = {
     {"type", "anon"}};

--- a/internal/core/src/monitor/Monitor.h
+++ b/internal/core/src/monitor/Monitor.h
@@ -90,6 +90,26 @@ DECLARE_PROMETHEUS_HISTOGRAM(internal_core_expr_filter_ratio);
 // approaches 1 the pruning has silently degraded to a full scan.
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_coarse_ratio);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_refine_ratio);
+DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_strict_group_phase2_count);
+DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_strict_group_phase2_ratio);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_phase1_candidates);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_phase2_candidates);
+DECLARE_PROMETHEUS_HISTOGRAM(internal_core_strict_group_phase2_batch_count);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_probe_candidates);
+DECLARE_PROMETHEUS_HISTOGRAM(internal_core_strict_group_phase2_probe_accepted);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_probe_group_hits);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_original_remaining_candidates);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_membership_build_latency);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_bitmap_build_latency);
+DECLARE_PROMETHEUS_HISTOGRAM(
+    internal_core_strict_group_phase2_acceptance_ratio);
 
 // async cgo metrics
 DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(internal_cgo_queue_duration_seconds);

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -14,6 +14,8 @@
 #include <google/protobuf/text_format.h>
 
 #include <cstdint>
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,6 +34,42 @@
 
 namespace milvus::query {
 namespace planpb = milvus::proto::plan;
+
+namespace {
+// QueryNode supplies a snapshot of server settings. These are Milvus-only
+// controls and must not be forwarded to the backend.
+void
+ParseStrictGroupSettings(SearchInfo& info) {
+    auto& params = info.search_params_;
+    if (auto it = params.find(kStrictGroupAcceptanceThreshold);
+        it != params.end()) {
+        if (!it->is_number()) {
+            ThrowInfo(InvalidParameter,
+                      "strict group acceptance must be numeric");
+        }
+        auto value = it->get<double>();
+        if (!std::isfinite(value) || value < 0 || value > 1) {
+            ThrowInfo(InvalidParameter,
+                      "strict group acceptance must be in [0,1]");
+        }
+        info.strict_group_acceptance_threshold_ = value;
+        params.erase(it);
+    }
+    if (auto it = params.find(kStrictGroupProbeCandidates);
+        it != params.end()) {
+        if (!it->is_number_integer() ||
+            (it->is_number_unsigned() &&
+             it->get<uint64_t>() >
+                 static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) ||
+            it->get<int64_t>() <= 0) {
+            ThrowInfo(InvalidParameter,
+                      "strict group probe must be a positive int64");
+        }
+        info.strict_group_probe_candidates_ = it->get<int64_t>();
+        params.erase(it);
+    }
+}
+}  // namespace
 
 void
 ProtoParser::PlanOptionsFromProto(
@@ -64,6 +102,7 @@ ProtoParser::PlanNodeFromProto(const planpb::PlanNode& plan_node_proto) {
         search_info.round_decimal_ = query_info_proto.round_decimal();
         search_info.search_params_ =
             nlohmann::json::parse(query_info_proto.search_params());
+        ParseStrictGroupSettings(search_info);
         search_info.materialized_view_involved =
             query_info_proto.materialized_view_involved();
         // currently, iterative filter does not support range search

--- a/internal/core/src/query/PlanProtoTest.cpp
+++ b/internal/core/src/query/PlanProtoTest.cpp
@@ -97,3 +97,70 @@ TEST(PlanProto, VectorArrayFieldIdGapInStructArray) {
     ASSERT_EQ(involved_fields.size(), 49);
     EXPECT_TRUE(involved_fields[48]);
 }
+
+TEST(PlanProto, StrictGroupSettings) {
+    using namespace milvus;
+    auto schema = std::make_shared<Schema>();
+    auto vec = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    proto::plan::PlanNode node;
+    auto* anns = node.mutable_vector_anns();
+    anns->set_vector_type(proto::plan::VectorType::FloatVector);
+    anns->set_field_id(vec.get());
+    anns->set_placeholder_tag("$0");
+    auto* info = anns->mutable_query_info();
+    info->set_metric_type("L2");
+    info->set_topk(10);
+    info->set_round_decimal(-1);
+    for (
+        const auto& params :
+        {R"({"nprobe":128})",
+         R"({"nprobe":128,"strict_group_acceptance_threshold":0,"strict_group_probe_candidates":1})",
+         R"({"nprobe":128,"strict_group_acceptance_threshold":0.1,"strict_group_probe_candidates":100})",
+         R"({"nprobe":128,"strict_group_acceptance_threshold":0.5,"strict_group_probe_candidates":17})",
+         R"({"nprobe":128,"strict_group_acceptance_threshold":1,"strict_group_probe_candidates":9223372036854775807})"}) {
+        info->set_search_params(params);
+        auto parsed = query::ProtoParser(schema).PlanNodeFromProto(node);
+        const auto& search = parsed->search_info_;
+        EXPECT_DOUBLE_EQ(search.strict_group_acceptance_threshold_,
+                         knowhere::Json::parse(params).value(
+                             kStrictGroupAcceptanceThreshold, 0.1));
+        EXPECT_FALSE(
+            search.search_params_.contains(kStrictGroupAcceptanceThreshold));
+        EXPECT_EQ(search.strict_group_probe_candidates_,
+                  knowhere::Json::parse(params).value(
+                      kStrictGroupProbeCandidates, int64_t(100)));
+        EXPECT_FALSE(
+            search.search_params_.contains(kStrictGroupProbeCandidates));
+        EXPECT_EQ(search.search_params_["nprobe"], 128);
+    }
+    for (const auto& key :
+         {kStrictGroupAcceptanceThreshold, kStrictGroupProbeCandidates}) {
+        for (const auto& value : {knowhere::Json(nullptr),
+                                  knowhere::Json(true),
+                                  knowhere::Json("0.5"),
+                                  knowhere::Json("NaN"),
+                                  knowhere::Json::array(),
+                                  knowhere::Json::object(),
+                                  knowhere::Json(-1),
+                                  knowhere::Json(1.1)}) {
+            info->set_search_params(knowhere::Json{{key, value}}.dump());
+            try {
+                query::ProtoParser(schema).PlanNodeFromProto(node);
+                FAIL() << "invalid strict group setting accepted";
+            } catch (const SegcoreError& error) {
+                EXPECT_EQ(error.get_error_code(), ErrorCode::InvalidParameter);
+            }
+        }
+    }
+    for (const auto& value : {knowhere::Json(0),
+                              knowhere::Json(1.0),
+                              knowhere::Json(uint64_t(1) << 63)}) {
+        info->set_search_params(
+            knowhere::Json{{kStrictGroupProbeCandidates, value}}.dump());
+        EXPECT_THROW(query::ProtoParser(schema).PlanNodeFromProto(node),
+                     SegcoreError);
+    }
+}

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -81,6 +81,35 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 const BitsetView& bitset,
                 milvus::OpContext* op_context,
                 SearchResult& search_result) {
+    const auto* segment_ptr = &segment;
+    auto register_vector_iterator_recreator = [&] {
+        if (!search_result.allow_vector_iterator_recreation_ ||
+            !CanUseStrictGroupFilteredIterator(info, num_queries) ||
+            !search_result.vector_iterators_.has_value()) {
+            return;
+        }
+        search_result.SetVectorIteratorRecreator(
+            bitset,
+            [segment_ptr,
+             recreate_search_info = info,
+             query_data,
+             query_offsets,
+             num_queries,
+             timestamp,
+             op_context](const BitsetView& combined_filter,
+                         SearchResult& recreated_result) {
+                SearchOnGrowing(*segment_ptr,
+                                recreate_search_info,
+                                query_data,
+                                query_offsets,
+                                num_queries,
+                                timestamp,
+                                combined_filter,
+                                op_context,
+                                recreated_result);
+            });
+    };
+
     auto& schema = segment.get_schema();
     auto& record = segment.get_insert_record();
 
@@ -122,13 +151,15 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                        "vector array(embedding list) is not supported for "
                        "growing segment indexing search");
 
-            return FloatSegmentIndexSearch(segment,
-                                           info,
-                                           query_data,
-                                           num_queries,
-                                           bitset,
-                                           op_context,
-                                           search_result);
+            FloatSegmentIndexSearch(segment,
+                                    info,
+                                    query_data,
+                                    num_queries,
+                                    bitset,
+                                    op_context,
+                                    search_result);
+            register_vector_iterator_recreator();
+            return;
         }
         SubSearchResult final_qr(num_queries, topk, metric_type, round_decimal);
         // TODO(SPARSE): see todo in PlanImpl.h::PlaceHolder.
@@ -365,6 +396,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         search_result.unity_topK_ = topk;
         search_result.total_nq_ = num_queries;
     }
+    register_vector_iterator_recreator();
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -39,6 +39,36 @@ SearchOnSealedIndex(const Schema& schema,
                     const BitsetView& bitset,
                     milvus::OpContext* op_context,
                     SearchResult& search_result) {
+    const auto* schema_ptr = &schema;
+    const auto* record_ptr = &record;
+    auto register_vector_iterator_recreator = [&] {
+        if (!search_result.allow_vector_iterator_recreation_ ||
+            !CanUseStrictGroupFilteredIterator(search_info, num_queries) ||
+            !search_result.vector_iterators_.has_value()) {
+            return;
+        }
+        search_result.SetVectorIteratorRecreator(
+            bitset,
+            [schema_ptr,
+             record_ptr,
+             recreate_search_info = search_info,
+             query_data,
+             query_offsets,
+             num_queries,
+             op_context](const BitsetView& combined_filter,
+                         SearchResult& recreated_result) {
+                SearchOnSealedIndex(*schema_ptr,
+                                    *record_ptr,
+                                    recreate_search_info,
+                                    query_data,
+                                    query_offsets,
+                                    num_queries,
+                                    combined_filter,
+                                    op_context,
+                                    recreated_result);
+            });
+    };
+
     auto topK = search_info.topk_;
     auto round_decimal = search_info.round_decimal_;
 
@@ -139,6 +169,7 @@ SearchOnSealedIndex(const Schema& schema,
         use_iterator ? nullptr : search_info.array_offsets_.get());
     search_result.total_nq_ = num_queries;
     search_result.unity_topK_ = topK;
+    register_vector_iterator_recreator();
 }
 
 void
@@ -153,6 +184,39 @@ SearchOnSealedColumn(const Schema& schema,
                      const BitsetView& bitview,
                      milvus::OpContext* op_context,
                      SearchResult& result) {
+    const auto* schema_ptr = &schema;
+    auto register_vector_iterator_recreator = [&] {
+        if (!result.allow_vector_iterator_recreation_ ||
+            !CanUseStrictGroupFilteredIterator(search_info, num_queries) ||
+            !result.vector_iterators_.has_value()) {
+            return;
+        }
+        result.SetVectorIteratorRecreator(
+            bitview,
+            [schema_ptr,
+             column,
+             recreate_search_info = search_info,
+             recreate_index_info = index_info,
+             query_data,
+             query_offsets,
+             num_queries,
+             row_count,
+             op_context](const BitsetView& combined_filter,
+                         SearchResult& recreated_result) {
+                SearchOnSealedColumn(*schema_ptr,
+                                     column,
+                                     recreate_search_info,
+                                     recreate_index_info,
+                                     query_data,
+                                     query_offsets,
+                                     num_queries,
+                                     row_count,
+                                     combined_filter,
+                                     op_context,
+                                     recreated_result);
+            });
+    };
+
     auto field_id = search_info.field_id_;
     auto& field = schema[field_id];
 
@@ -336,6 +400,7 @@ SearchOnSealedColumn(const Schema& schema,
     }
     result.unity_topK_ = query_dataset.topk;
     result.total_nq_ = query_dataset.num_queries;
+    register_vector_iterator_recreator();
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -59,6 +59,99 @@ MakeLogicalBitsetBytes(int64_t total_count) {
     return logical_bitset_bytes;
 }
 
+TargetBitmap
+MakeAdditionalFilter(int64_t total_count) {
+    TargetBitmap additional_filter(total_count, false);
+    for (int64_t i = 3; i < total_count; i += 5) {
+        additional_filter[i] = true;
+    }
+    return additional_filter;
+}
+
+bool
+IsFiltered(const std::vector<uint8_t>& bitset_bytes, int64_t offset) {
+    return (bitset_bytes[offset >> 3] & (1U << (offset & 0x07))) != 0;
+}
+
+TargetBitmap
+MakeCombinedFilter(const std::vector<uint8_t>& base_filter,
+                   const TargetBitmap& additional_filter) {
+    auto combined_filter = additional_filter.clone();
+    for (size_t i = 0; i < combined_filter.size(); ++i) {
+        if (IsFiltered(base_filter, i)) {
+            combined_filter[i] = true;
+        }
+    }
+    return combined_filter;
+}
+
+using IteratorResults = std::vector<std::pair<int64_t, float>>;
+
+void
+CollectIteratorResults(const std::shared_ptr<VectorIterator>& iterator,
+                       IteratorResults& results) {
+    ASSERT_NE(iterator, nullptr);
+    while (iterator->HasNext() && results.size() < kTopK) {
+        auto result = iterator->Next();
+        ASSERT_TRUE(result.has_value());
+        results.emplace_back(result.value());
+    }
+}
+
+void
+AssertMatchesDirectFilteredIterator(const SearchResult& direct_result,
+                                    const IteratorResults& recreated_results) {
+    ASSERT_TRUE(direct_result.vector_iterators_.has_value());
+    ASSERT_EQ(direct_result.vector_iterators_->size(), 1);
+    IteratorResults direct_results;
+    CollectIteratorResults(direct_result.vector_iterators_->at(0),
+                           direct_results);
+    EXPECT_EQ(recreated_results, direct_results);
+}
+
+template <typename IsValid>
+void
+AssertRecreatedIteratorUsesCombinedLogicalFilter(
+    SearchResult& search_result,
+    const std::vector<uint8_t>& base_filter,
+    const TargetBitmap& additional_filter,
+    IsValid&& is_valid,
+    IteratorResults& observed_results) {
+    ASSERT_TRUE(search_result.CanRecreateVectorIterator());
+    auto original_pinned_bitsets = search_result.pinned_bitsets_.size();
+    auto original_chunk_buffers = search_result.chunk_buffers_.size();
+    {
+        auto recreated =
+            search_result.RecreateVectorIterators(additional_filter.clone());
+        ASSERT_TRUE(recreated.has_value());
+        auto& batch_result = **recreated;
+        EXPECT_FALSE(batch_result.CanRecreateVectorIterator());
+        EXPECT_FALSE(batch_result.pinned_bitsets_.empty());
+        ASSERT_TRUE(batch_result.vector_iterators_.has_value());
+        ASSERT_EQ(batch_result.vector_iterators_->size(), 1);
+
+        auto iterator = batch_result.vector_iterators_->at(0);
+        ASSERT_NE(iterator, nullptr);
+        int64_t result_count = 0;
+        while (iterator->HasNext() && result_count < kTopK) {
+            auto result = iterator->Next();
+            ASSERT_TRUE(result.has_value());
+            auto logical_offset = result->first;
+            ASSERT_GE(logical_offset, 0);
+            ASSERT_LT(logical_offset,
+                      static_cast<int64_t>(additional_filter.size()));
+            EXPECT_FALSE(IsFiltered(base_filter, logical_offset));
+            EXPECT_FALSE(additional_filter[logical_offset]);
+            EXPECT_TRUE(is_valid(logical_offset));
+            observed_results.emplace_back(result.value());
+            ++result_count;
+        }
+        ASSERT_GT(result_count, 0);
+    }
+    EXPECT_EQ(search_result.pinned_bitsets_.size(), original_pinned_bitsets);
+    EXPECT_EQ(search_result.chunk_buffers_.size(), original_chunk_buffers);
+}
+
 std::unique_ptr<bool[]>
 MakeValidData(int64_t total_count, int64_t& valid_count) {
     std::unique_ptr<bool[]> valid_data(new bool[total_count]);
@@ -94,6 +187,8 @@ MakeGroupBySearchInfo(FieldId vector_field,
         {knowhere::indexparam::NPROBE, "32"},
     };
     search_info.group_by_field_id_ = group_by_field;
+    search_info.group_size_ = 3;
+    search_info.strict_group_size_ = true;
     return search_info;
 }
 
@@ -257,6 +352,70 @@ TEST(SearchOnSealedIndexBitsetLifetime,
                         search_result);
 
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    auto additional_filter = MakeAdditionalFilter(total_count);
+    IteratorResults recreated_results;
+    AssertRecreatedIteratorUsesCombinedLogicalFilter(
+        search_result,
+        logical_bitset_bytes,
+        additional_filter,
+        [&](int64_t offset) { return valid_data[offset]; },
+        recreated_results);
+
+    auto combined_filter =
+        MakeCombinedFilter(logical_bitset_bytes, additional_filter);
+    SearchResult direct_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        BitsetView(combined_filter),
+                        nullptr,
+                        direct_result);
+    AssertMatchesDirectFilteredIterator(direct_result, recreated_results);
+
+    auto non_strict_search_info = search_info;
+    non_strict_search_info.strict_group_size_ = false;
+    SearchResult non_strict_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        non_strict_search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        logical_bitset,
+                        nullptr,
+                        non_strict_result);
+    EXPECT_FALSE(non_strict_result.CanRecreateVectorIterator());
+
+    auto single_group_result_search_info = search_info;
+    single_group_result_search_info.group_size_ = 1;
+    SearchResult single_group_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        single_group_result_search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        logical_bitset,
+                        nullptr,
+                        single_group_result);
+    EXPECT_FALSE(single_group_result.CanRecreateVectorIterator());
+
+    std::vector<float> two_queries = query;
+    two_queries.insert(two_queries.end(), query.begin(), query.end());
+    SearchResult multiple_query_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        two_queries.data(),
+                        nullptr,
+                        2,
+                        logical_bitset,
+                        nullptr,
+                        multiple_query_result);
+    EXPECT_FALSE(multiple_query_result.CanRecreateVectorIterator());
 }
 
 TEST(SearchOnSealedIndexNullableNoFilter,
@@ -394,6 +553,8 @@ TEST(SearchOnGrowingBitsetLifetime,
     const auto& vector_data = FindFieldData(dataset, vector_field);
     auto valid_count = CountValidRows(vector_data, total_count);
     ASSERT_GT(valid_count, 0);
+    ASSERT_LT(valid_count, total_count);
+    ASSERT_EQ(vector_data.valid_data_size(), total_count);
 
     auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
     auto reserved_offset = segment->PreInsert(total_count);
@@ -426,6 +587,28 @@ TEST(SearchOnGrowingBitsetLifetime,
                     search_result);
 
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    auto additional_filter = MakeAdditionalFilter(total_count);
+    IteratorResults recreated_results;
+    AssertRecreatedIteratorUsesCombinedLogicalFilter(
+        search_result,
+        logical_bitset_bytes,
+        additional_filter,
+        [&](int64_t offset) { return vector_data.valid_data(offset); },
+        recreated_results);
+
+    auto combined_filter =
+        MakeCombinedFilter(logical_bitset_bytes, additional_filter);
+    SearchResult direct_result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    vectors.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    BitsetView(combined_filter),
+                    nullptr,
+                    direct_result);
+    AssertMatchesDirectFilteredIterator(direct_result, recreated_results);
 }
 
 TEST(SearchOnSealedColumnBitsetLifetime,
@@ -472,6 +655,30 @@ TEST(SearchOnSealedColumnBitsetLifetime,
                          search_result);
 
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+    auto additional_filter = MakeAdditionalFilter(total_count);
+    IteratorResults recreated_results;
+    AssertRecreatedIteratorUsesCombinedLogicalFilter(
+        search_result,
+        logical_bitset_bytes,
+        additional_filter,
+        [&](int64_t offset) { return valid_data[offset]; },
+        recreated_results);
+
+    auto combined_filter =
+        MakeCombinedFilter(logical_bitset_bytes, additional_filter);
+    SearchResult direct_result;
+    SearchOnSealedColumn(*schema,
+                         column.get(),
+                         search_info,
+                         std::map<std::string, std::string>{},
+                         vectors.data(),
+                         nullptr,
+                         1,
+                         total_count,
+                         BitsetView(combined_filter),
+                         nullptr,
+                         direct_result);
+    AssertMatchesDirectFilteredIterator(direct_result, recreated_results);
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -20,11 +20,21 @@
 #include "common/BitsetView.h"
 #include "common/Consts.h"
 #include "common/OffsetMapping.h"
+#include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "common/Types.h"
 #include "common/Utils.h"
 
 namespace milvus::query {
+inline bool
+CanUseStrictGroupFilteredIterator(const SearchInfo& search_info,
+                                  int64_t num_queries) {
+    return search_info.strict_group_acceptance_threshold_ > 0 &&
+           search_info.strict_group_size_ && search_info.group_size_ > 1 &&
+           search_info.topk_ > 0 && num_queries == 1 &&
+           search_info.array_offsets_ == nullptr;
+}
+
 inline void
 FillEmptySearchResult(SearchResult& result, int64_t num_queries, int64_t topk) {
     auto total_num = num_queries * topk;

--- a/internal/util/searchutil/optimizers/query_hook.go
+++ b/internal/util/searchutil/optimizers/query_hook.go
@@ -2,7 +2,10 @@ package optimizers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -25,11 +28,10 @@ type QueryHook interface {
 }
 
 func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, queryHook QueryHook, numSegments int) (*querypb.SearchRequest, error) {
-	// no hook applied or disabled, just return
-	if queryHook == nil || !paramtable.Get().AutoIndexConfig.Enable.GetAsBool() {
+	useQueryHook := queryHook != nil && paramtable.Get().AutoIndexConfig.Enable.GetAsBool()
+	if !useQueryHook {
 		req.Req.IsTopkReduce = false
 		req.Req.IsRecallEvaluation = false
-		return req, nil
 	}
 
 	collectionId := req.GetReq().GetCollectionID()
@@ -38,6 +40,9 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 	serializedPlan := req.GetReq().GetSerializedExprPlan()
 	// plan not found
 	if serializedPlan == nil {
+		if !useQueryHook {
+			return req, nil
+		}
 		log.Warn("serialized plan not found")
 		return req, merr.WrapErrParameterInvalid("serialized search plan", "nil")
 	}
@@ -57,49 +62,104 @@ func OptimizeSearchParams(ctx context.Context, req *querypb.SearchRequest, query
 
 	switch plan.GetNode().(type) {
 	case *planpb.PlanNode_VectorAnns:
-		// use shardNum * segments num in shard to estimate total segment number
-		estSegmentNum := numSegments * int(channelNum)
-		metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
-
-		withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
 		queryInfo := plan.GetVectorAnns().GetQueryInfo()
-		params := map[string]any{
-			common.TopKKey:         queryInfo.GetTopk(),
-			common.SearchParamKey:  queryInfo.GetSearchParams(),
-			common.SegmentNumKey:   estSegmentNum,
-			common.WithFilterKey:   withFilter,
-			common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
-			common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
-			common.CollectionKey:   req.GetReq().GetCollectionID(),
-			common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
+		if queryInfo == nil {
+			return nil, merr.WrapErrParameterInvalidMsg("missing search query info")
 		}
-		if withFilter && channelNum > 1 {
-			params[common.ChannelNumKey] = channelNum
+		if useQueryHook {
+			// use shardNum * segments num in shard to estimate total segment number
+			estSegmentNum := numSegments * int(channelNum)
+			metrics.QueryNodeSearchHitSegmentNum.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), fmt.Sprint(collectionId), metrics.SearchLabel).Observe(float64(estSegmentNum))
+
+			withFilter := (plan.GetVectorAnns().GetPredicates() != nil)
+			params := map[string]any{
+				common.TopKKey:         queryInfo.GetTopk(),
+				common.SearchParamKey:  queryInfo.GetSearchParams(),
+				common.SegmentNumKey:   estSegmentNum,
+				common.WithFilterKey:   withFilter,
+				common.DataTypeKey:     int32(plan.GetVectorAnns().GetVectorType()),
+				common.WithOptimizeKey: paramtable.Get().AutoIndexConfig.EnableOptimize.GetAsBool() && req.GetReq().GetIsTopkReduce() && queryInfo.GetGroupByFieldId() < 0,
+				common.CollectionKey:   req.GetReq().GetCollectionID(),
+				common.RecallEvalKey:   req.GetReq().GetIsRecallEvaluation(),
+			}
+			if withFilter && channelNum > 1 {
+				params[common.ChannelNumKey] = channelNum
+			}
+			err := queryHook.Run(params)
+			if err != nil {
+				log.Warn("failed to execute queryHook", zap.Error(err))
+				return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
+			}
+			finalTopk := params[common.TopKKey].(int64)
+			isTopkReduce := req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk())
+			queryInfo.Topk = finalTopk
+			queryInfo.SearchParams = params[common.SearchParamKey].(string)
+			req.Req.IsTopkReduce = isTopkReduce
+			if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
+				req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
+			} else {
+				req.Req.IsRecallEvaluation = false
+			}
 		}
-		err := queryHook.Run(params)
+		changed, err := applyStrictGroupSettings(queryInfo)
 		if err != nil {
-			log.Warn("failed to execute queryHook", zap.Error(err))
-			return nil, merr.WrapErrServiceUnavailable(err.Error(), "queryHook execution failed")
+			return nil, err
 		}
-		finalTopk := params[common.TopKKey].(int64)
-		isTopkReduce := req.GetReq().GetIsTopkReduce() && (finalTopk < queryInfo.GetTopk())
-		queryInfo.Topk = finalTopk
-		queryInfo.SearchParams = params[common.SearchParamKey].(string)
-		serializedExprPlan, err := proto.Marshal(&plan)
-		if err != nil {
-			log.Warn("failed to marshal optimized plan", zap.Error(err))
-			return nil, merr.WrapErrParameterInvalid("marshalable search plan", "plan with marshal error", err.Error())
-		}
-		req.Req.SerializedExprPlan = serializedExprPlan
-		req.Req.IsTopkReduce = isTopkReduce
-		if isRecallEvaluation, ok := params[common.RecallEvalKey]; ok {
-			req.Req.IsRecallEvaluation = isRecallEvaluation.(bool) && queryInfo.GetGroupByFieldId() < 0
-		} else {
-			req.Req.IsRecallEvaluation = false
+		if useQueryHook || changed {
+			serializedExprPlan, err := proto.Marshal(&plan)
+			if err != nil {
+				log.Warn("failed to marshal optimized plan", zap.Error(err))
+				return nil, merr.WrapErrParameterInvalid("marshalable search plan", "plan with marshal error", err.Error())
+			}
+			req.Req.SerializedExprPlan = serializedExprPlan
 		}
 		log.Debug("optimized search params done", zap.Any("queryInfo", queryInfo))
 	default:
 		log.Warn("not supported node type", zap.String("nodeType", fmt.Sprintf("%T", plan.GetNode())))
 	}
 	return req, nil
+}
+
+// applyStrictGroupSettings runs after the hook, including when it is disabled.
+// Server settings override caller/hook values; unrelated JSON values retain
+// their exact numeric/string types. The serialized plan freezes this snapshot.
+func applyStrictGroupSettings(info *planpb.QueryInfo) (bool, error) {
+	raw := info.GetSearchParams()
+	if raw == "" {
+		raw = "{}"
+	}
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &params); err != nil {
+		return false, merr.WrapErrParameterInvalidMsg("invalid search params: %s", err)
+	}
+	if params == nil {
+		params = make(map[string]json.RawMessage)
+	}
+	_, hadThreshold := params[common.StrictGroupAcceptanceThresholdKey]
+	_, hadProbe := params[common.StrictGroupProbeCandidatesKey]
+	delete(params, common.StrictGroupAcceptanceThresholdKey)
+	delete(params, common.StrictGroupProbeCandidatesKey)
+	eligible := info.GetStrictGroupSize() && info.GetGroupSize() > 1 && info.GetGroupByFieldId() > 0
+	if eligible {
+		cfg := &paramtable.Get().QueryNodeCfg
+		threshold, err := strconv.ParseFloat(cfg.StrictGroupAcceptanceThreshold.GetValue(), 64)
+		if err != nil || math.IsNaN(threshold) || math.IsInf(threshold, 0) || threshold < 0 || threshold > 1 {
+			return false, merr.WrapErrServiceUnavailable("invalid server config: " + cfg.StrictGroupAcceptanceThreshold.Key)
+		}
+		probe, err := strconv.ParseInt(cfg.StrictGroupProbeCandidates.GetValue(), 10, 64)
+		if err != nil || probe <= 0 {
+			return false, merr.WrapErrServiceUnavailable("invalid server config: " + cfg.StrictGroupProbeCandidates.Key)
+		}
+		params[common.StrictGroupAcceptanceThresholdKey] = json.RawMessage(strconv.FormatFloat(threshold, 'g', -1, 64))
+		params[common.StrictGroupProbeCandidatesKey] = json.RawMessage(strconv.FormatInt(probe, 10))
+	}
+	if !eligible && !hadThreshold && !hadProbe {
+		return false, nil
+	}
+	encoded, err := json.Marshal(params)
+	if err != nil {
+		return false, err
+	}
+	info.SearchParams = string(encoded)
+	return true, nil
 }

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -2,6 +2,7 @@ package optimizers
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -239,4 +240,93 @@ func (suite *QueryHookSuite) verifyQueryInfo(req *querypb.SearchRequest, topK in
 
 func TestOptimizeSearchParam(t *testing.T) {
 	suite.Run(t, new(QueryHookSuite))
+}
+
+func (suite *QueryHookSuite) TestStrictGroupServerSettings() {
+	paramtable.Init()
+	cfg := paramtable.Get()
+	vKey := cfg.QueryNodeCfg.StrictGroupAcceptanceThreshold.Key
+	tKey := cfg.QueryNodeCfg.StrictGroupProbeCandidates.Key
+	defer cfg.Reset(vKey)
+	defer cfg.Reset(tKey)
+	defer cfg.Reset(cfg.AutoIndexConfig.Enable.Key)
+	makeRequest := func(strict bool, raw string) *querypb.SearchRequest {
+		p := &planpb.PlanNode{Node: &planpb.PlanNode_VectorAnns{VectorAnns: &planpb.VectorANNS{
+			QueryInfo: &planpb.QueryInfo{
+				Topk: 10, GroupByFieldId: 101,
+				GroupSize: 3, StrictGroupSize: strict, SearchParams: raw,
+			},
+		}}}
+		bs, err := proto.Marshal(p)
+		suite.Require().NoError(err)
+		return &querypb.SearchRequest{Req: &internalpb.SearchRequest{SerializedExprPlan: bs}}
+	}
+	readParams := func(req *querypb.SearchRequest) map[string]json.RawMessage {
+		p := &planpb.PlanNode{}
+		suite.Require().NoError(proto.Unmarshal(req.GetReq().GetSerializedExprPlan(), p))
+		var values map[string]json.RawMessage
+		suite.Require().NoError(json.Unmarshal([]byte(p.GetVectorAnns().GetQueryInfo().GetSearchParams()), &values))
+		return values
+	}
+	raw := `{"large":9007199254740993,"text":"0.5","strict_group_acceptance_threshold":"bad","strict_group_probe_candidates":-1}`
+	// Exercise no hook, AutoIndex disabled, a hook dropping all caller keys,
+	// and a hook injecting conflicting/invalid values.
+	for _, enabled := range []string{"false", "true"} {
+		cfg.Save(cfg.AutoIndexConfig.Enable.Key, enabled)
+		for _, hookOutput := range []string{"none", `{"large":9007199254740993,"text":"0.5"}`, raw} {
+			var hook QueryHook
+			if hookOutput != "none" {
+				h := mock_optimizers.NewMockQueryHook(suite.T())
+				if enabled == "true" {
+					h.EXPECT().Run(mock.Anything).Run(func(p map[string]any) {
+						p[common.SearchParamKey] = hookOutput
+					}).Return(nil)
+				}
+				hook = h
+			}
+			cfg.Save(vKey, "0.5")
+			cfg.Save(tKey, "17")
+			req, err := OptimizeSearchParams(context.Background(), makeRequest(true, raw), hook, 1)
+			suite.Require().NoError(err)
+			values := readParams(req)
+			suite.Equal("0.5", string(values[common.StrictGroupAcceptanceThresholdKey]))
+			suite.Equal("17", string(values[common.StrictGroupProbeCandidatesKey]))
+			suite.Equal("9007199254740993", string(values["large"]))
+			suite.Equal(`"0.5"`, string(values["text"]))
+			// Updating config affects a later request, not the serialized snapshot.
+			cfg.Save(vKey, "0")
+			cfg.Save(tKey, "1")
+			next, err := OptimizeSearchParams(context.Background(), makeRequest(true, raw), nil, 1)
+			suite.Require().NoError(err)
+			suite.Equal("0", string(readParams(next)[common.StrictGroupAcceptanceThresholdKey]))
+			suite.Equal("1", string(readParams(next)[common.StrictGroupProbeCandidatesKey]))
+			suite.Equal("17", string(readParams(req)[common.StrictGroupProbeCandidatesKey]))
+		}
+	}
+	cfg.Reset(vKey)
+	cfg.Reset(tKey)
+	defaultReq, err := OptimizeSearchParams(context.Background(), makeRequest(true, "{}"), nil, 1)
+	suite.Require().NoError(err)
+	suite.Equal("0.1", string(readParams(defaultReq)[common.StrictGroupAcceptanceThresholdKey]))
+	suite.Equal("100", string(readParams(defaultReq)[common.StrictGroupProbeCandidatesKey]))
+	// Caller-controlled values are removed even on non-strict queries.
+	plain, err := OptimizeSearchParams(context.Background(), makeRequest(false, raw), nil, 1)
+	suite.Require().NoError(err)
+	suite.NotContains(readParams(plain), common.StrictGroupAcceptanceThresholdKey)
+	suite.NotContains(readParams(plain), common.StrictGroupProbeCandidatesKey)
+	for key, badValues := range map[string][]string{
+		vKey: {"-0.1", "1.1", "NaN", "+Inf", "bad"},
+		tKey: {"0", "-1", "1.5", "9223372036854775808", "bad"},
+	} {
+		for _, value := range badValues {
+			cfg.Save(key, value)
+			_, err := OptimizeSearchParams(context.Background(), makeRequest(true, "{}"), nil, 1)
+			suite.ErrorIs(err, merr.ErrServiceUnavailable)
+			cfg.Reset(key)
+		}
+	}
+	for _, raw := range []string{"invalid", "[]", "1"} {
+		_, err := OptimizeSearchParams(context.Background(), makeRequest(true, raw), nil, 1)
+		suite.Error(err)
+	}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -174,15 +174,17 @@ const (
 
 // Search, Index parameter keys
 const (
-	TopKKey         = "topk"
-	SearchParamKey  = "search_param"
-	SegmentNumKey   = "segment_num"
-	WithFilterKey   = "with_filter"
-	DataTypeKey     = "data_type"
-	ChannelNumKey   = "channel_num"
-	WithOptimizeKey = "with_optimize"
-	CollectionKey   = "collection"
-	RecallEvalKey   = "recall_eval"
+	TopKKey                           = "topk"
+	SearchParamKey                    = "search_param"
+	StrictGroupAcceptanceThresholdKey = "strict_group_acceptance_threshold"
+	StrictGroupProbeCandidatesKey     = "strict_group_probe_candidates"
+	SegmentNumKey                     = "segment_num"
+	WithFilterKey                     = "with_filter"
+	DataTypeKey                       = "data_type"
+	ChannelNumKey                     = "channel_num"
+	WithOptimizeKey                   = "with_optimize"
+	CollectionKey                     = "collection"
+	RecallEvalKey                     = "recall_eval"
 
 	ParamsKey      = "params"
 	IndexTypeKey   = "index_type"

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3442,7 +3442,9 @@ Set to 0 to disable the penalty period.`,
 // /////////////////////////////////////////////////////////////////////////////
 // --- querynode ---
 type queryNodeConfig struct {
-	SoPath ParamItem `refreshable:"false"`
+	StrictGroupAcceptanceThreshold ParamItem `refreshable:"true"`
+	StrictGroupProbeCandidates     ParamItem `refreshable:"true"`
+	SoPath                         ParamItem `refreshable:"false"`
 
 	// stats
 	// Deprecated: Never used
@@ -3636,6 +3638,18 @@ func formatDurationWithMillisecondFallback(v string) string {
 }
 
 func (p *queryNodeConfig) init(base *BaseTable) {
+	p.StrictGroupAcceptanceThreshold = ParamItem{
+		Key:     "queryNode.groupBy.strictGroupAcceptanceThreshold",
+		Version: "2.6.23", DefaultValue: "0.1", Export: true,
+		Doc: "Recreate a strict group iterator only below this acceptance ratio [0,1]. Zero disables the optimization.",
+	}
+	p.StrictGroupAcceptanceThreshold.Init(base.mgr)
+	p.StrictGroupProbeCandidates = ParamItem{
+		Key:     "queryNode.groupBy.strictGroupProbeCandidates",
+		Version: "2.6.23", DefaultValue: "100", Export: true,
+		Doc: "Positive consumer candidate budget after locking strict groups, not a backend graph visit budget.",
+	}
+	p.StrictGroupProbeCandidates.Init(base.mgr)
 	p.IDFPreload = ParamItem{
 		Key:          "queryNode.idfOracle.preload",
 		Version:      "2.6.8",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -973,3 +973,19 @@ func TestQueryCoordForceLoadPriority(t *testing.T) {
 		}
 	})
 }
+
+func TestQueryNodeStrictGroupSettings(t *testing.T) {
+	params := &ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+	cfg := &params.QueryNodeCfg
+	assert.Equal(t, 0.1, cfg.StrictGroupAcceptanceThreshold.GetAsFloat())
+	assert.Equal(t, 100, cfg.StrictGroupProbeCandidates.GetAsInt())
+	params.Save(cfg.StrictGroupAcceptanceThreshold.Key, "0")
+	params.Save(cfg.StrictGroupProbeCandidates.Key, "17")
+	assert.Equal(t, 0.0, cfg.StrictGroupAcceptanceThreshold.GetAsFloat())
+	assert.Equal(t, 17, cfg.StrictGroupProbeCandidates.GetAsInt())
+	params.Reset(cfg.StrictGroupAcceptanceThreshold.Key)
+	params.Reset(cfg.StrictGroupProbeCandidates.Key)
+	assert.Equal(t, 0.1, cfg.StrictGroupAcceptanceThreshold.GetAsFloat())
+	assert.Equal(t, 100, cfg.StrictGroupProbeCandidates.GetAsInt())
+}


### PR DESCRIPTION
Fixes #53277

## Changes

- Eligible only for strict_group_size=true, group_size>1, nq=1 and supported row-level grouping.
- After locking topK groups, probe at most T consumer candidates. If results remain incomplete and the effective acceptance ratio is strictly below V, recreate an iterator with a dense filter for the locked unfinished groups.
- Preserve original visibility, user and deletion filters, iterator ownership and fallback behavior. Leave backend algorithm selection unchanged.
- Refreshable server configuration: `queryNode.groupBy.strictGroupAcceptanceThreshold` (default 0.1, range [0,1], zero disables optimization) and `queryNode.groupBy.strictGroupProbeCandidates` (default 100, positive int64).
- Server values override same-name caller/hook search parameters. Keep metrics and regression tests from the source PR.
