### PR TITLE
test: pin tombstone GC window in broadcaster idempotency tests

### DIFF
--- a/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
+++ b/internal/streamingcoord/server/broadcaster/idempotency_index_test.go
@@ -684,6 +684,20 @@ func newBroadcastTaskManagerWithEntrypointForTest(t *testing.T, protos ...*strea
 		return nil
 	})
 
+	// Earlier tests in this package shrink the tombstone GC window to milliseconds and
+	// never restore it. The idempotency entry lives exactly as long as its task's
+	// tombstone, so under that window the GC can drop the winner's entry before a
+	// slow caller reaches the lookup, and the caller creates a second task. Pin a long
+	// window, as newBroadcastTaskManagerForTest does.
+	oldInterval := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue("1h")
+	oldLifetime := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue("1h")
+	oldCount := paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue("8192")
+	t.Cleanup(func() {
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue(oldInterval)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue(oldLifetime)
+		paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue(oldCount)
+	})
+
 	roleCheck := mockey.Mock((*broadcastTaskManager).checkClusterRole).Return(nil).Build()
 	t.Cleanup(func() { roleCheck.UnPatch() })
 


### PR DESCRIPTION
issue: #50954

`TestConcurrentSameKeyBroadcastsCreateExactlyOneTask` flakes in CI with `fresh=2`, e.g. [build 30193](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-build-ut-ciloop-pipeline/30193/consoleText) (it passed on the re-run, which runs it in isolation).

## Root cause

An idempotency index entry lives exactly as long as its task's tombstone — `removeBroadcastTask` drops the entry when the tombstone GC drops the task, and that is the only removal path.

`TestBroadcaster` (`broadcaster_test.go:47-49`) and the force-promote tests (`force_promote_failover_test.go:205-207`) `SwapTempValue` the tombstone window to `checkInternal=10ms / maxLifetime=20ms / maxCount=2` and never restore it. These are process-global, and both files sort before `idempotency_index_test.go`, so every later test in the package runs with a 20ms idempotency window.

The CI log shows the consequence directly:

```
38.551  broadcastID=1  state=BROADCAST_TASK_STATE_TOMBSTONE
38.595  triggerGCTombstone  expired time=38.575  -> tombstone dropped, index entry deleted
38.695  broadcastID=2  state=BROADCAST_TASK_STATE_PENDING   <- follower missed the index
```

The winner's entry was collected ~100ms before a slow follower reached the lookup, so the follower created a second task. On a loaded CI box that gap is ordinary.

`newBroadcastTaskManagerForTest` already pins a long window against exactly this (same file, with the same comment). `newBroadcastTaskManagerWithEntrypointForTest` — used by the three tests that drive the real `WithResourceKeys` entrypoint — did not.

## Fix

Pin the same long window in the entrypoint helper, restoring the previous values on cleanup so nothing downstream changes.

## Verification

- Reproduced deterministically with a throwaway test pinning the leaked 20ms window and a follower arriving 100ms late: `actual: 2`, identical to CI. Green with this change.
- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/streamingcoord/server/broadcaster/` run 4x on this branch: the target test passes in all 4. Two of the 4 fail on `TestResourceKeyLocker/deadlock_prevention` (a 5s deadline), at the same rate as the unpatched baseline on the same machine, and it passes in isolation and in CI -- unrelated to this change.
- `make static-check`: 0 issues across all four modules.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV2oBt8X3KjKGVPgn8DP5e
