### PR TITLE
fix: tolerate transient etcd leader-election errors during startup

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -435,12 +435,15 @@ func (mr *MilvusRoles) Run() {
 		params := paramtable.Get()
 		if params.EtcdCfg.UseEmbedEtcd.GetAsBool() {
 			// Start etcd server.
-			etcd.InitEtcdServer(
+			if err := etcd.InitEtcdServer(
 				params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
 				params.EtcdCfg.ConfigPath.GetValue(),
 				params.EtcdCfg.DataDir.GetValue(),
 				params.EtcdCfg.EtcdLogPath.GetValue(),
-				params.EtcdCfg.EtcdLogLevel.GetValue())
+				params.EtcdCfg.EtcdLogLevel.GetValue()); err != nil {
+				mlog.Error(context.TODO(), "failed to start embedded Etcd server", mlog.Err(err))
+				return
+			}
 			defer etcd.StopEtcdServer()
 		}
 		paramtable.SetRole(typeutil.StandaloneRole)

--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -441,8 +441,11 @@ func (mr *MilvusRoles) Run() {
 				params.EtcdCfg.DataDir.GetValue(),
 				params.EtcdCfg.EtcdLogPath.GetValue(),
 				params.EtcdCfg.EtcdLogLevel.GetValue()); err != nil {
+				// Panic (non-zero exit) so restart policies such as systemd
+				// Restart=on-failure or docker --restart on-failure treat the
+				// startup failure as a crash rather than a clean exit.
 				mlog.Error(context.TODO(), "failed to start embedded Etcd server", mlog.Err(err))
-				return
+				panic(err)
 			}
 			defer etcd.StopEtcdServer()
 		}

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -400,7 +400,16 @@ func (s *Session) getServerID() (int64, error) {
 			return nodeID, nil
 		}
 	}
