### PR TITLE
enhance: bump storage to e7f4477

### DIFF
--- a/internal/core/src/storage/loon_ffi/external_spec_c.h
+++ b/internal/core/src/storage/loon_ffi/external_spec_c.h
@@ -27,7 +27,7 @@ extern "C" {
  *     endpoint, process-local IOPS policy, AWS-form rewrite, Tier-1/2
  *     derivation)
  *   - format-layer properties derived from spec.format (e.g.
- *     iceberg.snapshot_id when format="iceberg-table")
+ *     reader.exttable.snapshot_id when format="iceberg-table")
  *
  * Idempotent over reallocation: the function frees existing LoonProperty
  * entries and rebuilds the array with the merged key set, so the caller

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -406,7 +406,7 @@ IsCloudEndpointHost(const std::string& host) {
     return false;
 }
 
-static void
+static arrow::Status
 InjectExternalSpecProperties(
     milvus_storage::api::Properties& properties,
     int64_t collection_id,
@@ -656,10 +656,10 @@ InjectExternalSpecProperties(
     }
 
     // Format-layer: emit per-format properties derived from spec.format.
-    // Currently only Iceberg-table → iceberg.snapshot_id. Future formats
+    // Currently only Iceberg-table → reader.exttable.snapshot_id. Future formats
     // (Lance version, Iceberg branch, etc.) land here.
     if (external_spec.empty()) {
-        return;
+        return arrow::Status::OK();
     }
     try {
         simdjson::ondemand::parser parser;
@@ -670,7 +670,8 @@ InjectExternalSpecProperties(
             simdjson::SUCCESS) {
             std::string format{format_view};
             if (format == "iceberg-table") {
-                auto snapshot_field = doc.find_field("snapshot_id");
+                // JSON fields may appear before or after "format".
+                auto snapshot_field = doc.find_field_unordered("snapshot_id");
                 int64_t snapshot_id = 0;
                 auto int_err = snapshot_field.get_int64().get(snapshot_id);
                 if (int_err == simdjson::INCORRECT_TYPE) {
@@ -691,10 +692,15 @@ InjectExternalSpecProperties(
                     }
                 }
                 if (int_err == simdjson::SUCCESS) {
-                    milvus_storage::api::SetValue(
+                    const auto error = milvus_storage::api::SetValue(
                         properties,
-                        "iceberg.snapshot_id",
+                        PROPERTY_READER_EXTTABLE_SNAPSHOT_ID,
                         std::to_string(snapshot_id).c_str());
+                    if (error.has_value()) {
+                        // An invalid snapshot must not fall back to latest.
+                        return arrow::Status::Invalid(
+                            PROPERTY_READER_EXTTABLE_SNAPSHOT_ID, ": ", *error);
+                    }
                 }
             }
         }
@@ -705,6 +711,7 @@ InjectExternalSpecProperties(
                  collection_id,
                  e.what());
     }
+    return arrow::Status::OK();
 }
 
 void
@@ -717,8 +724,11 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     const auto iops_config =
         milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
             .GetExternalIopsConfig();
-    InjectExternalSpecProperties(
+    const auto status = InjectExternalSpecProperties(
         properties, collection_id, external_source, external_spec, iops_config);
+    if (!status.ok()) {
+        ThrowInfo(milvus::InvalidParameter, "{}", status.message());
+    }
 }
 
 std::shared_ptr<milvus_storage::api::Properties>
@@ -821,7 +831,7 @@ GetLoonManifest(
 //
 // Bridges Go callers into the C++ InjectExternalSpecProperties pipeline so
 // that URI parsing, endpoint derivation, AWS-form rewriting, allowlist
-// enforcement, and format-property derivation (iceberg.snapshot_id etc.)
+// enforcement, and format-property derivation (reader.exttable.snapshot_id etc.)
 // all live in a single implementation driven by the raw external_spec JSON.
 
 extern "C" LoonFFIResult
@@ -855,11 +865,15 @@ loon_properties_inject_external_spec(LoonProperties* properties,
         // would couple concurrent FFI and native reads through global state.
         const milvus::storage::ExternalIopsConfig iops_config{iops_initial_rate,
                                                               iops_max_rate};
-        InjectExternalSpecProperties(props,
-                                     collection_id,
-                                     external_source,
-                                     external_spec ? external_spec : "",
-                                     iops_config);
+        const auto status =
+            InjectExternalSpecProperties(props,
+                                         collection_id,
+                                         external_source,
+                                         external_spec ? external_spec : "",
+                                         iops_config);
+        if (!status.ok()) {
+            RETURN_ERROR(LOON_INVALID_PROPERTIES, status.message());
+        }
 
         // Rebuild LoonProperties from the merged map. Free old entries first
         // so ownership stays with loon_properties_free.
@@ -885,8 +899,9 @@ loon_properties_inject_external_spec(LoonProperties* properties,
         size_t i = 0;
         for (const auto& kv : props) {
             arr[i].key = strdup(kv.first.c_str());
-            const auto* sval = std::get_if<std::string>(&kv.second);
-            arr[i].value = strdup(sval ? sval->c_str() : "");
+            // Registered properties such as snapshot_id are stored as INT64.
+            const auto value = PropertyValueAsString(props, kv.first.c_str());
+            arr[i].value = strdup(value ? value->c_str() : "");
             ++i;
         }
         properties->properties = arr;

--- a/internal/core/src/storage/loon_ffi/util.h
+++ b/internal/core/src/storage/loon_ffi/util.h
@@ -86,7 +86,7 @@ GetLoonManifest(
  *       Layer 2: apply external_spec.extfs JSON with allowlist gating.
  *       Post-process: AWS-form swap + Tier-1/2 endpoint derivation.
  *   - format-layer — per-format keys derived from spec.format (e.g.
- *     iceberg.snapshot_id when format="iceberg-table").
+ *     reader.exttable.snapshot_id when format="iceberg-table").
  *
  * The caller MUST have run ValidateExternalSource (Go side) first — this
  * function asserts non-empty scheme and host on external_source.

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION a18d007)
+set( milvus-storage_VERSION e7f4477)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -3630,17 +3630,95 @@ TEST(InjectExtfsAllowlist, AnonymousLayer0SkippedWithStalePreseed) {
     EXPECT_EQ(std::get<std::string>(props.at("extfs.42.anonymous")), "true");
 }
 
-TEST(InjectExtfsAllowlist, IcebergSnapshotIDAcceptsString) {
-    milvus_storage::api::Properties props;
-    const int64_t coll_id = 42;
-    std::string spec =
-        R"({"format":"iceberg-table","snapshot_id":"5320540205222981137"})";
+TEST(InjectExtfsAllowlist, IcebergSnapshotID) {
+    for (
+        const std::string spec : {
+            R"({"format":"iceberg-table","snapshot_id":"5320540205222981137"})",
+            R"({"format":"iceberg-table","snapshot_id":5320540205222981137})",
+            R"({"snapshot_id":"5320540205222981137","format":"iceberg-table"})",
+            R"({"snapshot_id":5320540205222981137,"format":"iceberg-table"})",
+        }) {
+        SCOPED_TRACE(spec);
+        milvus_storage::api::Properties props;
+        ::InjectExternalSpecProperties(
+            props, 42, "s3://s3.amazonaws.com/bucket/key", spec);
 
-    ::InjectExternalSpecProperties(
-        props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+        // Read the same typed property as IcebergFormat::explore so a stale
+        // property key cannot silently fall back to the latest snapshot.
+        const auto snapshot_id = milvus_storage::api::GetValue<int64_t>(
+            props, PROPERTY_READER_EXTTABLE_SNAPSHOT_ID);
+        ASSERT_TRUE(snapshot_id.ok()) << snapshot_id.status().ToString();
+        EXPECT_EQ(*snapshot_id, 5320540205222981137LL);
+    }
+}
 
-    EXPECT_EQ(std::get<std::string>(props.at("iceberg.snapshot_id")),
-              "5320540205222981137");
+TEST(InjectExtfsAllowlist, IcebergSnapshotIDCAbiRoundTrip) {
+    for (
+        const std::string spec : {
+            R"({"format":"iceberg-table","snapshot_id":"5320540205222981137"})",
+            R"({"format":"iceberg-table","snapshot_id":5320540205222981137})",
+            R"({"snapshot_id":"5320540205222981137","format":"iceberg-table"})",
+            R"({"snapshot_id":5320540205222981137,"format":"iceberg-table"})",
+        }) {
+        SCOPED_TRACE(spec);
+        LoonProperties properties{};
+        auto result = loon_properties_inject_external_spec(
+            &properties,
+            42,
+            "s3://s3.amazonaws.com/bucket/key",
+            spec.c_str(),
+            2000,
+            5000);
+        const std::string error =
+            result.message != nullptr ? result.message : "";
+        EXPECT_EQ(result.err_code, loon_errcode_success) << error;
+        loon_ffi_free_result(&result);
+
+        EXPECT_STREQ(loon_properties_get(&properties,
+                                         PROPERTY_READER_EXTTABLE_SNAPSHOT_ID),
+                     "5320540205222981137");
+        milvus_storage::api::Properties round_tripped;
+        const auto conversion_error = milvus_storage::api::ConvertFFIProperties(
+            round_tripped, &properties);
+        loon_properties_free(&properties);
+        ASSERT_FALSE(conversion_error.has_value())
+            << conversion_error.value_or("");
+        const auto snapshot_id = milvus_storage::api::GetValue<int64_t>(
+            round_tripped, PROPERTY_READER_EXTTABLE_SNAPSHOT_ID);
+        ASSERT_TRUE(snapshot_id.ok()) << snapshot_id.status().ToString();
+        EXPECT_EQ(*snapshot_id, 5320540205222981137LL);
+    }
+}
+
+TEST(InjectExtfsAllowlist, InvalidIcebergSnapshotIDIsRejected) {
+    for (const std::string spec : {
+             R"({"format":"iceberg-table","snapshot_id":-2})",
+             R"({"format":"iceberg-table","snapshot_id":"-2"})",
+             R"({"snapshot_id":-2,"format":"iceberg-table"})",
+             R"({"snapshot_id":"-2","format":"iceberg-table"})",
+         }) {
+        SCOPED_TRACE(spec);
+        milvus_storage::api::Properties props;
+        EXPECT_THROW(::InjectExternalSpecProperties(
+                         props, 42, "s3://s3.amazonaws.com/bucket/key", spec),
+                     milvus::SegcoreError);
+
+        LoonProperties properties{};
+        auto result = loon_properties_inject_external_spec(
+            &properties,
+            42,
+            "s3://s3.amazonaws.com/bucket/key",
+            spec.c_str(),
+            2000,
+            5000);
+        EXPECT_EQ(result.err_code, loon_errcode_invalid_properties);
+        const std::string error =
+            result.message != nullptr ? result.message : "";
+        EXPECT_NE(error.find("reader.exttable.snapshot_id"), std::string::npos);
+        EXPECT_NE(error.find("-2"), std::string::npos);
+        loon_ffi_free_result(&result);
+        loon_properties_free(&properties);
+    }
 }
 
 // ============================================================

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -282,7 +282,7 @@ func (m MilvusTablePrimaryKeyMode) usesExternalPrimaryKey() bool {
 
 // ExternalSpecContext carries the raw external-table inputs that C++
 // InjectExternalSpecProperties needs to derive both extfs.{collectionID}.*
-// (storage layer) and format-layer properties (e.g. iceberg.snapshot_id)
+// (storage layer) and format-layer properties (e.g. reader.exttable.snapshot_id)
 // from a single external_spec JSON. Zero value (CollectionID=0, Source="")
 // signals an internal (non-external) collection — injectExternalSpecProperties
 // treats it as a no-op.


### PR DESCRIPTION
issue: #53352

Bump milvus-storage from 3ae6ac4 to e7f4477.

Also Use reader.exttable.snapshot_id for Iceberg external specs.