### PR TITLE
fix: don't roll back a committing import job on timeout

### DIFF
--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -563,8 +563,18 @@ func (c *importChecker) tryFailingTasks(job ImportJob) {
 }
 
 func (c *importChecker) tryTimeoutJob(job ImportJob) {
-	if job.GetState() == internalpb.ImportJobState_Failed ||
-		job.GetState() == internalpb.ImportJobState_Completed {
+	switch job.GetState() {
+	case internalpb.ImportJobState_Failed, internalpb.ImportJobState_Completed:
+		return
+	case internalpb.ImportJobState_Committing:
+		// A committing job has already broadcast its commit fence, and
+		// HandleCommitVchannel clears is_importing per vchannel before the job
+		// reaches Completed, so some of its segments are already visible to
+		// queries. Failing the job here would run processFailed over those
+		// segments and drop them. Committing is not rollbackable: AbortImport
+		// and rollbackImportV2AckCallback refuse it for the same reason.
+		mlog.Warn(c.ctx, "import job reached its timeout while committing, not rolling back",
+			mlog.FieldJobID(job.GetJobID()))
 		return
 	}
 	timeoutTime := tsoutil.PhysicalTime(job.GetTimeoutTs())

--- a/internal/datacoord/import_checker.go
+++ b/internal/datacoord/import_checker.go
@@ -564,17 +564,10 @@ func (c *importChecker) tryFailingTasks(job ImportJob) {
 
 func (c *importChecker) tryTimeoutJob(job ImportJob) {
 	switch job.GetState() {
-	case internalpb.ImportJobState_Failed, internalpb.ImportJobState_Completed:
-		return
-	case internalpb.ImportJobState_Committing:
-		// A committing job has already broadcast its commit fence, and
-		// HandleCommitVchannel clears is_importing per vchannel before the job
-		// reaches Completed, so some of its segments are already visible to
-		// queries. Failing the job here would run processFailed over those
-		// segments and drop them. Committing is not rollbackable: AbortImport
-		// and rollbackImportV2AckCallback refuse it for the same reason.
-		mlog.Warn(c.ctx, "import job reached its timeout while committing, not rolling back",
-			mlog.FieldJobID(job.GetJobID()))
+	case internalpb.ImportJobState_Failed, internalpb.ImportJobState_Completed,
+		internalpb.ImportJobState_Committing:
+		// Fast path on this tick's snapshot only; UpdateJobState enforces the
+		// rule against the current state under importMeta's lock.
 		return
 	}
 	timeoutTime := tsoutil.PhysicalTime(job.GetTimeoutTs())

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -408,6 +408,38 @@ func (s *ImportCheckerSuite) TestCheckTimeoutSkipCommittingJob() {
 	s.Empty(job.GetReason())
 }
 
+// runGCLoop evaluates a snapshot taken at the start of the tick. A job that
+// entered Committing after the snapshot must still not be failed.
+func (s *ImportCheckerSuite) TestCheckTimeoutStaleSnapshotCommittingJob() {
+	err := s.importMeta.UpdateJob(context.TODO(), s.jobID, UpdateJobState(internalpb.ImportJobState_Uncommitted))
+	s.NoError(err)
+	staleSnapshot := s.importMeta.GetJob(context.TODO(), s.jobID)
+
+	err = s.importMeta.UpdateJob(context.TODO(), s.jobID, UpdateJobState(internalpb.ImportJobState_Committing))
+	s.NoError(err)
+
+	s.checker.tryTimeoutJob(staleSnapshot)
+
+	// Only the state is asserted: UpdateJobReason in the same UpdateJob call still
+	// applies, and reason is surfaced to clients only for Failed jobs.
+	job := s.importMeta.GetJob(context.TODO(), s.jobID)
+	s.Equal(internalpb.ImportJobState_Committing, job.GetState())
+}
+
+func (s *ImportCheckerSuite) TestUpdateJobStateRefusesFailingCommittedJob() {
+	for _, state := range []internalpb.ImportJobState{
+		internalpb.ImportJobState_Committing,
+		internalpb.ImportJobState_Completed,
+	} {
+		job := &importJob{ImportJob: &datapb.ImportJob{JobID: 1, State: state}}
+		UpdateJobState(internalpb.ImportJobState_Failed)(job)
+		s.Equal(state, job.GetState())
+	}
+	job := &importJob{ImportJob: &datapb.ImportJob{JobID: 1, State: internalpb.ImportJobState_Uncommitted}}
+	UpdateJobState(internalpb.ImportJobState_Failed)(job)
+	s.Equal(internalpb.ImportJobState_Failed, job.GetState())
+}
+
 func (s *ImportCheckerSuite) TestCheckFailure() {
 	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -394,6 +394,20 @@ func (s *ImportCheckerSuite) TestCheckTimeout() {
 	s.Equal("import timeout", job.GetReason())
 }
 
+// A committing job has already broadcast its commit fence, and its per-vchannel
+// callbacks may have made segments visible to queries, so a timeout must leave it
+// alone rather than fail it and drop those segments.
+func (s *ImportCheckerSuite) TestCheckTimeoutSkipCommittingJob() {
+	err := s.importMeta.UpdateJob(context.TODO(), s.jobID, UpdateJobState(internalpb.ImportJobState_Committing))
+	s.NoError(err)
+
+	s.checker.tryTimeoutJob(s.importMeta.GetJob(context.TODO(), s.jobID))
+
+	job := s.importMeta.GetJob(context.TODO(), s.jobID)
+	s.Equal(internalpb.ImportJobState_Committing, job.GetState())
+	s.Empty(job.GetReason())
+}
+
 func (s *ImportCheckerSuite) TestCheckFailure() {
 	catalog := s.importMeta.(*importMeta).catalog.(*mocks.DataCoordCatalog)
 	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)

--- a/internal/datacoord/import_job.go
+++ b/internal/datacoord/import_job.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 type ImportJobFilter func(job ImportJob) bool
@@ -65,8 +66,27 @@ type UpdateJobAction func(job ImportJob)
 
 const importJobReasonAbortedByUser = "aborted by user"
 
+// UnfailableJobStates are the committed states: the commit fence is out and
+// HandleCommitVchannel may already have made segments visible, so failing the
+// job would drop committed data.
+var UnfailableJobStates = typeutil.NewSet(
+	internalpb.ImportJobState_Committing,
+	internalpb.ImportJobState_Completed,
+)
+
+// isIllegalJobTransition reports whether moving job to state must be refused.
+func isIllegalJobTransition(job ImportJob, state internalpb.ImportJobState) bool {
+	return state == internalpb.ImportJobState_Failed && UnfailableJobStates.Contain(job.GetState())
+}
+
 func UpdateJobState(state internalpb.ImportJobState) UpdateJobAction {
 	return func(job ImportJob) {
+		if isIllegalJobTransition(job, state) {
+			mlog.Warn(context.TODO(), "refused illegal import job state transition",
+				mlog.FieldJobID(job.GetJobID()),
+				mlog.String("from", job.GetState().String()), mlog.String("to", state.String()))
+			return
+		}
 		job.(*importJob).State = state
 		if state == internalpb.ImportJobState_Completed || state == internalpb.ImportJobState_Failed {
 			// releases requested disk resource

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1963,10 +1963,9 @@ func UpdateCommitTimestamp(segmentID int64, ts uint64) UpdateOperator {
 				// Recovery from here is out of band. The job is already
 				// Committing by the time this runs -- commitImportV2AckCallback
 				// persists that state on the broadcast FastAck, independent of
-				// this fence -- and Committing is terminal for AbortImport while
-				// tryTimeoutJob never reaches it (TimeoutTs defaults to
-				// math.MaxUint64). Validating earlier does not change that: the
-				// ack path flips the state regardless of what this check says.
+				// this fence -- and Committing cannot be failed by any writer
+				// (UnfailableJobStates). Validating earlier does not change that:
+				// the ack path flips the state regardless of what this check says.
 				return modPack.fail(merr.WrapErrImportSysFailedMsg(
 					"commit timestamp %d is less than max binlog timestamp %d for import segment %d",
 					ts, maxTsTo, segmentID))

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -3204,8 +3204,7 @@ func (s *Server) AbortImport(ctx context.Context, req *datapb.AbortImportRequest
 				return merr.Success()
 			}
 			// Committed states are truly terminal and cannot be rolled back.
-			if state == internalpb.ImportJobState_Committing ||
-				state == internalpb.ImportJobState_Completed {
+			if UnfailableJobStates.Contain(state) {
 				return merr.Status(merr.WrapErrImportFailed(
 					fmt.Sprintf("job %d is in terminal/committed state %s, abort not allowed", req.GetJobId(), state)))
 			}

--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -143,15 +143,18 @@ func (t *ImportTask) GetSegmentsInfo() []*datapb.ImportSegmentInfo {
 }
 
 func (t *ImportTask) Clone() Task {
-	ctx, cancel := context.WithCancel(t.ctx)
 	infos := make(map[int64]*datapb.ImportSegmentInfo)
 	for id, info := range t.segmentsInfo {
 		infos[id] = typeutil.Clone(info)
 	}
+	// Share the running task's context instead of deriving a new one. The
+	// goroutines started by Execute hold the original ctx, and taskManager
+	// cancels whatever the map entry carries; a derived context would make
+	// that cancellation a no-op on the work actually in flight.
 	return &ImportTask{
 		ImportTaskV2: typeutil.Clone(t.ImportTaskV2),
-		ctx:          ctx,
-		cancel:       cancel,
+		ctx:          t.ctx,
+		cancel:       t.cancel,
 		segmentsInfo: infos,
 		req:          t.req,
 		allocator:    t.allocator,

--- a/internal/datanode/importv2/task_l0_import.go
+++ b/internal/datanode/importv2/task_l0_import.go
@@ -116,15 +116,18 @@ func (t *L0ImportTask) GetSegmentsInfo() []*datapb.ImportSegmentInfo {
 }
 
 func (t *L0ImportTask) Clone() Task {
-	ctx, cancel := context.WithCancel(t.ctx)
 	infos := make(map[int64]*datapb.ImportSegmentInfo)
 	for id, info := range t.segmentsInfo {
 		infos[id] = typeutil.Clone(info)
 	}
+	// Share the running task's context instead of deriving a new one. The
+	// goroutines started by Execute hold the original ctx, and taskManager
+	// cancels whatever the map entry carries; a derived context would make
+	// that cancellation a no-op on the work actually in flight.
 	return &L0ImportTask{
 		ImportTaskV2: typeutil.Clone(t.ImportTaskV2),
-		ctx:          ctx,
-		cancel:       cancel,
+		ctx:          t.ctx,
+		cancel:       t.cancel,
 		segmentsInfo: infos,
 		req:          t.req,
 		allocator:    t.allocator,

--- a/internal/datanode/importv2/task_l0_preimport.go
+++ b/internal/datanode/importv2/task_l0_preimport.go
@@ -109,11 +109,14 @@ func (t *L0PreImportTask) Cancel() {
 }
 
 func (t *L0PreImportTask) Clone() Task {
-	ctx, cancel := context.WithCancel(t.ctx)
+	// Share the running task's context instead of deriving a new one. The
+	// goroutines started by Execute hold the original ctx, and taskManager
+	// cancels whatever the map entry carries; a derived context would make
+	// that cancellation a no-op on the work actually in flight.
 	return &L0PreImportTask{
 		PreImportTask: typeutil.Clone(t.PreImportTask),
-		ctx:           ctx,
-		cancel:        cancel,
+		ctx:           t.ctx,
+		cancel:        t.cancel,
 		partitionIDs:  t.GetPartitionIDs(),
 		vchannels:     t.GetVchannels(),
 		schema:        t.GetSchema(),

--- a/internal/datanode/importv2/task_manager_test.go
+++ b/internal/datanode/importv2/task_manager_test.go
@@ -184,3 +184,70 @@ func TestUpdateSegmentInfoRefreshesStatsOnMerge(t *testing.T) {
 	assert.EqualValues(t, 250, got.GetStats().GetInsertBinlogSize(), "stats must reflect the latest cumulative snapshot")
 	assert.EqualValues(t, 3, got.GetStats().GetInsertBinlogCount())
 }
+
+// The task map stores a Clone on every Update, while the goroutines started by
+// Execute keep running against the context of the task that was originally
+// added. Remove cancels whatever the map holds, so Clone must carry that same
+// context forward -- a derived one would leave DropImport unable to stop the
+// import that is actually in flight.
+func TestTaskManagerRemoveCancelsRunningTask(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	ctx3, cancel3 := context.WithCancel(context.Background())
+	ctx4, cancel4 := context.WithCancel(context.Background())
+
+	cases := []struct {
+		task Task
+		ctx  context.Context
+	}{
+		{
+			task: &ImportTask{
+				ImportTaskV2: &datapb.ImportTaskV2{TaskID: 1, State: datapb.ImportTaskStateV2_Pending},
+				ctx:          ctx1,
+				cancel:       cancel1,
+			},
+			ctx: ctx1,
+		},
+		{
+			task: &L0ImportTask{
+				ImportTaskV2: &datapb.ImportTaskV2{TaskID: 2, State: datapb.ImportTaskStateV2_Pending},
+				ctx:          ctx2,
+				cancel:       cancel2,
+			},
+			ctx: ctx2,
+		},
+		{
+			task: &PreImportTask{
+				PreImportTask: &datapb.PreImportTask{TaskID: 3, State: datapb.ImportTaskStateV2_Pending},
+				ctx:           ctx3,
+				cancel:        cancel3,
+			},
+			ctx: ctx3,
+		},
+		{
+			task: &L0PreImportTask{
+				PreImportTask: &datapb.PreImportTask{TaskID: 4, State: datapb.ImportTaskStateV2_Pending},
+				ctx:           ctx4,
+				cancel:        cancel4,
+			},
+			ctx: ctx4,
+		},
+	}
+
+	manager := NewTaskManager()
+	for _, c := range cases {
+		manager.Add(c.task)
+		// Execute's first statement, which replaces the map entry with a clone.
+		manager.Update(c.task.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
+	}
+
+	for _, c := range cases {
+		manager.Remove(c.task.GetTaskID())
+		select {
+		case <-c.ctx.Done():
+		default:
+			assert.Failf(t, "running task was not canceled",
+				"task %d is still running after Remove", c.task.GetTaskID())
+		}
+	}
+}

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -118,11 +118,14 @@ func (t *PreImportTask) Cancel() {
 }
 
 func (t *PreImportTask) Clone() Task {
-	ctx, cancel := context.WithCancel(t.ctx)
+	// Share the running task's context instead of deriving a new one. The
+	// goroutines started by Execute hold the original ctx, and taskManager
+	// cancels whatever the map entry carries; a derived context would make
+	// that cancellation a no-op on the work actually in flight.
 	return &PreImportTask{
 		PreImportTask: typeutil.Clone(t.PreImportTask),
-		ctx:           ctx,
-		cancel:        cancel,
+		ctx:           t.ctx,
+		cancel:        t.cancel,
 		partitionIDs:  t.GetPartitionIDs(),
 		vchannels:     t.GetVchannels(),
 		schema:        t.GetSchema(),


### PR DESCRIPTION
issue: #53315, #53316

## What

Two defects on the same failure path, both reached when a 2PC import job with a
client-supplied `timeout` option is still committing.

### 1. The timeout deletes committed, query-visible data (#53315)

`importChecker.tryTimeoutJob` returned early only for `Failed` and `Completed`, so
it failed a job in `Committing`. That job has already broadcast its commit fence,
and `HandleCommitVchannel` clears `is_importing` **per vchannel** before the
job-level transition to `Completed`, so some of its segments are already served
by `GetRecoveryInfoV2`. The cascade that follows the timeout
(`tryFailingTasks` → `processFailed` → `UpdateStatusOperator(seg, Dropped)`) then
drops those segments. Rows that were queryable disappear, with no error in the logs.

A state test in `tryTimeoutJob` alone is not enough: `runGCLoop` evaluates a
snapshot taken at the start of the tick, and every `importMeta` writer replaces the
map entry with a `Clone()`, so a job that entered `Committing` after the snapshot
still looked `Uncommitted` to the checker. The rule therefore lives in
`UpdateJobState`, which runs against the freshly read job under `importMeta.mu` —
the same lock `HandleCommitVchannel` holds across the `Uncommitted → Committing`
persist and the visibility callback. Either the timeout wins and no segment is ever
made visible, or the commit wins and the write is refused.

The rule is shared as `UnfailableJobStates = {Committing, Completed}`: no writer
may fail a committed job, and `AbortImport` reuses the same set instead of its own
hard-coded pair. This also covers `checkCollection`: a `Committing` job whose
collection is dropped is no longer failed — it completes on its own once every
vchannel has acked the fence (`checkCommittingJob` does not depend on the
collection). The one case where it would not complete is a commit fence that
`UpdateCommitTimestamp` rejects permanently. That block is the designed behavior
from #51589 (recovery is deliberately manual; the rejection is logged at Error on
every attempt and surfaces as WAL lag). #51589 listed the `timeout` option as the
last automatic exit from it; this PR closes that exit because it worked by
dropping committed rows.

`internal/datacoord/meta.go` asserted *"tryTimeoutJob never reaches it (TimeoutTs
defaults to math.MaxUint64)"*. That held only when the client omits the `timeout`
option; the comment now points at `UnfailableJobStates`.

### 2. `DropImport` could not stop the worker (#53316)

The same cascade calls `DropImport`, which was a no-op against running work.
`taskManager.Update` replaces the map entry with `Clone()` on every update, and
`Execute`'s first statement is such an update — but `Clone()` derived a *fresh*
context from the running one, so the map held a child of the context Execute's
goroutines actually use. `Remove` cancelled that child; cancellation does not
propagate child → parent, so the import kept reading and syncing into segments
DataCoord had already dropped, holding memory budget and exec-pool workers.

Fixed in all four task types by sharing `ctx`/`cancel`, which
`CopySegmentTask.Clone` already does.

## Verification

| | without fix | with fix |
|---|---|---|
| `TestImportChecker/TestCheckTimeoutSkipCommittingJob` | fails (job → Failed) | passes |
| `TestImportChecker/TestCheckTimeoutStaleSnapshotCommittingJob` | fails (stale snapshot → Failed) | passes |
| `TestImportChecker/TestUpdateJobStateRefusesFailingCommittedJob` | fails | passes |
| `TestTaskManagerRemoveCancelsRunningTask` | fails for all 4 task types | passes |

- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/datanode/importv2/` — ok
- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord/ -run 'Import|Abort'` — ok
- `make static-check` — 0 issues

Both issues were found by code inspection and traced end to end; neither has been
reproduced on a live cluster, and the PR claims nothing beyond what the tests above
cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
