### PR TITLE
fix: [cp2.6]allow absent nullable vector binlogs in StorageV2 binlog import

### DIFF
--- a/internal/util/importutilv2/binlog/util.go
+++ b/internal/util/importutilv2/binlog/util.go
@@ -153,7 +153,12 @@ func verify(schema *schemapb.CollectionSchema, storageVersion int64, insertLogs 
 		for _, field := range allFields {
 			if typeutil.IsVectorType(field.GetDataType()) {
 				if _, ok := insertLogs[field.GetFieldID()]; !ok {
-					// vector field must be provided
+					// A nullable vector field has no column group in segments flushed
+					// before it was added via AddCollectionField; the packed reader
+					// fills the absent column with nulls. Other vector fields must be provided.
+					if field.GetNullable() {
+						continue
+					}
 					return nil, nil, merr.WrapErrImportFailedMsg("no binlog for field:%s", field.GetName())
 				}
 			}

--- a/internal/util/importutilv2/binlog/util_test.go
+++ b/internal/util/importutilv2/binlog/util_test.go
@@ -18,14 +18,17 @@ package binlog
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -122,4 +125,39 @@ func TestListInsertLogs_ParseFieldIDError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, merr.ErrImportSysFailed), "parse-field-id IO error must be wrapped as a server-side import failure")
+}
+
+// TestVerify_StorageV2_NullableVectorOptional pins that a nullable vector field
+// without a column group (added via AddCollectionField after the segment was
+// flushed) is accepted by the StorageV2 branch, while a non-nullable vector
+// field without binlogs is still rejected.
+func TestVerify_StorageV2_NullableVectorOptional(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector},
+			{FieldID: 102, Name: "added_sparse", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+			{FieldID: 103, Name: "added_scalar", DataType: schemapb.DataType_Int64, Nullable: true},
+		},
+	}
+	genLogs := func(fieldIDs ...int64) map[int64][]string {
+		logs := make(map[int64][]string, len(fieldIDs))
+		for _, id := range fieldIDs {
+			logs[id] = []string{fmt.Sprintf("insert_log/1/2/3/%d/1", id)}
+		}
+		return logs
+	}
+
+	for _, version := range []int64{storage.StorageV2} {
+		// nullable vector column group absent: accepted, schema and logs passed through unchanged
+		logs := genLogs(storagecommon.DefaultShortColumnGroupID, 101)
+		gotLogs, gotSchema, err := verify(schema, version, logs)
+		assert.NoError(t, err, "version %d", version)
+		assert.Equal(t, logs, gotLogs)
+		assert.Equal(t, schema, gotSchema)
+
+		// non-nullable vector column group absent: still rejected
+		_, _, err = verify(schema, version, genLogs(storagecommon.DefaultShortColumnGroupID, 102))
+		assert.ErrorContains(t, err, "no binlog for field:vec", "version %d", version)
+	}
 }


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #53362
issue: #53361

## Summary

Cherry-picked from master PR #53362 (open - preemptive backport). 2.6 has no StorageV3; the test covers StorageV2 only.

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR
- [x] Code changes verified line-by-line against the master PR
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)