### PR TITLE
enhance: [GoSDK] complete FunctionScore support in Go client

### DIFF
--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/samber/lo"
 )
 
 type FunctionType = schemapb.FunctionType
@@ -77,20 +78,24 @@ func (f *Function) WithType(funcType FunctionType) *Function {
 }
 
 func (f *Function) WithParam(key string, value any) *Function {
-	// Handle slices by converting to JSON format
+	f.Params[key] = paramValueToString(value)
+	return f
+}
+
+// paramValueToString renders a Function/FunctionScore param value on the wire:
+// slices are JSON-encoded, everything else uses its default string form.
+func paramValueToString(value any) string {
 	valueType := reflect.TypeOf(value)
 	if valueType == nil {
-		f.Params[key] = "null"
-	} else if valueType.Kind() == reflect.Slice {
-		if jsonBytes, err := json.Marshal(value); err == nil {
-			f.Params[key] = string(jsonBytes)
-		} else {
-			f.Params[key] = fmt.Sprintf("%v", value)
-		}
-	} else {
-		f.Params[key] = fmt.Sprintf("%v", value)
+		return "null"
 	}
-	return f
+	if valueType.Kind() == reflect.Slice {
+		if jsonBytes, err := json.Marshal(value); err == nil {
+			return string(jsonBytes)
+		}
+		return fmt.Sprintf("%v", value)
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 // ProtoMessage returns corresponding schemapb.FunctionSchema
@@ -122,4 +127,48 @@ func (f *Function) ReadProto(p *schemapb.FunctionSchema) *Function {
 	f.outputFieldIDs = p.GetOutputFieldIds()
 
 	return f
+}
+
+// FunctionScore models the search-time FunctionScore message: a set of scoring
+// Functions (e.g. boost rankers) plus score-option params such as boost_mode
+// and boost_function_mode.
+type FunctionScore struct {
+	Functions []*Function
+	Params    map[string]string
+}
+
+func NewFunctionScore() *FunctionScore {
+	return &FunctionScore{
+		Params: make(map[string]string),
+	}
+}
+
+func (fs *FunctionScore) AddFunction(f *Function) *FunctionScore {
+	fs.Functions = append(fs.Functions, f)
+	return fs
+}
+
+func (fs *FunctionScore) WithParam(key string, value any) *FunctionScore {
+	fs.Params[key] = paramValueToString(value)
+	return fs
+}
+
+// ProtoMessage returns corresponding schemapb.FunctionScore
+func (fs *FunctionScore) ProtoMessage() *schemapb.FunctionScore {
+	r := &schemapb.FunctionScore{
+		Params: MapKvPairs(fs.Params),
+	}
+	for _, f := range fs.Functions {
+		r.Functions = append(r.Functions, f.ProtoMessage())
+	}
+	return r
+}
+
+// ReadProto parses proto FunctionScore
+func (fs *FunctionScore) ReadProto(p *schemapb.FunctionScore) *FunctionScore {
+	fs.Functions = lo.Map(p.GetFunctions(), func(fn *schemapb.FunctionSchema, _ int) *Function {
+		return NewFunction().ReadProto(fn)
+	})
+	fs.Params = KvPairsMap(p.GetParams())
+	return fs
 }

--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/samber/lo"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 type FunctionType = schemapb.FunctionType
@@ -131,7 +132,7 @@ func (f *Function) ReadProto(p *schemapb.FunctionSchema) *Function {
 
 // FunctionScore models the search-time FunctionScore message: a set of scoring
 // Functions (e.g. boost rankers) plus score-option params such as boost_mode
-// and boost_function_mode.
+// and function_mode.
 type FunctionScore struct {
 	Functions []*Function
 	Params    map[string]string
@@ -151,6 +152,38 @@ func (fs *FunctionScore) AddFunction(f *Function) *FunctionScore {
 func (fs *FunctionScore) WithParam(key string, value any) *FunctionScore {
 	fs.Params[key] = paramValueToString(value)
 	return fs
+}
+
+// Clone returns a deep copy of fs: functions and params are copied so the
+// returned score does not share mutable state with the source.
+func (fs *FunctionScore) Clone() *FunctionScore {
+	nf := NewFunctionScore()
+	for _, f := range fs.Functions {
+		nf.AddFunction(f.Clone())
+	}
+	for k, v := range fs.Params {
+		nf.Params[k] = v
+	}
+	return nf
+}
+
+// Clone returns a deep copy of f.
+func (f *Function) Clone() *Function {
+	nf := &Function{
+		Name:             f.Name,
+		Description:      f.Description,
+		Type:             f.Type,
+		InputFieldNames:  append([]string(nil), f.InputFieldNames...),
+		OutputFieldNames: append([]string(nil), f.OutputFieldNames...),
+		Params:           make(map[string]string, len(f.Params)),
+		id:               f.id,
+		inputFieldIDs:    append([]int64(nil), f.inputFieldIDs...),
+		outputFieldIDs:   append([]int64(nil), f.outputFieldIDs...),
+	}
+	for k, v := range f.Params {
+		nf.Params[k] = v
+	}
+	return nf
 }
 
 // ProtoMessage returns corresponding schemapb.FunctionScore

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -115,3 +115,23 @@ func TestFunctionScoreSchema(t *testing.T) {
 		assert.Equal(t, fn.Params, nf.Functions[i].Params)
 	}
 }
+
+func TestFunctionScoreClone(t *testing.T) {
+	fs := NewFunctionScore().
+		AddFunction(NewFunction().WithName("boost").WithType(FunctionTypeRerank).
+			WithParam("reranker", "boost").WithParam("weight", 2.0)).
+		WithParam("boost_mode", "sum")
+
+	clone := fs.Clone()
+	assert.Equal(t, fs, clone)
+
+	fs.AddFunction(NewFunction().WithName("second"))
+	assert.Len(t, clone.Functions, 1, "clone must not share the source Functions slice")
+
+	clone.AddFunction(NewFunction().WithName("clone_only"))
+	assert.Len(t, fs.Functions, 2, "source must not see functions added to the clone")
+
+	fs.WithParam("function_mode", "multiply")
+	_, ok := clone.Params["function_mode"]
+	assert.False(t, ok, "clone must not share the source Params map")
+}

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -80,3 +80,38 @@ func TestFunctionWithParamSliceHandling(t *testing.T) {
 	f = NewFunction().WithParam("string_key", "string_value")
 	assert.Equal(t, "string_value", f.Params["string_key"])
 }
+
+func TestFunctionScoreSchema(t *testing.T) {
+	boostFn := NewFunction().
+		WithName("title_boost").
+		WithType(FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("filter", "text_match(title, \"ai\")").
+		WithParam("weight", 2.0)
+	weightedFn := NewFunction().
+		WithName("recency_boost").
+		WithType(FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 1.5)
+
+	fs := NewFunctionScore().
+		AddFunction(boostFn).
+		AddFunction(weightedFn).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
+
+	proto := fs.ProtoMessage()
+	assert.Len(t, proto.GetFunctions(), 2)
+	assert.Equal(t, map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, KvPairsMap(proto.GetParams()))
+	assert.Equal(t, boostFn.Params, KvPairsMap(proto.GetFunctions()[0].GetParams()))
+	assert.Equal(t, weightedFn.Params, KvPairsMap(proto.GetFunctions()[1].GetParams()))
+
+	nf := NewFunctionScore().ReadProto(proto)
+	assert.Equal(t, fs.Params, nf.Params)
+	assert.Len(t, nf.Functions, 2)
+	for i, fn := range fs.Functions {
+		assert.Equal(t, fn.Name, nf.Functions[i].Name)
+		assert.Equal(t, fn.Type, nf.Functions[i].Type)
+		assert.Equal(t, fn.Params, nf.Functions[i].Params)
+	}
+}

--- a/client/milvusclient/read_example_test.go
+++ b/client/milvusclient/read_example_test.go
@@ -523,19 +523,29 @@ func ExampleClient_Search_textMatch() {
 	q := "artificial intelligence"
 	expr := "text_match(" + titleField + ", \"" + q + "\", minimum_should_match=2) OR text_match(" + textField + ", \"" + q + "\", minimum_should_match=2)"
 
-	boost := entity.NewFunction().
+	titleBoost := entity.NewFunction().
 		WithName("title_boost").
 		WithType(entity.FunctionTypeRerank).
 		WithParam("reranker", "boost").
 		WithParam("filter", "text_match("+titleField+", \""+q+"\", minimum_should_match=2)").
 		WithParam("weight", "2.0")
+	textBoost := entity.NewFunction().
+		WithName("text_boost").
+		WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", "1.5")
+	functionScore := entity.NewFunctionScore().
+		AddFunction(titleBoost).
+		AddFunction(textBoost).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
 
 	vectors := []entity.Vector{entity.Text(q)}
 	rs, err := cli.Search(ctx, milvusclient.NewSearchOption(collectionName, 5, vectors).
 		WithANNSField(textSparse).
 		WithFilter(expr).
 		WithOutputFields("id", titleField, textField).
-		WithFunctionReranker(boost))
+		WithFunctionScore(functionScore))
 	if err != nil {
 		log.Fatal("failed to search: ", err.Error())
 	}

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -170,6 +170,50 @@ func (s *SearchOptionSuite) TestFunctionScore() {
 		s.Require().NoError(err)
 		s.Nil(req.GetFunctionScore())
 	})
+
+	s.Run("shared_score_not_aliased", func() {
+		shared := entity.NewFunctionScore().
+			AddFunction(boostFn1).
+			WithParam("boost_mode", "sum")
+
+		optA := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(shared)
+		optB := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(shared)
+
+		// mutating the shared score after building options must not leak into them
+		shared.AddFunction(boostFn2)
+		shared.WithParam("function_mode", "multiply")
+
+		reqA, err := optA.Request()
+		s.Require().NoError(err)
+		fsA := reqA.GetFunctionScore()
+		s.Len(fsA.GetFunctions(), 1, "options must not accumulate functions from a shared score")
+		s.Equal(map[string]string{"boost_mode": "sum"}, entity.KvPairsMap(fsA.GetParams()))
+
+		reqB, err := optB.Request()
+		s.Require().NoError(err)
+		s.Len(reqB.GetFunctionScore().GetFunctions(), 1)
+	})
+
+	s.Run("empty_score_errors", func() {
+		empty := entity.NewFunctionScore().WithParam("boost_mode", "sum")
+
+		_, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(empty).
+			Request()
+		s.Error(err)
+		s.Contains(err.Error(), "no functions")
+
+		_, err = NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(empty).
+			HybridRequest()
+		s.Error(err)
+		s.Contains(err.Error(), "no functions")
+	})
 }
 
 func (s *SearchOptionSuite) TestWithNamespace() {

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -214,6 +214,22 @@ func (s *SearchOptionSuite) TestFunctionScore() {
 		s.Error(err)
 		s.Contains(err.Error(), "no functions")
 	})
+
+	s.Run("nil_score_noop", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionReranker(boostFn1).
+			WithFunctionScore(nil).
+			Request()
+		s.Require().NoError(err)
+		s.Nil(req.GetFunctionScore(), "nil score must clear any accumulated functions")
+
+		hybridReq, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(nil).
+			HybridRequest()
+		s.Require().NoError(err)
+		s.Nil(hybridReq.GetFunctionScore())
+	})
 }
 
 func (s *SearchOptionSuite) TestWithNamespace() {

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -90,6 +90,88 @@ func (s *SearchOptionSuite) TestBasic() {
 	s.Error(err)
 }
 
+func (s *SearchOptionSuite) TestFunctionScore() {
+	collName := "search_opt_function_score"
+	topK := 10
+
+	boostFn1 := entity.NewFunction().WithName("boost1").WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 2.0).
+		WithParam("filter", "int64_field > 0")
+	boostFn2 := entity.NewFunction().WithName("boost2").WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 0.5)
+
+	score := entity.NewFunctionScore().
+		AddFunction(boostFn1).
+		AddFunction(boostFn2).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
+
+	s.Run("search", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(score).
+			Request()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Equal(map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, entity.KvPairsMap(fs.GetParams()))
+		s.Equal("boost", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["reranker"])
+		s.Equal("2", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["weight"])
+		s.Equal("int64_field > 0", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["filter"])
+	})
+
+	s.Run("search_with_function_reranker_appends", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionReranker(boostFn1).
+			WithFunctionReranker(boostFn2).
+			Request()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Empty(fs.GetParams())
+	})
+
+	s.Run("hybrid_search", func() {
+		req, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(score).
+			HybridRequest()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Equal(map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, entity.KvPairsMap(fs.GetParams()))
+	})
+
+	s.Run("hybrid_search_with_function_rerankers_appends", func() {
+		req, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionRerankers(boostFn1).
+			WithFunctionRerankers(boostFn2).
+			HybridRequest()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Empty(fs.GetParams())
+	})
+
+	s.Run("no_function_score", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			Request()
+		s.Require().NoError(err)
+		s.Nil(req.GetFunctionScore())
+	})
+}
+
 func (s *SearchOptionSuite) TestWithNamespace() {
 	collName := "namespace_read_option"
 	namespace := "tenant_a"

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -84,7 +84,7 @@ type AnnRequest struct {
 	offset          int
 	templateParams  map[string]any
 
-	functionRerankers []*entity.Function
+	functionScore *entity.FunctionScore
 }
 
 func NewAnnRequest(annField string, limit int, vectors ...entity.Vector) *AnnRequest {
@@ -173,11 +173,8 @@ func (r *AnnRequest) searchRequest() (*milvuspb.SearchRequest, error) {
 		request.ExprTemplateValues[key] = tmplVal
 	}
 
-	if len(r.functionRerankers) > 0 {
-		request.FunctionScore = &schemapb.FunctionScore{}
-		for _, fr := range r.functionRerankers {
-			request.FunctionScore.Functions = append(request.FunctionScore.Functions, fr.ProtoMessage())
-		}
+	if r.functionScore != nil {
+		request.FunctionScore = r.functionScore.ProtoMessage()
 	}
 
 	return request, nil
@@ -372,7 +369,18 @@ func (r *AnnRequest) WithIgnoreGrowing(ignoreGrowing bool) *AnnRequest {
 }
 
 func (r *AnnRequest) WithFunctionReranker(fr *entity.Function) *AnnRequest {
-	r.functionRerankers = append(r.functionRerankers, fr)
+	if r.functionScore == nil {
+		r.functionScore = entity.NewFunctionScore()
+	}
+	r.functionScore.AddFunction(fr)
+	return r
+}
+
+// WithFunctionScore sets the search FunctionScore (functions plus score
+// options such as boost_mode / boost_function_mode). It replaces any
+// functions accumulated via WithFunctionReranker.
+func (r *AnnRequest) WithFunctionScore(fs *entity.FunctionScore) *AnnRequest {
+	r.functionScore = fs
 	return r
 }
 
@@ -508,6 +516,11 @@ func (opt *searchOption) WithFunctionReranker(fr *entity.Function) *searchOption
 	return opt
 }
 
+func (opt *searchOption) WithFunctionScore(fs *entity.FunctionScore) *searchOption {
+	opt.annRequest.WithFunctionScore(fs)
+	return opt
+}
+
 // NewSearchOption creates a new search option for traditional vector search.
 // Provide the query vectors to search for similar vectors in the collection.
 // For search by primary key IDs, use NewSearchByIDsOption instead.
@@ -606,7 +619,7 @@ type hybridSearchOption struct {
 	limit             int
 	offset            int
 	reranker          Reranker
-	functionRerankers []*entity.Function
+	functionScore     *entity.FunctionScore
 }
 
 func (opt *hybridSearchOption) WithConsistencyLevel(cl entity.ConsistencyLevel) *hybridSearchOption {
@@ -641,7 +654,18 @@ func (opt *hybridSearchOption) WithReranker(reranker Reranker) *hybridSearchOpti
 }
 
 func (opt *hybridSearchOption) WithFunctionRerankers(functionReranker *entity.Function) *hybridSearchOption {
-	opt.functionRerankers = append(opt.functionRerankers, functionReranker)
+	if opt.functionScore == nil {
+		opt.functionScore = entity.NewFunctionScore()
+	}
+	opt.functionScore.AddFunction(functionReranker)
+	return opt
+}
+
+// WithFunctionScore sets the search FunctionScore (functions plus score
+// options such as boost_mode / boost_function_mode). It replaces any
+// functions accumulated via WithFunctionRerankers.
+func (opt *hybridSearchOption) WithFunctionScore(fs *entity.FunctionScore) *hybridSearchOption {
+	opt.functionScore = fs
 	return opt
 }
 
@@ -680,11 +704,8 @@ func (opt *hybridSearchOption) HybridRequest() (*milvuspb.HybridSearchRequest, e
 		RankParams:            params,
 	}
 
-	if len(opt.functionRerankers) > 0 {
-		r.FunctionScore = &schemapb.FunctionScore{}
-		for _, fr := range opt.functionRerankers {
-			r.FunctionScore.Functions = append(r.FunctionScore.Functions, fr.ProtoMessage())
-		}
+	if opt.functionScore != nil {
+		r.FunctionScore = opt.functionScore.ProtoMessage()
 	}
 
 	return r, nil

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -174,6 +174,9 @@ func (r *AnnRequest) searchRequest() (*milvuspb.SearchRequest, error) {
 	}
 
 	if r.functionScore != nil {
+		if len(r.functionScore.Functions) == 0 {
+			return nil, errors.New("FunctionScore has no functions")
+		}
 		request.FunctionScore = r.functionScore.ProtoMessage()
 	}
 
@@ -368,6 +371,12 @@ func (r *AnnRequest) WithIgnoreGrowing(ignoreGrowing bool) *AnnRequest {
 	return r
 }
 
+// WithFunctionReranker adds a scoring Function to the request. On a hybrid
+// search the score is attached to this sub-request and applied to this leg on
+// the server (server support for per-sub-request FunctionScore is in flight,
+// see https://github.com/milvus-io/milvus/issues/52956); to apply the same
+// score to every leg today, use HybridSearchOption.WithFunctionRerankers or
+// HybridSearchOption.WithFunctionScore instead.
 func (r *AnnRequest) WithFunctionReranker(fr *entity.Function) *AnnRequest {
 	if r.functionScore == nil {
 		r.functionScore = entity.NewFunctionScore()
@@ -377,10 +386,11 @@ func (r *AnnRequest) WithFunctionReranker(fr *entity.Function) *AnnRequest {
 }
 
 // WithFunctionScore sets the search FunctionScore (functions plus score
-// options such as boost_mode / boost_function_mode). It replaces any
-// functions accumulated via WithFunctionReranker.
+// options such as boost_mode / function_mode). It replaces any functions
+// accumulated via WithFunctionReranker, and stores a copy so the caller's
+// FunctionScore is never mutated or shared with other options.
 func (r *AnnRequest) WithFunctionScore(fs *entity.FunctionScore) *AnnRequest {
-	r.functionScore = fs
+	r.functionScore = fs.Clone()
 	return r
 }
 
@@ -616,10 +626,10 @@ type hybridSearchOption struct {
 	useDefaultConsistency bool
 	consistencyLevel      entity.ConsistencyLevel
 
-	limit             int
-	offset            int
-	reranker          Reranker
-	functionScore     *entity.FunctionScore
+	limit         int
+	offset        int
+	reranker      Reranker
+	functionScore *entity.FunctionScore
 }
 
 func (opt *hybridSearchOption) WithConsistencyLevel(cl entity.ConsistencyLevel) *hybridSearchOption {
@@ -653,6 +663,10 @@ func (opt *hybridSearchOption) WithReranker(reranker Reranker) *hybridSearchOpti
 	return opt
 }
 
+// WithFunctionRerankers adds a scoring Function applied to every leg of the
+// hybrid search on the server. For per-sub-request scores (server support in
+// flight, see https://github.com/milvus-io/milvus/issues/52956), attach the
+// Function to the sub-request's AnnRequest instead.
 func (opt *hybridSearchOption) WithFunctionRerankers(functionReranker *entity.Function) *hybridSearchOption {
 	if opt.functionScore == nil {
 		opt.functionScore = entity.NewFunctionScore()
@@ -662,10 +676,11 @@ func (opt *hybridSearchOption) WithFunctionRerankers(functionReranker *entity.Fu
 }
 
 // WithFunctionScore sets the search FunctionScore (functions plus score
-// options such as boost_mode / boost_function_mode). It replaces any
-// functions accumulated via WithFunctionRerankers.
+// options such as boost_mode / function_mode). It replaces any functions
+// accumulated via WithFunctionRerankers, and stores a copy so the caller's
+// FunctionScore is never mutated or shared with other options.
 func (opt *hybridSearchOption) WithFunctionScore(fs *entity.FunctionScore) *hybridSearchOption {
-	opt.functionScore = fs
+	opt.functionScore = fs.Clone()
 	return opt
 }
 
@@ -705,6 +720,9 @@ func (opt *hybridSearchOption) HybridRequest() (*milvuspb.HybridSearchRequest, e
 	}
 
 	if opt.functionScore != nil {
+		if len(opt.functionScore.Functions) == 0 {
+			return nil, errors.New("FunctionScore has no functions")
+		}
 		r.FunctionScore = opt.functionScore.ProtoMessage()
 	}
 

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -390,6 +390,10 @@ func (r *AnnRequest) WithFunctionReranker(fr *entity.Function) *AnnRequest {
 // accumulated via WithFunctionReranker, and stores a copy so the caller's
 // FunctionScore is never mutated or shared with other options.
 func (r *AnnRequest) WithFunctionScore(fs *entity.FunctionScore) *AnnRequest {
+	if fs == nil {
+		r.functionScore = nil
+		return r
+	}
 	r.functionScore = fs.Clone()
 	return r
 }
@@ -680,6 +684,10 @@ func (opt *hybridSearchOption) WithFunctionRerankers(functionReranker *entity.Fu
 // accumulated via WithFunctionRerankers, and stores a copy so the caller's
 // FunctionScore is never mutated or shared with other options.
 func (opt *hybridSearchOption) WithFunctionScore(fs *entity.FunctionScore) *hybridSearchOption {
+	if fs == nil {
+		opt.functionScore = nil
+		return opt
+	}
 	opt.functionScore = fs.Clone()
 	return opt
 }


### PR DESCRIPTION
Add entity.FunctionScore carrying both functions and score-option params (boost_mode / function_mode), and expose it on SearchOption and HybridSearchOption via WithFunctionScore. The client previously serialized only FunctionScore.functions, so the combination modes of the boost scorer were not expressible.

Keep WithFunctionReranker/WithFunctionRerankers append semantics by lazily building the score, leaving existing callers unaffected.

issue: #45235