### PR TITLE
enhance: Nominate sparknack as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,3 +12,4 @@ maintainers:
   - foxspy
   - chyezh
   - weiliu1031
+  - sparknack

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,4 +11,5 @@ aliases:
     - weiliu1031
     - zhuwenxing
     - foxspy
+    - sparknack
 


### PR DESCRIPTION
## Summary

Nominate sparknack as a Milvus maintainer.

## Changes

- Add sparknack to MAINTAINERS.
- Add sparknack to the maintainers alias in OWNERS_ALIASES.