### PR TITLE
fix: [2.6] allow nullable JSON field without binlog when creating json key index

### DIFF
--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -615,12 +615,12 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 		return binlog.GetFieldID()
 	})
 
-	getInsertFiles := func(fieldID int64) ([]string, error) {
+	getInsertFiles := func(fieldID int64, enableNull bool) ([]string, error) {
 		if st.req.GetStorageVersion() == storage.StorageV2 {
 			return []string{}, nil
 		}
 		binlogs, ok := fieldBinlogs[fieldID]
-		if !ok {
+		if !ok && !enableNull {
 			return nil, merr.WrapErrServiceInternalMsg("field binlog not found for field %d", fieldID)
 		}
 		result := make([]string, 0, len(binlogs))
@@ -654,7 +654,7 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 		log.Info("field enable json key index, ready to create json key index", zap.Int64("field id", field.GetFieldID()))
 
 		eg.Go(func() error {
-			files, err := getInsertFiles(field.GetFieldID())
+			files, err := getInsertFiles(field.GetFieldID(), field.GetNullable())
 			if err != nil {
 				return err
 			}

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -370,4 +371,98 @@ func genRowWithBM25(magic int64) map[int64]interface{} {
 
 func getMilvusBirthday() time.Time {
 	return time.Date(2019, time.Month(5), 30, 0, 0, 0, 0, time.UTC)
+}
+
+// nullable JSON may have no insert column binlog; getInsertFiles should allow empty paths (aligned with text index).
+func TestCreateJSONKeyStats_NullableJSONMissingFieldBinlog(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+	mgr.LoadOrStoreStatsTask("c1", 1, &StatsTaskInfo{SegID: 10})
+
+	req := &workerpb.CreateStatsRequest{
+		ClusterID:              "c1",
+		TaskID:                 1,
+		CollectionID:           100,
+		PartitionID:            101,
+		TargetSegmentID:        102,
+		SegmentID:              103,
+		InsertChannel:          "ch",
+		TaskVersion:            1,
+		JsonKeyStatsDataFormat: common.JSONStatsDataFormatVersion,
+		StorageConfig:          &indexpb.StorageConfig{RootPath: "/root"},
+		SubJobType:             indexpb.StatsSubJob_JsonKeyIndexJob,
+		StorageVersion:         1,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "j", DataType: schemapb.DataType_JSON, Nullable: true},
+			},
+		},
+	}
+	ctx2, cancel := context.WithCancel(ctx)
+	defer cancel()
+	st := NewStatsTask(ctx2, cancel, req, mgr, nil, nil)
+
+	insertBinlogs := []*datapb.FieldBinlog{
+		{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 1}}},
+	}
+
+	var gotInsertFiles []string
+	m := mockey.Mock(indexcgowrapper.CreateJSONKeyStats).To(func(_ context.Context, info *indexcgopb.BuildIndexInfo) (*indexcgowrapper.JSONKeyStatsResult, error) {
+		gotInsertFiles = info.InsertFiles
+		return &indexcgowrapper.JSONKeyStatsResult{Files: map[string]int64{}}, nil
+	}).Build()
+	defer m.UnPatch()
+
+	err := st.createJSONKeyStats(ctx, req.GetStorageConfig(),
+		req.GetCollectionID(), req.GetPartitionID(), req.GetTargetSegmentID(),
+		req.GetTaskVersion(), req.GetTaskID(),
+		common.JSONStatsDataFormatVersion,
+		insertBinlogs, 256, 0.3, 81920)
+	require.NoError(t, err)
+	require.Empty(t, gotInsertFiles)
+}
+
+func TestCreateJSONKeyStats_NonNullableJSONMissingFieldBinlog(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+	mgr.LoadOrStoreStatsTask("c1", 2, &StatsTaskInfo{SegID: 10})
+
+	req := &workerpb.CreateStatsRequest{
+		ClusterID:              "c1",
+		TaskID:                 2,
+		CollectionID:           100,
+		PartitionID:            101,
+		TargetSegmentID:        102,
+		SegmentID:              103,
+		InsertChannel:          "ch",
+		TaskVersion:            1,
+		JsonKeyStatsDataFormat: common.JSONStatsDataFormatVersion,
+		StorageConfig:          &indexpb.StorageConfig{RootPath: "/root"},
+		SubJobType:             indexpb.StatsSubJob_JsonKeyIndexJob,
+		StorageVersion:         1,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "j", DataType: schemapb.DataType_JSON, Nullable: false},
+			},
+		},
+	}
+	ctx2, cancel := context.WithCancel(ctx)
+	defer cancel()
+	st := NewStatsTask(ctx2, cancel, req, mgr, nil, nil)
+
+	insertBinlogs := []*datapb.FieldBinlog{
+		{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 1}}},
+	}
+
+	err := st.createJSONKeyStats(ctx, req.GetStorageConfig(),
+		req.GetCollectionID(), req.GetPartitionID(), req.GetTargetSegmentID(),
+		req.GetTaskVersion(), req.GetTaskID(),
+		common.JSONStatsDataFormatVersion,
+		insertBinlogs, 256, 0.3, 81920)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field binlog not found for field 201")
 }


### PR DESCRIPTION
issue: #48650
pr: #48651

Cherry-pick of #48651 (master commit 311fcea79444ed509708b62227a8bb3ae21f4550) to 2.6.

### Problem

When a nullable JSON field is added to a collection after a StorageV1 segment was already flushed, that segment has no insert binlog for the new field. `createJSONKeyStats` on 2.6 still required a binlog for every field with json key stats enabled, so the stats task failed with `field binlog not found for field <id>`. The error is classified as retriable, so DataCoord re-dispatched the task every few seconds forever (observed on an index-pool worker running v2.6.18: field 112 built fine each round, field 116 failed every round).

`createTextIndex` already had the nullable escape from #45317 / #45317's 2.6 backport; `createJSONKeyStats` never got it on 2.6.

### Change

Align `createJSONKeyStats` with `createTextIndex`: when a field is nullable and has no binlog, pass an empty insert file list instead of failing. The 2.6 C++ builder already handles this: `index_c.cpp` writes `INSERT_FILES_KEY` unconditionally (an empty vector keeps the key present) and `JsonKeyStats::Build` goes through `storage::CacheRawDataAndFillMissing`, which fills the missing rows with null based on `NumRows` -- the same helper the 2.6 scalar index builders (`InvertedIndexTantivy`, `BitmapIndex`, `HybridScalarIndex`, ...) use for added-field indexes.

Conflict resolution vs master: kept the 2.6 `StorageV2`-only check (2.6 has no `StorageV3`) and the existing `merr.WrapErrServiceInternalMsg` error.

### Tests

- `TestCreateJSONKeyStats_NullableJSONMissingFieldBinlog`: nullable JSON field with no binlog builds with an empty file list.
- `TestCreateJSONKeyStats_NonNullableJSONMissingFieldBinlog`: non-nullable field still fails with `field binlog not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoUputxuoJteHcXqsqDoRe
