### PR TITLE
fix: resolve macOS arm64 compilation failures in Storage V3 code

### DIFF
--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -959,7 +959,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
         index_size += 1024;
     }
     auto stream_overhead = static_cast<uint64_t>(milvus::SaturatingMultiply(
-        index_size, storage::kFileStreamBufferMultiplier));
+        index_size, static_cast<uint64_t>(storage::kFileStreamBufferMultiplier)));
     auto bounded_stream_overhead = storage::EntryStreamMaxTransientBytes(
         stream_overhead, max_task_transient_bytes);
     ASSERT_GT(stream_overhead, bounded_stream_overhead);

--- a/internal/core/src/storage/LoadAdmissionController.cpp
+++ b/internal/core/src/storage/LoadAdmissionController.cpp
@@ -84,11 +84,11 @@ LoadAdmissionController::AcquireAsync(
     }
     if (cancelled) {
         promise.trySetException(folly::OperationCancelled{});
-        return future;
+        return std::move(future);
     }
     if (admitted) {
         promise.trySetValue(LoadAdmissionLease(this, request));
-        return future;
+        return std::move(future);
     }
 
     // The returned future has not escaped yet, so only the explicit token
@@ -128,7 +128,7 @@ LoadAdmissionController::AcquireAsync(
     if (admitted) {
         FulfillAdmission(std::move(pending));
     }
-    return future;
+    return std::move(future);
 }
 
 void


### PR DESCRIPTION
## What this PR does

Fixes two portability errors that prevent compilation on macOS arm64 with Homebrew Clang 19 and libc++.

### Changes

1. **`LoadAdmissionController.cpp`**: `AcquireAsync` returns a move-only `folly::coro::Future` from a structured binding without an explicit move. On macOS, structured bindings are lvalues and `return future` attempts to use the deleted copy constructor. Added `std::move()` at all three return sites.

2. **`HybridScalarIndexTest.cpp`**: `SaturatingMultiply` is called with `uint64_t` and `size_t` arguments. On macOS arm64 these are distinct underlying types (`unsigned long long` vs `unsigned long`), causing template argument deduction failure. Cast the `size_t` argument to `uint64_t` at the mixed-type call site.

## Related Issue

Closes #53369

## Verification

- These are straightforward portability fixes with no behavioral change.
- The `std::move` addition makes the move semantics explicit (GCC/Clang on Linux already handle structured bindings as rvalues in some cases).
- The `static_cast` at the test call site ensures both arguments share a common type for template deduction.
