### PR TITLE
fix: release the built index and analyze object when a task is canceled

### DIFF
--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -234,6 +234,15 @@ func (at *analyzeTask) GetState() indexpb.JobState {
 }
 
 func (at *analyzeTask) Reset() {
+	// Reset runs from processTask's deferred cleanup on every exit path, including
+	// the canceled one where PostExecute -- the only other place that releases the
+	// analyze object -- is skipped. Delete is idempotent.
+	if at.analyze != nil {
+		if err := at.analyze.Delete(); err != nil {
+			mlog.Warn(at.ctx, "failed to release analyze object on task reset", mlog.Err(err))
+		}
+		at.analyze = nil
+	}
 	at.ident = ""
 	at.ctx = nil
 	at.cancel = nil

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -97,6 +97,16 @@ func (it *indexBuildTask) parseParams() {
 }
 
 func (it *indexBuildTask) Reset() {
+	// Reset runs from processTask's deferred cleanup on every exit path, including
+	// the canceled one where PostExecute -- the only other place that releases the
+	// index -- is skipped. Without this the native index built by Execute is never
+	// freed. Delete is idempotent, so releasing here after a normal PostExecute is
+	// a no-op.
+	if it.index != nil {
+		if err := it.index.Delete(); err != nil {
+			mlog.Warn(it.ctx, "failed to release index object on task reset", mlog.Err(err))
+		}
+	}
 	it.ident = ""
 	it.cancel = nil
 	it.ctx = nil

--- a/internal/datanode/index/task_reset_test.go
+++ b/internal/datanode/index/task_reset_test.go
@@ -1,0 +1,96 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
+	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
+)
+
+// fakeIndex counts Delete calls, standing in for the native index that
+// indexcgowrapper.CreateIndex hands back as a raw pointer.
+type fakeIndex struct {
+	indexcgowrapper.CodecIndex
+	deleted int
+}
+
+func (f *fakeIndex) Delete() error {
+	f.deleted++
+	return nil
+}
+
+func (f *fakeIndex) UpLoad() (*cgopb.IndexStats, error) {
+	return &cgopb.IndexStats{}, nil
+}
+
+type fakeAnalyze struct {
+	deleted int
+}
+
+func (f *fakeAnalyze) Delete() error {
+	f.deleted++
+	return nil
+}
+
+func (f *fakeAnalyze) GetResult(size int) (string, int64, []string, []int64, error) {
+	return "", 0, nil, nil, nil
+}
+
+// processTask skips PostExecute whenever the task context is canceled, and
+// PostExecute is the only other place that frees the native index. Reset runs on
+// every exit path, so it must do the release or the built index leaks for the
+// lifetime of the process.
+func TestIndexBuildTaskResetReleasesIndex(t *testing.T) {
+	index := &fakeIndex{}
+	it := &indexBuildTask{
+		ctx:   context.Background(),
+		index: index,
+	}
+
+	it.Reset()
+
+	assert.Equal(t, 1, index.deleted, "Reset must release the built index")
+	assert.Nil(t, it.index)
+}
+
+func TestAnalyzeTaskResetReleasesAnalyze(t *testing.T) {
+	analyze := &fakeAnalyze{}
+	at := &analyzeTask{
+		ctx:     context.Background(),
+		analyze: analyze,
+	}
+
+	at.Reset()
+
+	assert.Equal(t, 1, analyze.deleted, "Reset must release the analyze object")
+	assert.Nil(t, at.analyze)
+}
+
+// Reset must stay safe after a normal PostExecute, which already released the
+// object; the cgo wrappers make Delete idempotent for exactly this reason.
+func TestResetAfterReleaseIsSafe(t *testing.T) {
+	it := &indexBuildTask{ctx: context.Background()}
+	assert.NotPanics(t, it.Reset)
+
+	at := &analyzeTask{ctx: context.Background()}
+	assert.NotPanics(t, at.Reset)
+}


### PR DESCRIPTION
issue: #53317

## What

`TaskScheduler.processTask` checks the task context **before each pipeline stage**:

```go
select {
case <-t.Ctx().Done():
    return errCancel
default:
    return fn(t.Ctx())
}
```

`indexcgowrapper.CreateIndex` is a blocking cgo call that ignores `ctx`, so a
cancellation arriving any time during the build is only observed at the *next*
gate — the one before `PostExecute`, which is the only place that calls
`Delete()` on the object `Execute` just built. `Reset()` then dropped the last Go
reference without freeing the native allocation.

Nothing else reclaims it: the C++ side does `*res_index = index.release()`
(`index_c.cpp:379`), handing ownership to Go as a raw pointer, and the
`runtime.SetFinalizer` at `indexcgowrapper/index.go:126` only logs
*"there is leakage in index object, please check."* — it frees nothing. So a
whole built index (in-RAM HNSW/IVF plus DiskANN local files) leaks for the
lifetime of the DataNode process. `task_analyze.go` has the identical shape, and
its `Reset()` did not even null the field.

A single failed `QueryIndex` RPC is enough to reach this, via
`dropAndResetTaskOnWorker` → `DropJobsV2` → `Cancel()`; DataCoord then
re-dispatches, so each flap costs one full rebuild *and* one leaked index.

## Why `Reset()`

`Reset()` has exactly one caller — the unconditional `defer` registered as the
first statement of `processTask` — so it runs on every exit path, including the
canceled one. A handle can only exist if `processTask` ran, so the coverage is
exact rather than approximate. Both `Delete()` implementations are already
idempotent (`index.go:519`, `analyze.go:93`), so the early release in
`PostExecute` is unaffected.

## Verification

| | without fix | with fix |
|---|---|---|
| `TestIndexBuildTaskResetReleasesIndex` | fails (Delete not called) | passes |
| `TestAnalyzeTaskResetReleasesAnalyze` | fails (Delete not called) | passes |
| `TestResetAfterReleaseIsSafe` | passes | passes |

- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/datanode/index/` — ok
- `make static-check` — 0 issues

The `"there is leakage in index object"` error log is the existing detector for
this condition and should stop appearing.

Found by code inspection, traced end to end; not reproduced on a live cluster, and
this PR claims nothing beyond what the tests above cover.

Related: #53233 / #53234 make DataCoord abort in-flight index and stats tasks
earlier, which increases how often this cancellation path is taken. No file
overlap with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHd63h9WCCrhEForHnWWsZ