### PR TITLE
test: restore threshold control in the channelmgr packing tests

### DIFF
--- a/internal/proxy/channelmgr/msg_pack_benchmark_test.go
+++ b/internal/proxy/channelmgr/msg_pack_benchmark_test.go
@@ -19,13 +19,9 @@ package channelmgr
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func BenchmarkGenInsertMsgsByPartition(b *testing.B) {
@@ -59,9 +55,7 @@ func BenchmarkGenInsertMsgsByPartition(b *testing.B) {
 				{"single_row_batches", 1},
 			} {
 				b.Run(fmt.Sprintf("dim%d/%s/%s", dim, layout, batching.name), func(b *testing.B) {
-					key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-					require.NoError(b, paramtable.Get().Save(key, strconv.Itoa(batching.threshold)))
-					b.Cleanup(func() { paramtable.Get().Reset(key) })
+					savePackingThresholdForTest(b, batching.threshold)
 					b.ReportAllocs()
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {

--- a/internal/proxy/channelmgr/msg_pack_fallback_test.go
+++ b/internal/proxy/channelmgr/msg_pack_fallback_test.go
@@ -18,7 +18,6 @@ package channelmgr
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -30,7 +29,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -52,9 +50,7 @@ func TestGenInsertMsgsByPartitionFallbackSingleIndexPass(t *testing.T) {
 		{"empty selection", 128, nil, nil, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-			require.NoError(t, paramtable.Get().Save(key, strconv.Itoa(tc.threshold)))
-			t.Cleanup(func() { paramtable.Get().Reset(key) })
+			savePackingThresholdForTest(t, tc.threshold)
 			src := newNullableVectorInsertMsgForPackTest(12, 2, 1)
 			if tc.disableViews {
 				patch := mockey.Mock(typeutil.CreateFieldDataRangeView).Return(nil, false).Build()
@@ -143,9 +139,7 @@ func TestGenInsertMsgsByPartitionMixedSelectionKeepsContiguousBatchViews(t *test
 	threshold := max(firstPairSize, secondPairSize) + 1
 	require.GreaterOrEqual(t, firstPairSize+rowSizes[2], threshold)
 
-	key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-	require.NoError(t, paramtable.Get().Save(key, strconv.Itoa(threshold)))
-	t.Cleanup(func() { paramtable.Get().Reset(key) })
+	savePackingThresholdForTest(t, threshold)
 
 	msgs, err := GenInsertMsgsByPartition(
 		context.Background(), 2, 1, "test_partition", offsets,
@@ -166,9 +160,7 @@ func TestGenInsertMsgsByPartitionMixedSelectionKeepsContiguousBatchViews(t *test
 }
 
 func TestGenInsertMsgsByPartitionGapWithinBatchCopiesContiguousPrefix(t *testing.T) {
-	key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-	require.NoError(t, paramtable.Get().Save(key, "1024"))
-	t.Cleanup(func() { paramtable.Get().Reset(key) })
+	savePackingThresholdForTest(t, 1024)
 
 	src := newNullableVectorInsertMsgForPackTest(10, 2, 1)
 	offsets := []int{1, 2, 4, 5}
@@ -187,9 +179,7 @@ func TestGenInsertMsgsByPartitionGapWithinBatchCopiesContiguousPrefix(t *testing
 }
 
 func TestGenInsertMsgsByPartitionFallbackNullableSparseVectorSizes(t *testing.T) {
-	key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-	require.NoError(t, paramtable.Get().Save(key, "73"))
-	t.Cleanup(func() { paramtable.Get().Reset(key) })
+	savePackingThresholdForTest(t, 73)
 	src := newNullableVectorInsertMsgForPackTest(8, 2, 1)
 	logicalContents := make([][]byte, 8)
 	var contents [][]byte
@@ -237,9 +227,7 @@ func TestGenInsertMsgsByPartitionFallbackNullableSparseVectorSizes(t *testing.T)
 }
 
 func TestGenInsertMsgsByPartitionFallbackErrorsDiscardPartialBatches(t *testing.T) {
-	key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
-	require.NoError(t, paramtable.Get().Save(key, "64"))
-	t.Cleanup(func() { paramtable.Get().Reset(key) })
+	savePackingThresholdForTest(t, 64)
 
 	for _, tc := range []struct {
 		name    string

--- a/internal/proxy/channelmgr/msg_pack_fastpath_test.go
+++ b/internal/proxy/channelmgr/msg_pack_fastpath_test.go
@@ -174,8 +174,7 @@ func TestGenInsertMsgsByPartitionNonContiguousFallback(t *testing.T) {
 }
 
 func TestGenInsertMsgsByPartitionContiguousFastPathAfterSplit(t *testing.T) {
-	assert.NoError(t, paramtable.Get().Save(paramtable.Get().PulsarCfg.MaxMessageSize.Key, "17"))
-	defer paramtable.Get().Reset(paramtable.Get().PulsarCfg.MaxMessageSize.Key)
+	savePackingThresholdForTest(t, 17)
 
 	longData := []int64{10, 20, 30, 40}
 	insertMsg := &msgstream.InsertMsg{

--- a/internal/proxy/channelmgr/msg_pack_test.go
+++ b/internal/proxy/channelmgr/msg_pack_test.go
@@ -35,6 +35,22 @@ import (
 
 const minWALMessageSizeForTest = 256 * 1024
 
+// savePackingThresholdForTest pins the proxy packing threshold for one test.
+//
+// It goes through SwapTempValue rather than Save because walMessageSizeFormatter
+// raises pulsar.maxMessageSize to minWALMessageSize (256KiB) for any smaller
+// value: that floor protects real WAL writes, but it also makes a saved
+// threshold below it unobservable, so a packing test would silently run at
+// 256KiB and never split. The temp-value path bypasses the formatter, which is
+// what it exists for, and lets these tests keep byte-sized payloads instead of
+// allocating megabytes per case.
+func savePackingThresholdForTest(tb testing.TB, threshold int) {
+	tb.Helper()
+	item := &paramtable.Get().PulsarCfg.MaxMessageSize
+	old := item.SwapTempValue(strconv.Itoa(threshold))
+	tb.Cleanup(func() { item.SwapTempValue(old) })
+}
+
 func TestGenInsertMsgsByPartitionRejectsSingleOversizedRow(t *testing.T) {
 	params := paramtable.Get()
 	assert.NoError(t, params.Save(params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(minWALMessageSizeForTest)))


### PR DESCRIPTION
## What is broken

`master` is red on UT-GO. Eight tests in `internal/proxy/channelmgr` fail:

```
--- FAIL: TestGenInsertMsgsByPartitionFallbackSingleIndexPass
    "…num_rows:6 version:ColumnBased]" should have 3 item(s), but has 1
--- FAIL: TestGenInsertMsgsByPartitionMixedSelectionKeepsContiguousBatchViews
--- FAIL: TestGenInsertMsgsByPartitionFallbackNullableSparseVectorSizes
--- FAIL: TestGenInsertMsgsByPartitionFallbackErrorsDiscardPartialBatches
--- FAIL: TestGenInsertMsgsByPartitionContiguousFastPathAfterSplit
```

Reproduced on a clean checkout of `b5f8ff453b`, and by the branch pipeline itself:
[MILVUS-CI-V2-BRANCH-TRIGGER/master #1316](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/MILVUS-CI-V2-BRANCH-TRIGGER/job/master/1316/) ran on
`1759fb09` and went UNSTABLE with these same failures after three automatic retries.

## Why

The tests drive the packing path by saving a byte-sized threshold:

```go
key := paramtable.Get().PulsarCfg.MaxMessageSize.Key
require.NoError(t, paramtable.Get().Save(key, strconv.Itoa(tc.threshold)))  // 17, 25, 33, 64, 73, 128, 1024
```

`#52775` attached `walMessageSizeFormatter` to that key, which raises anything below
`minWALMessageSize` (256 KiB) to 256 KiB (`pkg/util/paramtable/service_param.go:80-86`).
`GenInsertMsgsByPartition` therefore reads 256 KiB, the byte-sized payloads never reach it,
nothing splits, and every batch-boundary assertion fails. The clamp is visible in the test
output as `WAL message size is below the supported minimum, clamping`.

Neither PR could see this before merging, because they share no file:
`#52434` last ran CI on 09-04 against a base predating the clamp and merged on 09-09
without a rerun.

## The change

Set the threshold through `ParamItem.SwapTempValue`, which exists for unit tests and
returns before the formatter is applied (`param_item.go:203-207`). Every threshold value and
every assertion in these tests is preserved exactly as written, and the tests keep byte-sized
payloads instead of allocating megabytes per case just to clear the production floor.

`BenchmarkGenInsertMsgsByPartition` gets the same treatment: its `single_row_batches` and
`split_batches` cases were also being clamped to 256 KiB, so they were not measuring the
layouts they are named after.

**No production code changes.** The 256 KiB floor keeps applying to every real WAL write.

## Verification

- `go test -count=2 ./internal/proxy/channelmgr/` passes on this branch.
- The same tests fail on `b5f8ff453b` without this change.
- `BenchmarkGenInsertMsgsByPartition/dim2/*/single_row_batches` runs.

/cc @sunby @xiaofan-luan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZNt74EvaSRZ1y2nrYT1Lv
