### PR TITLE
enhance: make arrow IO thread pool coefficient 0 a fixed Milvus default

### DIFF
--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -94,11 +94,8 @@ func InitSegcore(nodeID int64) error {
 	cGpuMemoryPoolMaxSize := C.uint32_t(paramtable.Get().GpuConfig.MaxSize.GetAsUint32())
 	C.SegcoreSetKnowhereGpuMemoryPoolSize(cGpuMemoryPoolInitSize, cGpuMemoryPoolMaxSize)
 
-	// Apply Arrow IO thread pool capacity from paramtable. Without this call the
-	// pool stays at Arrow's built-in default (kDefaultNumIoThreads = 8), which is
-	// almost always undersized for DataNode under concurrent storage v2 reads
-	// (sort compaction, import, stats). Mirror of the QueryNode wiring in #49208.
-	C.SetArrowIOThreadPoolCapacity(C.int(initcore.ResolveArrowIOThreadPoolCapacity()))
+	// Apply Arrow IO thread pool capacity from paramtable.
+	initcore.ApplyArrowIOThreadPoolCapacity("datanode", "init")
 
 	// Apply Arrow parquet reader range-coalescing config (hole/range size limits).
 	if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -23,11 +23,90 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus/internal/util/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+func TestResolveArrowIOThreadPoolCapacity(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)
+
+	for _, tc := range []struct {
+		name, coefficient, maxCapacity string
+		want                           int
+		wantErr                        bool
+	}{
+		{name: "negative", coefficient: "-1", maxCapacity: "1", wantErr: true},
+		{name: "negative_fraction", coefficient: "-0.5", maxCapacity: "1", wantErr: true},
+		{name: "zero_fixed_default", coefficient: "0", maxCapacity: "0", want: defaultArrowIOThreadPoolCapacity},
+		{name: "zero_ignores_cap", coefficient: "0", maxCapacity: "1", want: defaultArrowIOThreadPoolCapacity},
+		{name: "positive", coefficient: "2", maxCapacity: "0", want: 2 * hardware.GetCPUNum()},
+		{name: "positive_fraction", coefficient: "0.5", maxCapacity: "0", want: max(1, hardware.GetCPUNum()/2)},
+		{name: "positive_capped", coefficient: "2", maxCapacity: "1", want: 1},
+		{name: "positive_minimum", coefficient: "0.000001", maxCapacity: "0", want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, tc.coefficient))
+			assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, tc.maxCapacity))
+			got, err := ResolveArrowIOThreadPoolCapacity()
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestApplyArrowIOThreadPoolCapacityHotReload drives paramtable Save ->
+// watcher -> ApplyArrowIOThreadPoolCapacity -> arrow and reads the capacity
+// back through the core prometheus gauge.
+func TestApplyArrowIOThreadPoolCapacityHotReload(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer func() {
+		pt.Reset(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)
+		pt.Reset(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)
+		ApplyArrowIOThreadPoolCapacity("test", "cleanup")
+	}()
+	RegisterArrowIOThreadPoolWatchers(pt, "test")
+
+	registry := metrics.NewCRegistry()
+	capacity := func() int {
+		families, err := registry.Gather()
+		require.NoError(t, err)
+		for _, mf := range families {
+			if mf.GetName() == "internal_arrow_io_pool_capacity" {
+				require.Len(t, mf.GetMetric(), 1)
+				return int(mf.GetMetric()[0].GetGauge().GetValue())
+			}
+		}
+		require.FailNow(t, "internal_arrow_io_pool_capacity gauge not found")
+		return -1
+	}
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, "0"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "2"))
+	assert.Equal(t, 2*hardware.GetCPUNum(), capacity())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "0"))
+	assert.Equal(t, defaultArrowIOThreadPoolCapacity, capacity())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "-1"))
+	assert.Equal(t, defaultArrowIOThreadPoolCapacity, capacity())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "2"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, "3"))
+	assert.Equal(t, 3, capacity())
+}
 
 func TestTracer(t *testing.T) {
 	paramtable.Init()

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -174,7 +174,7 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		UpdateExprResCacheConfig()
 	}
 
-	C.SetArrowIOThreadPoolCapacity(C.int(ResolveArrowIOThreadPoolCapacity()))
+	ApplyArrowIOThreadPoolCapacity("querynode", "init")
 
 	cStorageV2CellTargetSizeBytes := C.int64_t(paramtable.Get().QueryNodeCfg.StorageV2CellTargetSizeBytes.GetAsInt64())
 	C.SetStorageV2CellTargetSizeBytes(cStorageV2CellTargetSizeBytes)

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -117,15 +118,22 @@ func UpdateArrowIOThreadPoolCapacity(threads int) {
 	C.SetArrowIOThreadPoolCapacity(C.int(threads))
 }
 
+// defaultArrowIOThreadPoolCapacity is the pool size used when
+// common.arrow.ioThreadPoolCoefficient is 0.
+const defaultArrowIOThreadPoolCapacity = 8
+
 // ResolveArrowIOThreadPoolCapacity returns the effective arrow IO thread pool
