### PR TITLE
enhance: [3.0] Nominate sparknack as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,3 +8,8 @@ maintainers:
   - tedxu
   - liliu-z
   - zhengbuqian
+  - zhuwenxing
+  - foxspy
+  - chyezh
+  - weiliu1031
+  - sparknack

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,4 +9,7 @@ aliases:
     - zhengbuqian
     - chyezh
     - weiliu1031
+    - zhuwenxing
+    - foxspy
+    - sparknack
 


### PR DESCRIPTION
Cherry-pick from master
pr: #53324

## Summary

Nominate sparknack as a Milvus maintainer, and add the maintainers from #52865 who were missing on 3.0.

## Changes

- Add zhuwenxing, foxspy, chyezh, weiliu1031, and sparknack to MAINTAINERS.
- Add zhuwenxing and foxspy to the maintainers alias in OWNERS_ALIASES.