### PR TITLE
fix: [cp2.6]release the built index and analyze object when a task is canceled

### DIFF
--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -223,6 +223,15 @@ func (at *analyzeTask) GetState() indexpb.JobState {
 }
 
 func (at *analyzeTask) Reset() {
+	// Reset runs from processTask's deferred cleanup on every exit path, including
+	// the canceled one where PostExecute -- the only other place that releases the
+	// analyze object -- is skipped. Delete is idempotent.
+	if at.analyze != nil {
+		if err := at.analyze.Delete(); err != nil {
+			log.Ctx(at.ctx).Warn("failed to release analyze object on task reset", zap.Error(err))
+		}
+		at.analyze = nil
+	}
 	at.ident = ""
 	at.ctx = nil
 	at.cancel = nil

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -97,6 +97,16 @@ func (it *indexBuildTask) parseParams() {
 }
 
 func (it *indexBuildTask) Reset() {
+	// Reset runs from processTask's deferred cleanup on every exit path, including
+	// the canceled one where PostExecute -- the only other place that releases the
+	// index -- is skipped. Without this the native index built by Execute is never
+	// freed. Delete is idempotent, so releasing here after a normal PostExecute is
+	// a no-op.
+	if it.index != nil {
+		if err := it.index.Delete(); err != nil {
+			log.Ctx(it.ctx).Warn("failed to release index object on task reset", zap.Error(err))
+		}
+	}
 	it.ident = ""
 	it.cancel = nil
 	it.ctx = nil

--- a/internal/datanode/index/task_reset_test.go
+++ b/internal/datanode/index/task_reset_test.go
@@ -1,0 +1,96 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
+	"github.com/milvus-io/milvus/pkg/v2/proto/cgopb"
+)
+
+// fakeIndex counts Delete calls, standing in for the native index that
+// indexcgowrapper.CreateIndex hands back as a raw pointer.
+type fakeIndex struct {
+	indexcgowrapper.CodecIndex
+	deleted int
+}
+
+func (f *fakeIndex) Delete() error {
+	f.deleted++
+	return nil
+}
+
+func (f *fakeIndex) UpLoad() (*cgopb.IndexStats, error) {
+	return &cgopb.IndexStats{}, nil
+}
+
+type fakeAnalyze struct {
+	deleted int
+}
+
+func (f *fakeAnalyze) Delete() error {
+	f.deleted++
+	return nil
+}
+
+func (f *fakeAnalyze) GetResult(size int) (string, int64, []string, []int64, error) {
+	return "", 0, nil, nil, nil
+}
+
+// processTask skips PostExecute whenever the task context is canceled, and
+// PostExecute is the only other place that frees the native index. Reset runs on
+// every exit path, so it must do the release or the built index leaks for the
+// lifetime of the process.
+func TestIndexBuildTaskResetReleasesIndex(t *testing.T) {
+	index := &fakeIndex{}
+	it := &indexBuildTask{
+		ctx:   context.Background(),
+		index: index,
+	}
+
+	it.Reset()
+
+	assert.Equal(t, 1, index.deleted, "Reset must release the built index")
+	assert.Nil(t, it.index)
+}
+
+func TestAnalyzeTaskResetReleasesAnalyze(t *testing.T) {
+	analyze := &fakeAnalyze{}
+	at := &analyzeTask{
+		ctx:     context.Background(),
+		analyze: analyze,
+	}
+
+	at.Reset()
+
+	assert.Equal(t, 1, analyze.deleted, "Reset must release the analyze object")
+	assert.Nil(t, at.analyze)
+}
+
+// Reset must stay safe after a normal PostExecute, which already released the
+// object; the cgo wrappers make Delete idempotent for exactly this reason.
+func TestResetAfterReleaseIsSafe(t *testing.T) {
+	it := &indexBuildTask{ctx: context.Background()}
+	assert.NotPanics(t, it.Reset)
+
+	at := &analyzeTask{ctx: context.Background()}
+	assert.NotPanics(t, at.Reset)
+}


### PR DESCRIPTION
Cherry-pick from master

pr: #53319
issue: #53317

## Summary

Cherry-picked from master PR #53319 (merged).

`processTask` checks the task context before each pipeline stage, so a cancellation arriving during the blocking `indexcgowrapper.CreateIndex` cgo call is only observed at the gate before `PostExecute` — the only place that calls `Delete()` on the object `Execute` just built. `Reset()` then dropped the last Go reference without freeing the native allocation, leaking a whole built index for the lifetime of the DataNode process.

## Differences from the master diff

Three lines, all forced by 2.6 not carrying master commits; behavior is identical.

- `task_index.go` / `task_analyze.go`: the warn log uses `log.Ctx(ctx).Warn(..., zap.Error(err))` instead of `mlog.Warn(ctx, ..., mlog.Err(err))` — this package still imports `pkg/v2/log` on 2.6; `mlog` does not exist here.
- `task_reset_test.go`: imports `pkg/v2/proto/cgopb` instead of `pkg/v3/proto/cgopb`.

Every other line is byte-identical to the master diff.

## Verification

- [x] File count matches original PR (3 files, +115/-0)
- [x] Diff compared line by line against the master PR — the only differences are the three adaptations above
- [x] No conflict markers
- [x] `go vet -tags dynamic,test ./internal/datanode/index/` — clean (built against 2.6 core headers)
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)