### PR TITLE
fix: preserve logical offsets for growing nullable vector output

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -97,6 +97,23 @@ namespace milvus::segcore {
 
 namespace {
 
+// Call only after selecting raw storage: index APIs must keep logical IDs even
+// if an interim index takes over between NULL filtering and vector retrieval.
+std::vector<int64_t>
+MapValidVectorOffsets(const VectorBase& vec,
+                      const int64_t* logical_offsets,
+                      int64_t count) {
+    std::vector<int64_t> physical_offsets;
+    if (vec.is_mapping_storage()) {
+        auto valid_data = std::make_unique<bool[]>(count);
+        vec.get_offset_mapping().FilterValidLogicalOffsets(
+            logical_offsets, count, valid_data.get(), physical_offsets);
+        AssertInfo(physical_offsets.size() == count,
+                   "Valid vector offsets must map to stored rows");
+    }
+    return physical_offsets;
+}
+
 int64_t
 GetLoadedFieldRows(
     const std::vector<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>&
@@ -2019,7 +2036,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
     if (field_meta.is_vector()) {
         int64_t valid_count = count;
         const bool* valid_data = nullptr;
-        const int64_t* valid_offsets = seg_offsets;
+        const int64_t* valid_logical_offsets = seg_offsets;
         ValidResult filter_result;
 
         if (field_meta.is_nullable()) {
@@ -2027,7 +2044,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 FilterVectorValidOffsets(op_ctx, field_id, seg_offsets, count);
             valid_count = filter_result.valid_count;
             valid_data = filter_result.valid_data.get();
-            valid_offsets = filter_result.valid_offsets.data();
+            valid_logical_offsets = filter_result.valid_logical_offsets.data();
         }
 
         auto result = CreateEmptyVectorDataArray(
@@ -2040,7 +2057,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                              field_id,
                                              field_meta.get_sizeof(),
                                              vec_ptr,
-                                             valid_offsets,
+                                             valid_logical_offsets,
                                              valid_count,
                                              result->mutable_vectors()
                                                  ->mutable_float_vector()
@@ -2052,7 +2069,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 field_id,
                 field_meta.get_sizeof(),
                 vec_ptr,
-                valid_offsets,
+                valid_logical_offsets,
                 valid_count,
                 result->mutable_vectors()->mutable_binary_vector()->data());
         } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
@@ -2061,7 +2078,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 field_id,
                 field_meta.get_sizeof(),
                 vec_ptr,
-                valid_offsets,
+                valid_logical_offsets,
                 valid_count,
                 result->mutable_vectors()->mutable_float16_vector()->data());
         } else if (field_meta.get_data_type() == DataType::VECTOR_BFLOAT16) {
@@ -2070,7 +2087,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 field_id,
                 field_meta.get_sizeof(),
                 vec_ptr,
-                valid_offsets,
+                valid_logical_offsets,
                 valid_count,
                 result->mutable_vectors()->mutable_bfloat16_vector()->data());
         } else if (field_meta.get_data_type() ==
@@ -2079,7 +2096,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 op_ctx,
                 field_id,
                 (const ConcurrentVector<SparseFloatVector>*)vec_ptr,
-                valid_offsets,
+                valid_logical_offsets,
                 valid_count,
                 result->mutable_vectors()->mutable_sparse_float_vector());
             result->mutable_vectors()->set_dim(
@@ -2090,7 +2107,7 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 field_id,
                 field_meta.get_sizeof(),
                 vec_ptr,
-                valid_offsets,
+                valid_logical_offsets,
                 valid_count,
                 result->mutable_vectors()->mutable_int8_vector()->data());
         } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
