### PR TITLE
fix: fill the redacted replicate tokens from the snapshot being validated

### DIFF
--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -84,13 +84,11 @@ func (s *assignmentServiceImpl) UpdateReplicateConfiguration(ctx context.Context
 		return s.handleForcePromote(ctx, config)
 	}
 
-	// Connection tokens are redacted whenever the configuration is read, so a
-	// caller that read it back cannot resend them. Take the stored ones before
-	// anything compares or validates this configuration.
-	config, err := s.fillRedactedConnectionTokens(ctx, config)
-	if err != nil {
-		return nil, err
-	}
+	// The connection tokens redacted on read are filled in by
+	// validateReplicateConfiguration, from the same configuration snapshot it
+	// validates against. Do not fill them here: this is outside the cluster
+	// resource key, and a token taken from a snapshot older than the one the
+	// validation sees would escape the connection-parameter consistency check.
 
 	// check if the configuration is same.
 	// so even if current cluster is not primary, we can still make a idempotent success result.
@@ -132,22 +130,6 @@ func (s *assignmentServiceImpl) UpdateReplicateConfiguration(ctx context.Context
 	return &streamingpb.UpdateReplicateConfigurationResponse{}, nil
 }
 
-// fillRedactedConnectionTokens replaces the redacted connection tokens of an
-// incoming configuration with the ones already stored for the same clusters.
-// Without it a configuration that was read back can never be written again: the
-// read redacts the tokens and the validator rejects the change.
-func (s *assignmentServiceImpl) fillRedactedConnectionTokens(ctx context.Context, config *commonpb.ReplicateConfiguration) (*commonpb.ReplicateConfiguration, error) {
-	balancer, err := balance.GetWithContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	latestAssignment, err := balancer.GetLatestChannelAssignment()
-	if err != nil {
-		return nil, err
-	}
-	return replicateutil.FillRedactedConnectionTokens(config, latestAssignment.ReplicateConfiguration), nil
-}
-
 // waitUntilPrimaryChangeOrConfigurationSame waits until the primary changes or the configuration is same.
 func (s *assignmentServiceImpl) waitUntilPrimaryChangeOrConfigurationSame(ctx context.Context, config *commonpb.ReplicateConfiguration) error {
 	b, err := balance.GetWithContext(ctx)
@@ -155,7 +137,10 @@ func (s *assignmentServiceImpl) waitUntilPrimaryChangeOrConfigurationSame(ctx co
 		return err
 	}
 	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
-		if proto.Equal(config, param.ReplicateConfiguration) {
+		// Fill against the snapshot being compared, so a configuration whose
+		// tokens were redacted on read still matches once CDC has applied it.
+		filled := replicateutil.FillRedactedConnectionTokens(config, param.ReplicateConfiguration)
+		if proto.Equal(filled, param.ReplicateConfiguration) {
 			return errAssignmentDone
 		}
 		return nil
@@ -178,6 +163,14 @@ func (s *assignmentServiceImpl) validateReplicateConfiguration(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+
+	// Connection tokens are redacted whenever the configuration is read, so a
+	// caller that read it back cannot resend them. Take the stored ones from
+	// this snapshot, the one everything below compares and validates against:
+	// filling from an older snapshot would let a cluster that has since been
+	// removed be re-added with its former token under a new uri, which the
+	// consistency check no longer covers once the cluster is gone.
+	config = replicateutil.FillRedactedConnectionTokens(config, latestAssignment.ReplicateConfiguration)
 
 	// double check if the configuration is same after resource key is acquired.
 	if proto.Equal(config, latestAssignment.ReplicateConfiguration) {

--- a/internal/streamingcoord/server/service/assignment_test.go
+++ b/internal/streamingcoord/server/service/assignment_test.go
@@ -811,10 +811,10 @@ func TestUpdateReplicateConfigSecondValidateSameConfig(t *testing.T) {
 	}).Build()
 	defer mockGetClusterChannels.UnPatch()
 
-	// UpdateReplicateConfiguration reads the latest assignment three times: once
-	// to fill the redacted connection tokens, once for the validation before the
-	// cluster resource key is acquired, and once for the validation after it.
-	// Only the third read must observe the configuration as already applied.
+	// UpdateReplicateConfiguration reads the latest assignment twice: once for
+	// the validation before the cluster resource key is acquired and once for
+	// the validation after it. Only the second read must observe the
+	// configuration as already applied.
 	callCount := 0
 	cfg := &commonpb.ReplicateConfiguration{
 		Clusters: []*commonpb.MilvusCluster{
@@ -835,7 +835,7 @@ func TestUpdateReplicateConfigSecondValidateSameConfig(t *testing.T) {
 	b.EXPECT().Close().Return().Maybe()
 	b.EXPECT().GetLatestChannelAssignment().RunAndReturn(func() (*balancer.WatchChannelAssignmentsCallbackParam, error) {
 		callCount++
-		if callCount <= 2 {
+		if callCount <= 1 {
 			// Before the resource key: config is different (nil)
 			return &balancer.WatchChannelAssignmentsCallbackParam{
 				PChannelView: &channel.PChannelView{
@@ -1277,8 +1277,8 @@ func TestSecondValidateNonSameError(t *testing.T) {
 	}).Build()
 	defer mockGetClusterChannels.UnPatch()
 
-	// As above, the first two reads serve the token filling and the validation
-	// before the resource key is acquired; the failure belongs to the third.
+	// As above, the first read serves the validation before the resource key is
+	// acquired; the failure belongs to the second.
 	callCount := 0
 	b := mock_balancer.NewMockBalancer(t)
 	b.EXPECT().WaitUntilWALbasedDDLReady(mock.Anything).Return(nil).Maybe()
@@ -1289,7 +1289,7 @@ func TestSecondValidateNonSameError(t *testing.T) {
 	b.EXPECT().Close().Return().Maybe()
 	b.EXPECT().GetLatestChannelAssignment().RunAndReturn(func() (*balancer.WatchChannelAssignmentsCallbackParam, error) {
 		callCount++
-		if callCount <= 2 {
+		if callCount <= 1 {
 			return &balancer.WatchChannelAssignmentsCallbackParam{
 				PChannelView: &channel.PChannelView{
 					Channels: map[channel.ChannelID]*channel.PChannelMeta{
@@ -1433,4 +1433,110 @@ func TestForcePromoteMultiplePChannels(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestUpdateReplicateConfigTokenFillUsesValidationSnapshot(t *testing.T) {
+	// A cluster removed between the token filling and the validation must not be
+	// re-addable with the token it used to hold. The connection-parameter
+	// consistency check only covers clusters present in the current
+	// configuration, so a token taken from an older snapshot than the one the
+	// validation reads would be bound to a uri nobody checked.
+	resource.InitForTest()
+
+	mw := mock_streaming.NewMockWALAccesser(t)
+	mw.EXPECT().ControlChannel().Return("by-dev-1_vcchan").Maybe()
+	streaming.SetWALForTest(mw)
+
+	broadcast.ResetBroadcaster()
+	snmanager.ResetStreamingNodeManager()
+
+	mockGetClusterChannels := mockey.Mock(channel.GetClusterChannels).Return(message.ClusterChannels{
+		Channels:       []string{"by-dev-1"},
+		ControlChannel: "by-dev-1_vcchan",
+	}).Build()
+	defer mockGetClusterChannels.UnPatch()
+
+	// The stored configuration replicates to "peer", reachable at its own uri
+	// with a token the caller was never given.
+	withPeer := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"by-dev-1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://test:19530", Token: "by-dev"}},
+			{ClusterId: "peer", Pchannels: []string{"peer-1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://peer:19530", Token: "peer-secret"}},
+		},
+		CrossClusterTopology: []*commonpb.CrossClusterTopology{
+			{SourceClusterId: "by-dev", TargetClusterId: "peer"},
+		},
+	}
+	// A concurrent update drops the edge, so "peer" is gone from the
+	// configuration every later read observes.
+	withoutPeer := &commonpb.ReplicateConfiguration{
+		Clusters: []*commonpb.MilvusCluster{
+			{ClusterId: "by-dev", Pchannels: []string{"by-dev-1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://test:19530", Token: "by-dev"}},
+		},
+	}
+
+	pchannelView := &channel.PChannelView{
+		Channels: map[channel.ChannelID]*channel.PChannelMeta{
+			{Name: "by-dev-1"}: channel.NewPChannelMeta("by-dev-1", types.AccessModeRW),
+		},
+	}
+
+	callCount := 0
+	b := mock_balancer.NewMockBalancer(t)
+	b.EXPECT().WaitUntilWALbasedDDLReady(mock.Anything).Return(nil).Maybe()
+	b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}).Maybe()
+	b.EXPECT().Close().Return().Maybe()
+	b.EXPECT().GetLatestChannelAssignment().RunAndReturn(func() (*balancer.WatchChannelAssignmentsCallbackParam, error) {
+		callCount++
+		if callCount <= 1 {
+			return &balancer.WatchChannelAssignmentsCallbackParam{PChannelView: pchannelView, ReplicateConfiguration: withPeer}, nil
+		}
+		return &balancer.WatchChannelAssignmentsCallbackParam{PChannelView: pchannelView, ReplicateConfiguration: withoutPeer}, nil
+	})
+	balance.Register(b)
+
+	var broadcasted *commonpb.ReplicateConfiguration
+	mba := mock_broadcaster.NewMockBroadcastAPI(t)
+	mba.EXPECT().Broadcast(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, msg message.BroadcastMutableMessage) (*types.BroadcastAppendResult, error) {
+		broadcasted = message.MustAsBroadcastAlterReplicateConfigMessageV2(msg).Header().GetReplicateConfiguration()
+		return &types.BroadcastAppendResult{BroadcastID: 1}, nil
+	}).Maybe()
+	mba.EXPECT().Close().Return().Maybe()
+
+	mb := mock_broadcaster.NewMockBroadcaster(t)
+	mb.EXPECT().WithResourceKeys(mock.Anything, mock.Anything).Return(mba, nil).Maybe()
+	mb.EXPECT().Close().Return().Maybe()
+	broadcast.Register(mb)
+
+	// The caller re-adds "peer" under a uri it controls, with the token redacted
+	// as every read hands it back.
+	as := NewAssignmentService()
+	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev", Pchannels: []string{"by-dev-1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://test:19530", Token: ""}},
+				{ClusterId: "peer", Pchannels: []string{"peer-1"}, ConnectionParam: &commonpb.ConnectionParam{Uri: "http://elsewhere:19530", Token: ""}},
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: "by-dev", TargetClusterId: "peer"},
+			},
+		},
+	})
+
+	// Whatever the outcome, the token of the removed cluster must not reach a uri
+	// no consistency check ever saw.
+	for _, cluster := range broadcasted.GetClusters() {
+		assert.NotEqual(t, "peer-secret", cluster.GetConnectionParam().GetToken(),
+			"stored token broadcast under uri %s", cluster.GetConnectionParam().GetUri())
+	}
+	// The uri change is caught, because the filling and the validation agree on
+	// which configuration is current. Filling before the first read instead let
+	// this through and broadcast "peer-secret" bound to the new uri.
+	assert.Nil(t, broadcasted)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "connection_param.uri cannot be changed")
+	}
 }


### PR DESCRIPTION
issue: #52734

Follow-up to #52735, addressing @xiaofan-luan's review comment on that PR: the token filling it added runs outside the `ExclusiveCluster` resource key and reads its own copy of the current configuration, while each `validateReplicateConfiguration` reads another one. The configuration a token is taken from is not the configuration the token is checked against.

### The interleaving

1. The current topology replicates to cluster `B`, reachable at its uri with token `T`.
2. A request re-adds `B` under a different uri with the redacted (empty) token. The filling copies `T` out of the configuration that still holds `B`.
3. A concurrent request removes `B` and commits the standalone configuration first.
4. Both validations of the first request now read a configuration without `B`. `validateClusterConsistency` only compares clusters present in the current configuration (`config_validator.go`, "If cluster doesn't exist in current config, it's a new cluster, which is allowed"), so the uri change is never checked.

The broadcast stores the new uri together with `T`, and CDC sends `T` to that endpoint. Without the interleaving the uri change is rejected, so this is reachable only through the window between the filling and the validation.

### The change

The filling moves into `validateReplicateConfiguration`, which already reads the configuration it validates against. The same snapshot supplies the token and is compared with it: if `B` is still there the uri change is rejected as before, and if `B` is gone no token is filled at all. Both call sites keep the original incoming configuration, so the validation after the resource key is acquired rebuilds from the snapshot it holds the key for.

`waitUntilPrimaryChangeOrConfigurationSame` fills against the configuration each watch callback carries, for the same reason.

### Verification

New service-level test `TestUpdateReplicateConfigTokenFillUsesValidationSnapshot` drives the interleaving directly: the first assignment read still holds `peer` with `peer-secret`, every later read does not, and the caller submits `peer` at a uri of its own with an empty token.

| | before | after |
|---|---|---|
| request accepted | yes | no (`connection_param.uri cannot be changed`) |
| broadcast configuration | `peer-secret` bound to `http://elsewhere:19530` | none |

The two existing tests that count assignment reads drop back to one read before the resource key.

The unit tests of `internal/streamingcoord/server/service` and `pkg/util/replicateutil` pass with the same result as the baseline on `master`; `golangci-lint run --build-tags dynamic,test` reports 0 issues.

The same shape is on `poc_2.6.17` via #52736 and needs the same follow-up.
