### PR TITLE
fix: make async load compile on macOS

### DIFF
--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -959,7 +959,8 @@ TYPED_TEST_P(HybridIndexTestInverted,
         index_size += 1024;
     }
     auto stream_overhead = static_cast<uint64_t>(milvus::SaturatingMultiply(
-        index_size, storage::kFileStreamBufferMultiplier));
+        index_size,
+        static_cast<uint64_t>(storage::kFileStreamBufferMultiplier)));
     auto bounded_stream_overhead = storage::EntryStreamMaxTransientBytes(
         stream_overhead, max_task_transient_bytes);
     ASSERT_GT(stream_overhead, bounded_stream_overhead);

--- a/internal/core/src/storage/LoadAdmissionController.cpp
+++ b/internal/core/src/storage/LoadAdmissionController.cpp
@@ -84,11 +84,11 @@ LoadAdmissionController::AcquireAsync(
     }
     if (cancelled) {
         promise.trySetException(folly::OperationCancelled{});
-        return future;
+        return std::move(future);
     }
     if (admitted) {
         promise.trySetValue(LoadAdmissionLease(this, request));
-        return future;
+        return std::move(future);
     }
 
     // The returned future has not escaped yet, so only the explicit token
@@ -128,7 +128,7 @@ LoadAdmissionController::AcquireAsync(
     if (admitted) {
         FulfillAdmission(std::move(pending));
     }
-    return future;
+    return std::move(future);
 }
 
 void


### PR DESCRIPTION
issue: #53369

## What this PR does

Fix two macOS compilation failures introduced by the async Storage V3 loading changes:

- Explicitly move the `folly::coro::Future` extracted through structured binding at each return site.
- Cast the stream buffer multiplier to `uint64_t` where the test combines it with a `uint64_t` index size.

## Why

Structured-binding names are lvalues, so returning the move-only future without `std::move` attempts to use its deleted copy constructor. On macOS arm64, `uint64_t` and `size_t` have different underlying unsigned types, which prevents `SaturatingMultiply(T, T)` from deducing a single `T`.

## Test Plan

- Not run (per request).