-// size: coefficient × CPU cores, clamped by MaxCapacity when > 0. Returns 0
-// when the coefficient is unset, which signals the C++ side to keep arrow's
-// built-in default (8).
-func ResolveArrowIOThreadPoolCapacity() int {
+// size: coefficient × CPU cores, clamped by MaxCapacity when > 0. A zero
+// coefficient returns defaultArrowIOThreadPoolCapacity. A negative coefficient
+// returns an error.
+func ResolveArrowIOThreadPoolCapacity() (int, error) {
 	cfg := &paramtable.Get().CommonCfg
 	coef := cfg.ArrowIOThreadPoolCoefficient.GetAsFloat()
-	if coef <= 0 {
-		return 0
+	if coef < 0 {
+		return 0, merr.WrapErrParameterInvalidMsg("invalid %s %v: must be >= 0", cfg.ArrowIOThreadPoolCoefficient.Key, coef)
+	}
+	if coef == 0 {
+		return defaultArrowIOThreadPoolCapacity, nil
 	}
 	threads := int(coef * float64(hardware.GetCPUNum()))
 	if threads < 1 {
@@ -134,26 +142,37 @@ func ResolveArrowIOThreadPoolCapacity() int {
 	if maxCap := cfg.ArrowIOThreadPoolMaxCapacity.GetAsInt(); maxCap > 0 && threads > maxCap {
 		threads = maxCap
 	}
-	return threads
+	return threads, nil
+}
+
+// ApplyArrowIOThreadPoolCapacity resolves the configured capacity and applies
+// it to arrow's IO thread pool. Invalid config is logged and the pool is left
+// unchanged. `source` and `trigger` are included in the log entry.
+func ApplyArrowIOThreadPoolCapacity(source, trigger string) {
+	threads, err := ResolveArrowIOThreadPoolCapacity()
+	if err != nil {
+		mlog.Warn(context.TODO(), "ignore invalid arrow io thread pool config",
+			mlog.String("source", source),
+			mlog.String("trigger", trigger),
+			mlog.String("error", err.Error()))
+		return
+	}
+	UpdateArrowIOThreadPoolCapacity(threads)
+	mlog.Info(context.TODO(), "arrow io thread pool capacity updated",
+		mlog.String("source", source),
+		mlog.String("trigger", trigger),
+		mlog.Int("threads", threads))
 }
 
 // RegisterArrowIOThreadPoolWatchers wires hot-reload of arrow IO pool capacity
-// to paramtable updates on the two coefficient/maxCapacity keys. `source` is
-// included in the log entry so log lines from different components (e.g.
-// "querynode" vs "datanode" in standalone, where both register the same keys)
-// remain distinguishable.
+// to paramtable updates on the two coefficient/maxCapacity keys.
 func RegisterArrowIOThreadPoolWatchers(pt *paramtable.ComponentParam, source string) {
 	handler := func(key string) func(*config.Event) {
 		return func(evt *config.Event) {
 			if !evt.HasUpdated {
 				return
 			}
-			newThreads := ResolveArrowIOThreadPoolCapacity()
-			UpdateArrowIOThreadPoolCapacity(newThreads)
-			mlog.Info(context.TODO(), "arrow io thread pool capacity updated",
-				mlog.String("source", source),
-				mlog.String("trigger", key),
-				mlog.Int("threads", newThreads))
+			ApplyArrowIOThreadPoolCapacity(source, key)
 		}
 	}
 	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -769,9 +769,8 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`range reads (ReadRangeCache) on this pool, which issue the actual ` +
 			`S3 GetObject requests — it is the real ceiling on parallel ` +
 			`object-storage reads, independent of segcore HIGH/MIDDLE pools and ` +
-			`minio.maxConnections. Arrow's built-in default is a fixed constant ` +
-			`of 8, which is almost always undersized. Typical range 2–8. 0 keeps ` +
-			`arrow's default (and the cap is ignored).`,
+			`minio.maxConnections. 0 means a fixed pool of 8 threads (the cap ` +
+			`is ignored). Typical range: 2–8. Negative values are ignored.`,
 		Export: false,
 	}
 	p.ArrowIOThreadPoolCoefficient.Init(base.mgr)


### PR DESCRIPTION
enhance: make arrow IO thread pool coefficient 0 a fixed Milvus default

Hot-reload of `common.arrow.ioThreadPoolCoefficient` is one-way today: setting
it back to 0 passes 0 to C++, which is ignored, so the pool keeps its previous
size until restart.

Resolve the value entirely on the Go side:

- `0` → fixed pool of 8 threads owned by Milvus (was "keep arrow's current size").
- `< 0` → rejected with a warning, pool unchanged.
- `> 0` → unchanged: coefficient × CPU cores, clamped by `maxCapacity`.

Init paths (QueryNode, DataNode) and the paramtable watcher now share
`ApplyArrowIOThreadPoolCapacity`. Default stays 8, so no behavior change for
existing deployments.

Tests: `TestResolveArrowIOThreadPoolCapacity` covers the resolve table;
`TestApplyArrowIOThreadPoolCapacityHotReload` drives paramtable → watcher →
arrow and reads the capacity back via the `internal_arrow_io_pool_capacity`
gauge (2 → 0 → -1 → capped).

issue: #53331

<img width="128" height="128" alt="milvus-emoji-09-on-it-unofficial-small" src="https://github.com/user-attachments/assets/a1c48a98-1c22-4fac-8208-ff1207806b69" />

Hope Milvus keeps getting a little better every day.
Thanks in advance for any time or advice you can spare.

