### PR TITLE
fix: [3.0] ignore non-positive backfill partitionId (#53330)

### DIFF
--- a/internal/datacoord/services_commit_backfill.go
+++ b/internal/datacoord/services_commit_backfill.go
@@ -302,10 +302,12 @@ func (s *Server) classifyBackfillSegments(ctx context.Context, result *BackfillR
 			continue
 		}
 		// Partition-scoped backfills set PartitionID to the target partition;
-		// collection-wide backfills leave it at 0 (no check). When non-zero,
-		// rejecting a mismatching segment prevents writing metadata against
-		// the wrong partition.
-		if result.PartitionID != 0 && segInfo.GetPartitionID() != result.PartitionID {
+		// collection-wide / multi-partition backfills leave it at 0 (no check).
+		// Spark historically emits -1 for multi-partition results; partition IDs
+		// are always positive, so any value <= 0 means "no partition check".
+		// Rejecting a mismatching segment otherwise prevents writing metadata
+		// against the wrong partition.
+		if result.PartitionID > 0 && segInfo.GetPartitionID() != result.PartitionID {
 			statuses = append(statuses, &datapb.CommitBackfillResultSegmentStatus{
 				SegmentId: segID, Ok: false, Kind: inferKind(&entry),
 				Reason: "segment does not belong to the result's partition",

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -4685,6 +4685,77 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 		assert.Contains(t, resp.GetSegmentStatuses()[0].GetReason(), "does not belong to the result's partition")
 	})
 
+	// Multi-partition backfill: result.PartitionID == -1 is Spark's sentinel
+	// for "result spans multiple partitions". It must NOT be treated as a real
+	// partition ID; segments from different partitions are all accepted.
+	t.Run("multi_partition_negative_partition_id_ok", func(t *testing.T) {
+		ctx := context.Background()
+		m, err := newMemoryMeta(t)
+		require.NoError(t, err)
+		for _, p := range []int64{101, 102} {
+			id := 1000 + p
+			m.AddSegment(ctx, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+				ID: id, CollectionID: 100, PartitionID: p,
+				State:          commonpb.SegmentState_Flushed,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   packed.MarshalManifestPath("/seg/"+strconv.FormatInt(id, 10), 1),
+			}})
+		}
+		jsonStr := `{
+          "success": true,
+          "collectionId": 100,
+          "partitionId": -1,
+          "segments": {
+            "1101": {"version": 10, "rowCount": 5, "outputPath": "x", "manifestPaths": []},
+            "1102": {"version": 20, "rowCount": 7, "outputPath": "x", "manifestPaths": []}
+          }
+        }`
+		mockBroker := broker.NewMockBroker(t)
+		mockBroker.EXPECT().DescribeCollectionInternal(mock.Anything, mock.Anything).
+			Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(), DbName: "default", CollectionName: "c",
+			}, nil)
+		server := newServerForCommit(t, m, mockBroker, []byte(jsonStr))
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Maybe()
+		streaming.SetWALForTest(wal)
+
+		bapi := mock_broadcaster.NewMockBroadcastAPI(t)
+		var captured message.BroadcastMutableMessage
+		bapi.EXPECT().Broadcast(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msg message.BroadcastMutableMessage) (*types2.BroadcastAppendResult, error) {
+				captured = msg
+				return &types2.BroadcastAppendResult{
+					BroadcastID: 1,
+					AppendResults: map[string]*types2.AppendResult{
+						"by-dev-rootcoord-dml_0": {
+							MessageID:              rmq.NewRmqID(1),
+							TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
+							LastConfirmedMessageID: rmq.NewRmqID(1),
+						},
+					},
+				}, nil
+			})
+		bapi.EXPECT().Close().Return()
+		patch := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return bapi, nil
+			}).Build()
+		defer patch.UnPatch()
+
+		resp, err := server.CommitBackfillResult(ctx, &datapb.CommitBackfillResultRequest{
+			ResultPath: "s3a://bkt/foo",
+		})
+		assert.NoError(t, err)
+		assert.True(t, merr.Ok(resp.GetStatus()))
+		assert.Equal(t, int32(2), resp.GetTotalSegments())
+		assert.Equal(t, int32(2), resp.GetCommittedSegments())
+		assert.Equal(t, int32(0), resp.GetFailedSegments())
+		specialized := message.MustAsMutableBatchUpdateManifestMessageV2(captured)
+		require.Len(t, specialized.MustBody().GetItems(), 2)
+	})
+
 	// V3 entry pointing at a segment whose actual storage version is V2 must
 	// be rejected: UpdateManifestVersion would no-op and the caller would see
 	// a fake committed=true.


### PR DESCRIPTION
Cherry-pick from master
pr: #53330

Spark emits partitionId = -1 when a backfill result spans multiple partitions, but CommitBackfillResult only treated 0 as "no partition restriction". The -1 was matched against real partition IDs (always positive), so every segment failed pre-validation with "segment does not belong to the result's partition" and the commit was rejected as a whole with "no backfill segments passed pre-validation" (HTTP 500) even though Spark wrote all files successfully.

Treat any non-positive partitionId (0 or -1) as "no partition check" by requiring result.PartitionID > 0 before enabling the check. Add a unit test covering a multi-partition result with partitionId = -1.

issue: #53327