-	nodeID, err := s.getServerIDWithKey(DefaultIDKey)
+	var nodeID int64
+	// Embedded etcd may still be electing its leader when session
+	// initialization starts. A transient leader-election error (e.g.
+	// "etcdserver: leader changed") must be retried with backoff rather than
+	// propagated to Init, which would panic and terminate the whole process.
+	err := retry.Do(s.ctx, func() error {
+		var err error
+		nodeID, err = s.getServerIDWithKey(DefaultIDKey)
+		return err
+	}, retry.Attempts(uint(s.sessionRetryTimes)), retry.RetryErr(etcd.IsRetriableEtcdErr))
 	if err != nil {
 		return nodeID, err
 	}

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -317,7 +317,6 @@ func (s *Session) Init(serverName, address string, exclusive bool) {
 	s.ServerName = serverName
 	s.Address = address
 	s.Exclusive = exclusive
-	s.checkIDExist()
 	serverID, err := s.getServerID()
 	if err != nil {
 		panic(err)
@@ -406,6 +405,13 @@ func (s *Session) getServerID() (int64, error) {
 	// "etcdserver: leader changed") must be retried with backoff rather than
 	// propagated to Init, which would panic and terminate the whole process.
 	err := retry.Do(s.ctx, func() error {
+		// Ensure the ID key exists inside the retry loop: if its creation
+		// txn failed with a transient error, the key stays absent and
+		// getServerIDWithKey would spin on "no value" forever without
+		// returning an error.
+		if err := s.checkIDExist(); err != nil {
+			return err
+		}
 		var err error
 		nodeID, err = s.getServerIDWithKey(DefaultIDKey)
 		return err
@@ -419,13 +425,14 @@ func (s *Session) getServerID() (int64, error) {
 	return nodeID, nil
 }
 
-func (s *Session) checkIDExist() {
-	s.etcdCli.Txn(s.ctx).If(
+func (s *Session) checkIDExist() error {
+	_, err := s.etcdCli.Txn(s.ctx).If(
 		clientv3.Compare(
 			clientv3.Version(path.Join(s.metaRoot, DefaultServiceRoot, DefaultIDKey)),
 			"=",
 			0)).
 		Then(clientv3.OpPut(path.Join(s.metaRoot, DefaultServiceRoot, DefaultIDKey), "1")).Commit()
+	return err
 }
 
 func (s *Session) getServerIDWithKey(key string) (int64, error) {

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -53,7 +53,6 @@ func TestGetServerIDConcurrently(t *testing.T) {
 	res := make([]int64, 0)
 
 	getIDFunc := func() {
-		s.checkIDExist()
 		id, err := s.getServerID()
 		assert.NoError(t, err)
 		muList.Lock()

--- a/pkg/util/etcd/etcd_server.go
+++ b/pkg/util/etcd/etcd_server.go
@@ -3,12 +3,14 @@ package etcd
 import (
 	"context"
 	"sync"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EtcdServer is the singleton of embedded etcd server
@@ -53,8 +55,20 @@ func InitEtcdServer(
 			if err != nil {
 				mlog.Error(context.TODO(), "failed to init embedded Etcd server", mlog.Err(err))
 				initError = err
+				return
 			}
 			etcdServer = e
+			// embed.StartEtcd returns once the server is serving traffic, but a
+			// single-member cluster has not necessarily elected itself leader
+			// yet. Wait until etcd is ready (leader elected + member published)
+			// before returning, otherwise components starting right after would
+			// race the leader election and hit transient "etcdserver: leader
+			// changed" errors during session initialization.
+			if err := waitEtcdServerReady(e); err != nil {
+				mlog.Error(context.TODO(), "embedded Etcd server failed to become ready", mlog.Err(err))
+				initError = err
+				return
+			}
 			mlog.Info(context.TODO(), "finish init Etcd config", mlog.String("path", path), mlog.String("data", dataDir))
 		})
 		return initError
@@ -64,6 +78,20 @@ func InitEtcdServer(
 
 func HasServer() bool {
 	return etcdServer != nil
+}
+
+// waitEtcdServerReady blocks until the embedded etcd server has elected a
+// leader and published its member, i.e. it can serve linearizable requests.
+// embed.StartEtcd returns as soon as the server is serving traffic, which for
+// a single-member cluster happens before the leader election completes.
+func waitEtcdServerReady(e *embed.Etcd) error {
+	select {
+	case <-e.Server.ReadyNotify():
+		return nil
+	case <-time.After(60 * time.Second):
+		e.Server.Stop()
+		return merr.WrapErrServiceInternalMsg("embedded etcd took too long to become ready")
+	}
 }
 
 // StopEtcdServer stops embedded etcd server singleton.

--- a/pkg/util/etcd/etcd_server.go
+++ b/pkg/util/etcd/etcd_server.go
@@ -18,10 +18,18 @@ var (
 	initOnce   sync.Once
 	closeOnce  sync.Once
 	etcdServer *embed.Etcd
+	// initError records the singleton's first initialization result. It is a
+	// package-level variable on purpose: sync.Once never re-runs the init
+	// closure, so a later InitEtcdServer call must still observe the failure
+	// (otherwise it would return nil while etcdServer is nil).
+	initError error
 )
 
 // GetEmbedEtcdClient returns client of embed etcd server
 func GetEmbedEtcdClient() (*clientv3.Client, error) {
+	if etcdServer == nil {
+		return nil, merr.WrapErrServiceUnavailableMsg("embedded etcd server is not initialized")
+	}
 	client := v3client.New(etcdServer.Server)
 	return client, nil
 }
@@ -35,7 +43,6 @@ func InitEtcdServer(
 	logLevel string,
 ) error {
 	if useEmbedEtcd {
-		var initError error
 		initOnce.Do(func() {
 			path := configPath
 			var cfg *embed.Config

--- a/pkg/util/etcd/etcd_server.go
+++ b/pkg/util/etcd/etcd_server.go
@@ -100,7 +100,11 @@ func waitEtcdServerReady(e *embed.Etcd) error {
 	case <-e.Server.ReadyNotify():
 		return nil
 	case <-time.After(60 * time.Second):
-		e.Server.Stop()
+		// Close releases the client/peer listeners (2379/2380) in addition to
+		// stopping the server (Close already stops the server internally), so
+		// the ports are freed even if the process keeps running (e.g. the
+		// cmd/embedded export path).
+		e.Close()
 		return merr.WrapErrServiceInternalMsg("embedded etcd took too long to become ready")
 	}
 }

--- a/pkg/util/etcd/etcd_server.go
+++ b/pkg/util/etcd/etcd_server.go
@@ -43,6 +43,7 @@ func InitEtcdServer(
 				cfgFromFile, err := embed.ConfigFromFile(path)
 				if err != nil {
 					initError = err
+					return
 				}
 				cfg = cfgFromFile
 			} else {
@@ -57,7 +58,6 @@ func InitEtcdServer(
 				initError = err
 				return
 			}
-			etcdServer = e
 			// embed.StartEtcd returns once the server is serving traffic, but a
 			// single-member cluster has not necessarily elected itself leader
 			// yet. Wait until etcd is ready (leader elected + member published)
@@ -69,6 +69,10 @@ func InitEtcdServer(
 				initError = err
 				return
 			}
+			// Only publish the singleton after etcd is fully ready. Assigning it
+			// earlier would leave HasServer()/GetEmbedEtcdClient() pointing at a
+			// stopped server if the readiness wait times out.
+			etcdServer = e
 			mlog.Info(context.TODO(), "finish init Etcd config", mlog.String("path", path), mlog.String("data", dataDir))
 		})
 		return initError

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -31,6 +31,8 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -73,6 +75,41 @@ func IsRetriableWatchErr(err error) bool {
 		errors.Is(err, rpctypes.ErrInvalidAuthToken) ||
 		errors.Is(err, rpctypes.ErrUserEmpty) ||
 		errors.Is(err, rpctypes.ErrAuthOldRevision)
+}
+
+// IsRetriableEtcdErr reports whether an etcd error is transient and safe to
+// retry the same request against.
+//
+// It returns true for the leader-election / availability errors a single-node
+// embedded etcd returns while it is still electing its leader during startup
+// (e.g. "etcdserver: leader changed", "etcdserver: no leader", the various
+// request-timeout sentinels) as well as a generic gRPC Unavailable (no
+// connection established yet). These are the errors that Session.Init /
+// Session.Register can legitimately observe during a cold start and should
+// backoff-and-retry rather than treat as fatal.
+//
+// Genuine authorization failures, permission denials, data loss (corrupt
+// cluster) and other non-transient errors carry different codes and are
+// deliberately NOT retriable.
+func IsRetriableEtcdErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Context cancellation / deadline is a terminal condition, never retried.
+	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+		return false
+	}
+	return errors.Is(err, rpctypes.ErrLeaderChanged) ||
+		errors.Is(err, rpctypes.ErrNoLeader) ||
+		errors.Is(err, rpctypes.ErrNotLeader) ||
+		errors.Is(err, rpctypes.ErrNotCapable) ||
+		errors.Is(err, rpctypes.ErrTimeout) ||
+		errors.Is(err, rpctypes.ErrTimeoutDueToLeaderFail) ||
+		errors.Is(err, rpctypes.ErrTimeoutDueToConnectionLost) ||
+		errors.Is(err, rpctypes.ErrTimeoutWaitAppliedIndex) ||
+		errors.Is(err, rpctypes.ErrUnhealthy) ||
+		errors.Is(err, rpctypes.ErrClusterVersionUnavailable) ||
+		status.Code(err) == codes.Unavailable
 }
 
 type ClientOption func(*clientv3.Config)

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -58,6 +58,37 @@ func TestIsRetriableWatchErr(t *testing.T) {
 	}
 }
 
+func TestIsRetriableEtcdErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"leader changed", rpctypes.ErrLeaderChanged, true},
+		{"no leader", rpctypes.ErrNoLeader, true},
+		{"not leader", rpctypes.ErrNotLeader, true},
+		{"not capable", rpctypes.ErrNotCapable, true},
+		{"timeout", rpctypes.ErrTimeout, true},
+		{"timeout due to leader fail", rpctypes.ErrTimeoutDueToLeaderFail, true},
+		{"timeout due to connection lost", rpctypes.ErrTimeoutDueToConnectionLost, true},
+		{"timeout wait applied index", rpctypes.ErrTimeoutWaitAppliedIndex, true},
+		{"unhealthy", rpctypes.ErrUnhealthy, true},
+		{"raw grpc unavailable", status.Error(codes.Unavailable, "connection refused"), true},
+		{"wrapped leader changed", errors.Wrap(rpctypes.ErrLeaderChanged, "get key failed"), true},
+		{"permission denied", rpctypes.ErrPermissionDenied, false},
+		{"corrupt cluster", rpctypes.ErrCorrupt, false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline exceeded", context.DeadlineExceeded, false},
+		{"generic error", errors.New("some other error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, IsRetriableEtcdErr(c.err))
+		})
+	}
+}
+
 // freePort grabs a random unused TCP port. There's a small TOCTOU window
 // between Close and the subsequent bind, but for unit tests it's acceptable.
 func freePort(t *testing.T) int {


### PR DESCRIPTION
## What this PR does / why we need it

Milvus standalone with embedded etcd can panic during startup with `panic: etcdserver: leader changed`.

A single-node embedded etcd starts serving traffic before it has elected itself leader. `Session.Init` could run inside that election window; its `getServerID` etcd `Get` then returns a transient `etcdserver: leader changed`, which `Init` treats as fatal via `panic(err)`, terminating the whole process.

## Changes

- `pkg/util/etcd/etcd_server.go`: wait for `Etcd.Server.ReadyNotify()` (leader elected + member published) in `InitEtcdServer` so components only start after etcd is truly ready.
- `pkg/util/etcd/etcd_util.go`: add `IsRetriableEtcdErr` to classify transient leader-election / availability errors (leader changed, no leader, request-timeout sentinels, gRPC Unavailable).
- `internal/util/sessionutil/session_util.go`: retry `getServerID` on retriable transient etcd errors with bounded backoff instead of failing fast (`Register` already retries; `Init` was the gap).
- `pkg/util/etcd/etcd_util_test.go`: table-driven tests for `IsRetriableEtcdErr`.

issue: #53144