@@ -2295,10 +2312,13 @@ SegmentGrowingImpl::bulk_subscript_sparse_float_vector_impl(
     // concurrent retrieves against each other for a read-only operation.
     auto chunks = vec_raw->acquire_chunks();
     if (!chunks.empty() && !indexing_record_.HasRawData(field_id)) {
-        // copy from raw data
+        const auto physical_offsets =
+            MapValidVectorOffsets(*vec_raw, seg_offsets, count);
+        const auto* raw_offsets =
+            physical_offsets.empty() ? seg_offsets : physical_offsets.data();
         SparseRowsToProto(
             [&](size_t i) {
-                auto offset = seg_offsets[i];
+                auto offset = raw_offsets[i];
                 return offset != INVALID_SEG_OFFSET
                            ? vec_raw->get_physical_element(chunks, offset)
                            : nullptr;
@@ -2373,10 +2393,14 @@ SegmentGrowingImpl::bulk_subscript_impl(milvus::OpContext* op_ctx,
     // for why the snapshot replaces the chunk lock here.
     auto chunks = vec.acquire_chunks();
     if (!chunks.empty() && !indexing_record_.HasRawData(field_id)) {
+        const auto physical_offsets =
+            MapValidVectorOffsets(vec, seg_offsets, count);
+        const auto* raw_offsets =
+            physical_offsets.empty() ? seg_offsets : physical_offsets.data();
         auto output_base = reinterpret_cast<char*>(output_raw);
         for (int i = 0; i < count; ++i) {
             auto dst = output_base + i * element_sizeof;
-            auto offset = seg_offsets[i];
+            auto offset = raw_offsets[i];
             auto src = (const uint8_t*)vec.get_physical_element(chunks, offset);
             milvus::fastmem::FastMemcpy(dst, src, element_sizeof);
         }
@@ -3721,60 +3745,22 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
                                              FieldId field_id,
                                              const int64_t* seg_offsets,
                                              int64_t count) const {
+    AssertInfo(count >= 0, "Vector offset count must be nonnegative");
     ValidResult result;
-    result.valid_count = count;
+    result.valid_data = std::make_unique<bool[]>(count);
+    result.valid_logical_offsets.reserve(count);
 
-    if (indexing_record_.SyncDataWithIndex(field_id)) {
-        const auto& field_indexing =
-            indexing_record_.get_vec_field_indexing(field_id);
-        auto indexing = field_indexing.get_segment_indexing();
-        auto vec_index = dynamic_cast<index::VectorIndex*>(indexing.get());
-
-        if (vec_index != nullptr && vec_index->HasValidData()) {
-            result.valid_data = std::make_unique<bool[]>(count);
-            result.valid_offsets.reserve(count);
-            for (int64_t i = 0; i < count; ++i) {
-                result.valid_data[i] = vec_index->IsRowValid(seg_offsets[i]);
-                if (result.valid_data[i]) {
-                    result.valid_offsets.push_back(seg_offsets[i]);
-                }
-            }
-            result.valid_count = result.valid_offsets.size();
-        }
-    } else {
-        auto vec_base = insert_record_.get_data_base(field_id);
-        if (vec_base != nullptr) {
-            // Avoid vec_base->get_valid_data(): it materializes a flat copy of
-            // the WHOLE validity bitmap (O(segment rows)) while this path only
-            // needs `count` offsets (and, on the mapping-storage branch, only
-            // an emptiness check).
-            auto valid_data_ptr = insert_record_.is_valid_data_exist(field_id)
-                                      ? insert_record_.get_valid_data(field_id)
-                                      : nullptr;
-            bool is_mapping_storage = vec_base->is_mapping_storage();
-            if (valid_data_ptr != nullptr && !valid_data_ptr->empty()) {
-                result.valid_data = std::make_unique<bool[]>(count);
-
-                if (is_mapping_storage) {
-                    vec_base->get_offset_mapping().FilterValidLogicalOffsets(
-                        seg_offsets,
-                        count,
-                        result.valid_data.get(),
-                        result.valid_offsets);
-                } else {
-                    result.valid_offsets.reserve(count);
-                    valid_data_ptr->bulk_is_valid(
-                        seg_offsets, count, result.valid_data.get());
-                    for (int64_t i = 0; i < count; ++i) {
-                        if (result.valid_data[i]) {
-                            result.valid_offsets.push_back(seg_offsets[i]);
-                        }
-                    }
-                }
-                result.valid_count = result.valid_offsets.size();
-            }
+    // Insert/Load maintain this bitmap even after a raw-owning index takes
+    // over and the raw chunks are reclaimed. Filtering must not depend on
+    // index state or change the coordinate space of the offsets it returns.
+    const auto valid_data = insert_record_.get_valid_data(field_id);
+    valid_data->bulk_is_valid(seg_offsets, count, result.valid_data.get());
+    for (int64_t i = 0; i < count; ++i) {
+        if (result.valid_data[i]) {
+            result.valid_logical_offsets.push_back(seg_offsets[i]);
         }
     }
+    result.valid_count = result.valid_logical_offsets.size();
     return result;
 }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -672,7 +672,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     struct ValidResult {
         int64_t valid_count = 0;
         std::unique_ptr<bool[]> valid_data;
-        std::vector<int64_t> valid_offsets;
+        // NULL filtering preserves logical segment offsets and their order.
+        std::vector<int64_t> valid_logical_offsets;
     };
 
     ValidResult

--- a/internal/core/src/segcore/SegmentGrowingNullableVectorTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingNullableVectorTest.cpp
@@ -1,0 +1,345 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/Utils.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+namespace {
+
+// Compare the returned payload against the original insert batch, independently
+// of either the segment's offset mapping or its interim index.
+std::vector<std::string>
+VectorRows(const DataArray& field, int64_t dim) {
+    const auto& vectors = field.vectors();
+    if (field.type() == proto::schema::SparseFloatVector) {
+        const auto& rows = vectors.sparse_float_vector().contents();
+        return {rows.begin(), rows.end()};
+    }
+    std::string bytes;
+    int64_t width = 0;
+    switch (field.type()) {
+        case proto::schema::FloatVector:
+            bytes.assign(reinterpret_cast<const char*>(
+                             vectors.float_vector().data().data()),
+                         vectors.float_vector().data_size() * sizeof(float));
+            width = dim * sizeof(float);
+            break;
+        case proto::schema::Float16Vector:
+            bytes = vectors.float16_vector();
+            width = dim * sizeof(float16);
+            break;
+        case proto::schema::BFloat16Vector:
+            bytes = vectors.bfloat16_vector();
+            width = dim * sizeof(bfloat16);
+            break;
+        case proto::schema::BinaryVector:
+            bytes = vectors.binary_vector();
+            width = dim / 8;
+            break;
+        case proto::schema::Int8Vector:
+            bytes = vectors.int8_vector();
+            width = dim;
+            break;
+        default:
+            throw std::runtime_error("unsupported test vector type");
+    }
+    std::vector<std::string> rows;
+    for (size_t i = 0; i < bytes.size(); i += width) {
+        rows.push_back(bytes.substr(i, width));
+    }
+    return rows;
+}
+
+class GrowingNullableVectorTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        auto& config = SegcoreConfig::default_config();
+        restore_ = std::make_unique<ScopedSegcoreConfigRestore>(config);
+        build_ratio_ = config.get_build_ratio();
+        config.set_build_ratio(0);
+        InterimIndexConfigForTest options;
+        options.nlist = 16;
+        options.nprobe = 16;
+        options.chunk_rows = 128;
+        options.dense_vector_interim_index_type =
+            knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+        ApplyInterimIndexConfigForTest(options, config);
+    }
+
+    void
+    TearDown() override {
+        segment_.reset();
+        SegcoreConfig::default_config().set_build_ratio(build_ratio_);
+        restore_.reset();
+    }
+
+    void
+    MakeSegment(DataType type, bool nullable, const std::string& interim) {
+        segment_.reset();
+        expected_.clear();
+        auto& config = SegcoreConfig::default_config();
+        config.set_enable_interim_segment_index(!interim.empty());
+        if (!interim.empty()) {
+            config.set_dense_vector_intermin_index_type(interim);
+        }
+        schema_ = std::make_shared<Schema>();
+        const auto metric =
+            type == DataType::VECTOR_SPARSE_U32_F32 ? knowhere::metric::IP
+            : type == DataType::VECTOR_BINARY       ? knowhere::metric::HAMMING
+                                                    : knowhere::metric::L2;
+        vec_ = schema_->AddDebugField("vec", type, kDim, metric, nullable);
+        auto pk = schema_->AddDebugField("pk", DataType::INT64);
+        schema_->set_primary_field_id(pk);
+        std::map<std::string, std::string> index_params = {
+            {"index_type",
+             type == DataType::VECTOR_SPARSE_U32_F32
+                 ? knowhere::IndexEnum::INDEX_SPARSE_INVERTED_INDEX
+                 : knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+            {"metric_type", metric}};
+        std::map<FieldId, FieldIndexMeta> fields;
+        fields.emplace(vec_,
+                       FieldIndexMeta(vec_,
+                                      std::move(index_params),
+                                      {{"dim", std::to_string(kDim)}}));
+        auto meta =
+            std::make_shared<CollectionIndexMeta>(20000, std::move(fields));
+        segment_ = CreateGrowingSegment(schema_, meta);
+        impl_ = dynamic_cast<SegmentGrowingImpl*>(segment_.get());
+        ASSERT_NE(impl_, nullptr);
+    }
+
+    void
+    Insert(int64_t count, int null_percent = 10, bool nulls_at_end = false) {
+        const auto start = expected_.size();
+        auto data = DataGen(schema_,
+                            count,
+                            42 + start,
+                            start,
+                            1,
+                            10,
+                            1,
+                            false,
+                            true,
+                            false,
+                            null_percent);
+        for (auto& field : *data.raw_->mutable_fields_data()) {
+            if (field.field_id() != vec_.get()) {
+                continue;
+            }
+            if (nulls_at_end) {
+                auto reversed_valid_data = GetFieldDataRowValidData(field);
+                std::reverse(reversed_valid_data.begin(),
+                             reversed_valid_data.end());
+                MutableFieldDataRowValidData(&field)->Swap(
+                    &reversed_valid_data);
+            }
+            const auto& valid_data = GetFieldDataRowValidData(field);
+            auto rows = VectorRows(field, kDim);
+            size_t physical = 0;
+            for (int64_t i = 0; i < count; ++i) {
+                if (valid_data.empty() || valid_data[i]) {
+                    expected_.emplace_back(rows.at(physical++));
+                } else {
+                    expected_.emplace_back(std::nullopt);
+                }
+            }
+            ASSERT_EQ(physical, rows.size());
+        }
+        auto offset = segment_->PreInsert(count);
+        ASSERT_EQ(offset, start);
+        segment_->Insert(offset,
+                         count,
+                         data.row_ids_.data(),
+                         data.timestamps_.data(),
+                         data.raw_);
+    }
+
+    void
+    Check(const std::vector<int64_t>& offsets) {
+        auto output = impl_->bulk_subscript(
+            nullptr, vec_, offsets.data(), offsets.size());
+        auto rows = VectorRows(*output, kDim);
+        const bool nullable = (*schema_)[vec_].is_nullable();
+        const auto& valid_data = GetFieldDataRowValidData(*output);
+        ASSERT_EQ(valid_data.size(), nullable ? offsets.size() : 0);
+        size_t physical = 0;
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            const auto offset = offsets[i];
+            const bool valid = offset >= 0 && offset < expected_.size() &&
+                               expected_[offset].has_value();
+            if (nullable) {
+                EXPECT_EQ(valid_data[i], valid) << offset;
+            }
+            if (valid) {
+                ASSERT_LT(physical, rows.size());
+                EXPECT_EQ(rows[physical++], expected_[offset].value())
+                    << "logical offset " << offset;
+            }
+        }
+        EXPECT_EQ(physical, rows.size());
+    }
+
+    static constexpr int64_t kDim = 8;
+    std::unique_ptr<ScopedSegcoreConfigRestore> restore_;
+    float build_ratio_;
+    SchemaPtr schema_;
+    FieldId vec_{100};
+    SegmentGrowingPtr segment_;
+    SegmentGrowingImpl* impl_ = nullptr;
+    std::vector<std::optional<std::string>> expected_;
+};
+
+TEST_F(GrowingNullableVectorTest, RawStorageTypesAndNullPatterns) {
+    for (auto type : {DataType::VECTOR_FLOAT,
+                      DataType::VECTOR_FLOAT16,
+                      DataType::VECTOR_BFLOAT16,
+                      DataType::VECTOR_BINARY,
+                      DataType::VECTOR_INT8,
+                      DataType::VECTOR_SPARSE_U32_F32}) {
+        for (int null_percent : {0, 10, 100}) {
+            for (bool reverse : {false, true}) {
+                SCOPED_TRACE(::testing::Message()
+                             << int(type) << "/" << null_percent << "/"
+                             << reverse);
+                MakeSegment(type, true, "");
+                Check({});
+                Check({-1, 0});  // Empty validity bitmap: no valid rows.
+                Insert(300, null_percent, reverse);
+                std::vector<int64_t> offsets(300);
+                std::iota(offsets.begin(), offsets.end(), 0);
+                Check(offsets);
+                Check({299, 14, 0, 150, 14, 10, -1, 300});
+            }
+        }
+    }
+}
+
+TEST_F(GrowingNullableVectorTest, IndexedTypesKeepLogicalOffsets) {
+    for (auto type : {DataType::VECTOR_FLOAT,
+                      DataType::VECTOR_FLOAT16,
+                      DataType::VECTOR_BFLOAT16,
+                      DataType::VECTOR_SPARSE_U32_F32}) {
+        for (const std::string interim : {"IVF_FLAT_CC", "SCANN_DVR"}) {
+            if (type == DataType::VECTOR_SPARSE_U32_F32 &&
+                interim == "SCANN_DVR") {
+                continue;
+            }
+            for (bool nullable : {false, true}) {
+                SCOPED_TRACE(::testing::Message()
+                             << int(type) << "/" << interim << "/" << nullable);
+                MakeSegment(type, nullable, interim);
+                Insert(100);
+                ASSERT_FALSE(
+                    impl_->get_indexing_record().SyncDataWithIndex(vec_));
+                Check({99, 14, 0, 14, 10});
+                Insert(2000);
+                ASSERT_TRUE(
+                    impl_->get_indexing_record().SyncDataWithIndex(vec_));
+                ASSERT_EQ(impl_->get_indexing_record().HasRawData(vec_),
+                          interim == "IVF_FLAT_CC");
+                std::vector<int64_t> offsets(expected_.size());
+                std::iota(offsets.begin(), offsets.end(), 0);
+                Check(offsets);
+                Check({2099, 14, 0, 1999, 14, 10, 100});
+                // Validity must still be maintained when subsequent inserts
+                // bypass raw chunks because the index already owns the data.
+                Insert(100);
+                Check({2199, 2114, 2100, 14, 2114});
+            }
+        }
+    }
+}
+
+TEST_F(GrowingNullableVectorTest, IndexTakesOverBetweenFilteringAndFetch) {
+    for (auto type : {DataType::VECTOR_FLOAT,
+                      DataType::VECTOR_FLOAT16,
+                      DataType::VECTOR_BFLOAT16,
+                      DataType::VECTOR_SPARSE_U32_F32}) {
+        SCOPED_TRACE(int(type));
+        MakeSegment(type, true, "IVF_FLAT_CC");
+        Insert(100);
+        const auto& index = impl_->get_indexing_record();
+        ASSERT_FALSE(index.HasRawData(vec_));
+        const std::vector<int64_t> offsets = {14, 99, 12, 14, 0, -1, 100};
+        auto filtered = impl_->FilterVectorValidOffsets(
+            nullptr, vec_, offsets.data(), offsets.size());
+        auto* vec = impl_->get_insert_record().get_data_base(vec_);
+        const auto pinned_chunks = vec->acquire_chunks();
+        ASSERT_FALSE(pinned_chunks.empty());
+
+        // Deterministically schedule the writer between the two actual read
+        // stages. Insert builds the index and reclaims the segment's chunks.
+        // No sleeps or product-only test hooks are needed at this boundary.
+        Insert(2000);
+        ASSERT_TRUE(index.HasRawData(vec_));
+        ASSERT_TRUE(vec->acquire_chunks().empty());
+        ASSERT_FALSE(pinned_chunks.empty());
+        const std::vector<int64_t> expected_offsets = {14, 99, 12, 14};
+        ASSERT_EQ(filtered.valid_logical_offsets, expected_offsets);
+        auto output = CreateEmptyVectorDataArray(offsets.size(),
+                                                 filtered.valid_count,
+                                                 filtered.valid_data.get(),
+                                                 (*schema_)[vec_]);
+        auto* ids = filtered.valid_logical_offsets.data();
+        auto count = filtered.valid_count;
+        // This is the same index consumer selected by the vector fetch path
+        // once HasRawData becomes true. Its IDs must be the logical IDs saved
+        // before the writer built the index, not raw-column physical offsets.
+        void* raw_output = nullptr;
+        int64_t element_size = 0;
+        if (type == DataType::VECTOR_SPARSE_U32_F32) {
+            raw_output =
+                output->mutable_vectors()->mutable_sparse_float_vector();
+        } else {
+            element_size = (*schema_)[vec_].get_sizeof();
+            if (type == DataType::VECTOR_FLOAT) {
+                raw_output = output->mutable_vectors()
+                                 ->mutable_float_vector()
+                                 ->mutable_data()
+                                 ->mutable_data();
+            } else if (type == DataType::VECTOR_FLOAT16) {
+                raw_output =
+                    output->mutable_vectors()->mutable_float16_vector()->data();
+            } else {
+                raw_output = output->mutable_vectors()
+                                 ->mutable_bfloat16_vector()
+                                 ->data();
+            }
+        }
+        index.GetDataFromIndex(vec_, ids, count, element_size, raw_output);
+        auto rows = VectorRows(*output, kDim);
+        ASSERT_EQ(rows.size(), expected_offsets.size());
+        for (size_t i = 0; i < rows.size(); ++i) {
+            EXPECT_EQ(rows[i], expected_[expected_offsets[i]].value());
+        }
+        Check(offsets);
+    }
+}
+
+}  // namespace

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -63,7 +63,7 @@
 namespace milvus::segcore::storagev2translator {
 
 // See GroupChunkTranslator.cpp for explanation of g_mmap_path_generation.
-static std::atomic<uint64_t> g_mmap_path_generation{0};
+static std::atomic<uint64_t> g_manifest_mmap_path_generation{0};
 
 ColumnSizeEstimateResult
 FetchColumnSizeEstimates(milvus_storage::api::ChunkReader& chunk_reader) {
@@ -770,8 +770,8 @@ ManifestGroupTranslator::load_group_chunk(
     } else {
         // Mmap mode — use unique generation suffix to avoid truncating files
         // that old MAP_SHARED mmaps still reference (see #48658).
-        const auto gen =
-            g_mmap_path_generation.fetch_add(1, std::memory_order_relaxed);
+        const auto gen = g_manifest_mmap_path_generation.fetch_add(
+            1, std::memory_order_relaxed);
         std::filesystem::path filepath;
         switch (group_chunk_type_) {
             case GroupChunkType::DEFAULT:


### PR DESCRIPTION
issue: #53371

## Summary

- Give the manifest translator mmap generation counter a distinct file-local name so Unity Build can compile it together with GroupChunkTranslator without a duplicate definition. The counters and memory ordering remain unchanged.

- Fix wrong-row nullable vector output after a non-raw-owning interim index synchronizes. NULL filtering now retains logical segment IDs; dense and sparse raw reads map to compact physical offsets only after pinning chunks and checking index ownership. Index reads always receive logical IDs, including when ownership changes between filtering and fetch.
- Add regressions for raw and indexed reads, NULL patterns, invalid/unsorted/duplicate offsets, post-takeover inserts, and deterministic index takeover. Use master's field-specific validity helpers in the fixture.

Fixes #53371. This is the primary fix; #53372 is its cherry-pick for 3.0.

## Test Plan

- Compiled the real 3.0 GroupChunkTranslator and ManifestGroupTranslator sources together with the task-private product dependency flags (`-fsyntax-only`): the original sources fail with the same duplicate-definition error as CI; the corrected sources pass. clang-format-15 and scoped submission hooks pass on both branches. This is targeted compiler validation, not a full rebuild. A master attempt with the available 3.0 dependencies encounters protobuf API mismatches, so master CI validation remains outstanding.

- The same production patch passed the 3.0 Release + AddressSanitizer build and three focused GTest groups (54 fixture combinations). The original SCANN_DVR sample changed from 450 wrong vectors to zero; full 20,000-row queries and vector-to-ID consistency checks passed with SCANN_DVR and IVF_FLAT_CC in growing and sealed states. The takeover regression fails against the original library and passes with the fix.
- On master, the production patch matches the verified 3.0 patch (stable patch ID); adapted the fixture to `GetFieldDataRowValidData` / `MutableFieldDataRowValidData`. Diff checks, test formatting and scoped submission checks passed. A master build/runtime rerun has not been performed; master CI remains outstanding.
- Repository-wide pre-commit was executed: Python lint/format passed; golangci-lint is unavailable locally and typos reports existing issues. Hook-only changes were reverted. Scoped spell checking retains only three existing spellings (`happends`, `LoadFieldDatasFromRemote`, `GetByteSizeOfFieldDatas`). These results are not a full repository-check pass.
- The original large backfill deployment was not replayed; the functional results above cover the local mechanism. The unit driver disabled leak detection, and ANN checks validate output consistency rather than recall.

<!-- skills-delivery:923ef6b00dca31ec585d9d402c43aef3011fe21fca61b47741551d84214b0ca1 -->
