### PR TITLE
test: [cp3.0] stabilize and streamline E2E coverage

### DIFF
--- a/tests/go_client/common/response_checker.go
+++ b/tests/go_client/common/response_checker.go
@@ -264,12 +264,12 @@ func CheckOutputFields(t *testing.T, expFields []string, actualColumns []column.
 
 // CheckSearchResult check search result, check nq, topk, ids, score
 func CheckSearchResult(t *testing.T, actualSearchResults []client.ResultSet, expNq int, expTopK int) {
-	require.Equalf(t, len(actualSearchResults), expNq, fmt.Sprintf("Expected nq=%d, actual SearchResultsLen=%d", expNq, len(actualSearchResults)))
+	require.Equalf(t, expNq, len(actualSearchResults), fmt.Sprintf("Expected nq=%d, actual SearchResultsLen=%d", expNq, len(actualSearchResults)))
 	require.Len(t, actualSearchResults, expNq)
 	for _, actualSearchResult := range actualSearchResults {
-		require.Equalf(t, actualSearchResult.ResultCount, expTopK, fmt.Sprintf("Expected topK=%d, actual ResultCount=%d", expTopK, actualSearchResult.ResultCount))
-		require.Equalf(t, actualSearchResult.IDs.Len(), expTopK, fmt.Sprintf("Expected topK=%d, actual IDsLen=%d", expTopK, actualSearchResult.IDs.Len()))
-		require.Equalf(t, len(actualSearchResult.Scores), expTopK, fmt.Sprintf("Expected topK=%d, actual ScoresLen=%d", expTopK, len(actualSearchResult.Scores)))
+		require.Equalf(t, expTopK, actualSearchResult.ResultCount, fmt.Sprintf("Expected topK=%d, actual ResultCount=%d", expTopK, actualSearchResult.ResultCount))
+		require.Equalf(t, expTopK, actualSearchResult.IDs.Len(), fmt.Sprintf("Expected topK=%d, actual IDsLen=%d", expTopK, actualSearchResult.IDs.Len()))
+		require.Equalf(t, expTopK, len(actualSearchResult.Scores), fmt.Sprintf("Expected topK=%d, actual ScoresLen=%d", expTopK, len(actualSearchResult.Scores)))
 	}
 }
 

--- a/tests/go_client/testcases/index_test.go
+++ b/tests/go_client/testcases/index_test.go
@@ -1005,10 +1005,12 @@ func TestCreateIndexVanillaFaissGeneric(t *testing.T) {
 	prepare.Load(ctx, t, mc, hp.NewLoadParams(schema.CollectionName))
 
 	queryVec := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
+	annParam := index.NewCustomAnnParam()
+	annParam.WithExtraParam("nprobe", 64)
 	searchRes, err := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, common.DefaultLimit, queryVec).
 		WithANNSField(common.DefaultFloatVecFieldName).
 		// nprobe=nlist (IVF64) scans all lists so topK results are returned deterministically (#50392)
-		WithSearchParam("nprobe", "64").
+		WithAnnParam(annParam).
 		WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
 	common.CheckSearchResult(t, searchRes, common.DefaultNq, common.DefaultLimit)

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -70,6 +70,18 @@ DECAY_RERANK_SHARED_COLLECTION_GROWING = "test_decay_rerank_shared_growing_" + c
 DECAY_RERANK_SHARED_COLLECTION_FLUSHED = "test_decay_rerank_shared_flushed_" + cf.gen_unique_str("_")
 DECAY_RERANK_SHARED_DIM = 5
 
+# Rerank scores from an external model service are not bit-reproducible run to run
+# on GPU: batched inference has a nondeterministic reduction order, and float16
+# amplifies that into ~1e-3 .. 5e-3 relative score movement (milvus#52737). CPU
+# backends are bit-identical, so tolerating near-ties only ever loosens the GPU
+# case and never masks a real ordering bug (a wrong pairing moves a score far more).
+RERANK_ORDER_REL_TOL = 0.05
+RERANK_ORDER_ABS_TOL = 1e-6
+
+
+def _rerank_scores_tied(a, b):
+    return math.isclose(a, b, rel_tol=RERANK_ORDER_REL_TOL, abs_tol=RERANK_ORDER_ABS_TOL)
+
 
 class TestMilvusClientSearchInvalid(TestMilvusClientV2Base):
     """ Test case of search interface """
@@ -6459,8 +6471,28 @@ class TestMilvusClientSearchModelRerank(TestMilvusClientV2Base):
             self.display_side_by_side_comparison(query_text, actual_rerank_results, gt, doc_to_original,
                                                milvus_scores=distances, gt_scores=gt_scores)
 
-            # Use strict comparison since scores are now normalized to f32 precision
-            assert gt == actual_rerank_results, "Rerank result is different from ground truth rerank result"
+            # The reranker service is not bit-reproducible run to run on GPU
+            # (nondeterministic reduction order + float16 => ~1e-3 relative score
+            # drift, milvus#52737), so exact list equality is not a valid contract.
+            # Compare the document set exactly, and enforce ordering only between
+            # documents whose ground-truth scores differ beyond the service's own
+            # reproducibility tolerance.
+            assert sorted(actual_rerank_results) == sorted(gt), \
+                "Rerank result set is different from ground truth rerank result set"
+
+            gt_rank = {doc: idx for idx, doc in enumerate(gt)}
+            gt_score_by_doc = dict(zip(gt, gt_scores))
+            for i in range(len(actual_rerank_results)):
+                for j in range(i + 1, len(actual_rerank_results)):
+                    doc_i = actual_rerank_results[i]
+                    doc_j = actual_rerank_results[j]
+                    if gt_rank[doc_i] > gt_rank[doc_j] and \
+                            not _rerank_scores_tied(gt_score_by_doc[doc_i], gt_score_by_doc[doc_j]):
+                        raise AssertionError(
+                            f"Rerank order mismatch: '{doc_i[:30]}' is outranked by "
+                            f"'{doc_j[:30]}' in ground truth (scores "
+                            f"{gt_score_by_doc[doc_i]} vs {gt_score_by_doc[doc_j]})"
+                        )
 
     @pytest.mark.parametrize("ranker_model", [
         pytest.param("tei", marks=pytest.mark.tags(CaseLabel.L1)),

--- a/tests/python_client/milvus_client/test_milvus_client_search_by_pk.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_by_pk.py
@@ -945,6 +945,82 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
 class TestSearchByPkIndependent(TestMilvusClientV2Base):
     """Test search by primary keys functionality with independent collections"""
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_by_pk_preserves_requested_id_order(self):
+        """
+        target: verify search by primary keys preserves the requested ID order
+        method: compare top-1 results from vector search and search by non-ascending primary keys
+        expected: each search-by-PK result block matches the corresponding requested primary key
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 4
+
+        schema = self.create_schema(client, auto_id=False, enable_dynamic_field=False)[0]
+        schema.add_field(fast_create_pk_field, DataType.INT64, is_primary=True)
+        schema.add_field(fast_create_vector_field, DataType.FLOAT_VECTOR, dim=dim)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name=fast_create_vector_field,
+            index_type="FLAT",
+            metric_type="L2",
+        )
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+
+        vectors = {
+            1: [1.0, 0.0, 0.0, 0.0],
+            2: [0.0, 1.0, 0.0, 0.0],
+            3: [0.0, 0.0, 1.0, 0.0],
+        }
+        data = [
+            {fast_create_pk_field: primary_key, fast_create_vector_field: vector}
+            for primary_key, vector in vectors.items()
+        ]
+        self.insert(client, collection_name, data)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        requested_ids = [3, 1, 2]
+        check_items = {
+            "enable_milvus_client_api": True,
+            "nq": len(requested_ids),
+            "limit": 1,
+            "metric": "L2",
+            "pk_name": fast_create_pk_field,
+        }
+        baseline_results, _ = self.search(
+            client,
+            collection_name,
+            data=[vectors[primary_key] for primary_key in requested_ids],
+            anns_field=fast_create_vector_field,
+            search_params={"metric_type": "L2", "params": {}},
+            limit=1,
+            check_task=CheckTasks.check_search_results,
+            check_items=check_items,
+        )
+        by_pk_results, _ = self.search(
+            client,
+            collection_name,
+            ids=requested_ids,
+            anns_field=fast_create_vector_field,
+            search_params={"metric_type": "L2", "params": {}},
+            limit=1,
+            check_task=CheckTasks.check_search_results,
+            check_items=check_items,
+        )
+
+        baseline_top1 = [result.ids[0] for result in baseline_results]
+        by_pk_top1 = [result.ids[0] for result in by_pk_results]
+        assert baseline_top1 == requested_ids
+        assert by_pk_top1 == baseline_top1
+
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_by_pk_on_empty_partition(self):
         """

--- a/tests/python_client/milvus_client/test_milvus_client_search_reranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_reranker.py
@@ -56,6 +56,18 @@ DECAY_RERANK_SHARED_COLLECTION_GROWING = "test_decay_rerank_shared_growing_" + c
 DECAY_RERANK_SHARED_COLLECTION_FLUSHED = "test_decay_rerank_shared_flushed_" + cf.gen_unique_str("_")
 DECAY_RERANK_SHARED_DIM = 5
 
+# Rerank scores from an external model service are not bit-reproducible run to run
+# on GPU: batched inference has a nondeterministic reduction order, and float16
+# amplifies that into ~1e-3 .. 5e-3 relative score movement (milvus#52737). CPU
+# backends are bit-identical, so tolerating near-ties only ever loosens the GPU
+# case and never masks a real ordering bug (a wrong pairing moves a score far more).
+RERANK_ORDER_REL_TOL = 0.05
+RERANK_ORDER_ABS_TOL = 1e-6
+
+
+def _rerank_scores_tied(a, b):
+    return math.isclose(a, b, rel_tol=RERANK_ORDER_REL_TOL, abs_tol=RERANK_ORDER_ABS_TOL)
+
 
 @pytest.mark.xdist_group("TestMilvusClientSearchInvalidRerankerShared")
 class TestMilvusClientSearchInvalidRerankerShared(TestMilvusClientV2Base):
@@ -2874,8 +2886,30 @@ class TestMilvusClientSearchModelRerank(TestMilvusClientV2Base):
                 query_text, actual_rerank_results, gt, doc_to_original, milvus_scores=distances, gt_scores=gt_scores
             )
 
-            # Use strict comparison since scores are now normalized to f32 precision
-            assert gt == actual_rerank_results, "Rerank result is different from ground truth rerank result"
+            # The reranker service is not bit-reproducible run to run on GPU
+            # (nondeterministic reduction order + float16 => ~1e-3 relative score
+            # drift, milvus#52737), so exact list equality is not a valid contract.
+            # Compare the document set exactly, and enforce ordering only between
+            # documents whose ground-truth scores differ beyond the service's own
+            # reproducibility tolerance.
+            assert sorted(actual_rerank_results) == sorted(gt), (
+                "Rerank result set is different from ground truth rerank result set"
+            )
+
+            gt_rank = {doc: idx for idx, doc in enumerate(gt)}
+            gt_score_by_doc = dict(zip(gt, gt_scores))
+            for i in range(len(actual_rerank_results)):
+                for j in range(i + 1, len(actual_rerank_results)):
+                    doc_i = actual_rerank_results[i]
+                    doc_j = actual_rerank_results[j]
+                    if gt_rank[doc_i] > gt_rank[doc_j] and not _rerank_scores_tied(
+                        gt_score_by_doc[doc_i], gt_score_by_doc[doc_j]
+                    ):
+                        raise AssertionError(
+                            f"Rerank order mismatch: '{doc_i[:30]}' is outranked by "
+                            f"'{doc_j[:30]}' in ground truth (scores "
+                            f"{gt_score_by_doc[doc_i]} vs {gt_score_by_doc[doc_j]})"
+                        )
 
     @pytest.mark.parametrize(
         "ranker_model",

--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -22,7 +22,6 @@ from utils.utils import gen_collection_name
 IMPORT_2PC_TIMEOUT = 360
 
 
-@pytest.mark.tags(CaseLabel.L0)
 class TestImport2PCRestOperation(TestBase):
     def _kubectl_get_release_pods(self, release_name, namespace="chaos-testing"):
         if not shutil.which("kubectl"):
@@ -2411,7 +2410,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_list_empty_collection_filter_returns_no_records(self):
         """
         target: REST import list empty collectionName filter
@@ -2426,7 +2425,7 @@ class TestImport2PCRestOperation(TestBase):
         records = list_rsp.get("data", {}).get("records", [])
         assert records == [], list_rsp
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_list_rejects_numeric_collection_name(self):
         """
         target: REST import list collectionName type validation
@@ -2548,7 +2547,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_string_options_value(self):
         """
         target: import create options type validation
@@ -2567,7 +2566,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "object", "map", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_partition_name(self):
         """
         target: import create partitionName type validation
@@ -2587,7 +2586,7 @@ class TestImport2PCRestOperation(TestBase):
             ("partition", "string", "type", "number"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_file_path(self):
         """
         target: import create file path type validation
@@ -2606,7 +2605,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "string", "type", "number"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_flat_files_list(self):
         """
         target: import create files nested shape validation
@@ -2625,7 +2624,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "type", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_empty_file_group(self):
         """
         target: import create empty file group validation
@@ -2644,7 +2643,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "file", "empty"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_timeout_option(self):
         """
         target: import create timeout option type validation
@@ -2671,7 +2670,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_read_job_endpoints_reject_boolean_job_id(self):
         """
         target: import read job endpoint jobId type validation
@@ -2689,7 +2688,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "type", "bool"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_write_job_endpoints_reject_boolean_job_id(self):
         """
         target: import write job endpoint jobId type validation
@@ -2707,7 +2706,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "type", "bool"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_collection_name(self):
         """
         target: import create collectionName null validation
@@ -2723,7 +2722,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "string", "null"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_files(self):
         """
         target: import create files null validation
@@ -2742,7 +2741,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "array", "list", "null"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_partition_name(self):
         """
         target: import create partitionName array validation
@@ -2762,7 +2761,7 @@ class TestImport2PCRestOperation(TestBase):
             ("partition", "string", "array", "type"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_read_job_endpoints_reject_array_job_id(self):
         """
         target: import read job endpoint jobId array validation
@@ -2780,7 +2779,7 @@ class TestImport2PCRestOperation(TestBase):
             ("job", "id", "array", "type", "unmarshal", "parse"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_write_job_endpoints_reject_array_job_id(self):
         """
         target: import write job endpoint jobId array validation
@@ -2820,7 +2819,7 @@ class TestImport2PCRestOperation(TestBase):
                 ("job", "id", "object", "type", "unmarshal", "parse"),
             )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_collection_name(self):
         """
         target: import create collectionName array validation
@@ -2836,7 +2835,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "array", "type", "unmarshal", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_collection_name(self):
         """
         target: import create collectionName object validation
@@ -2852,7 +2851,7 @@ class TestImport2PCRestOperation(TestBase):
             ("collection", "name", "object", "type", "unmarshal", "string"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_files_value(self):
         """
         target: import create files object validation
@@ -2871,7 +2870,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "object", "array", "list", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_file_path(self):
         """
         target: import create nested file path object validation
@@ -2890,7 +2889,7 @@ class TestImport2PCRestOperation(TestBase):
             ("files", "path", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_options_value(self):
         """
         target: import create options array validation
@@ -2909,7 +2908,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "array", "object", "map", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_options_value(self):
         """
         target: import create options numeric validation
@@ -2928,7 +2927,7 @@ class TestImport2PCRestOperation(TestBase):
             ("options", "number", "object", "map", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_auto_commit_option(self):
         """
         target: import create auto_commit option value type validation
@@ -2947,7 +2946,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_null_auto_commit_option(self):
         """
         target: import create auto_commit option null validation
@@ -2975,7 +2974,7 @@ class TestImport2PCRestOperation(TestBase):
         ), rsp
         assert "jobId" not in str(rsp), rsp
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_auto_commit_option(self):
         """
         target: import create auto_commit option array validation
@@ -2994,7 +2993,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_backup_option(self):
         """
         target: import create backup option value type validation
@@ -3014,7 +3013,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_l0_import_option(self):
         """
         target: import create l0_import option value type validation
@@ -3033,7 +3032,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option value type validation
@@ -3052,7 +3051,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_backup_option(self):
         """
         target: import create backup option array validation
@@ -3072,7 +3071,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_backup_option(self):
         """
         target: import create backup option object validation
@@ -3092,7 +3091,7 @@ class TestImport2PCRestOperation(TestBase):
             ("backup", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_l0_import_option(self):
         """
         target: import create l0_import option array validation
@@ -3111,7 +3110,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_l0_import_option(self):
         """
         target: import create l0_import option object validation
@@ -3130,7 +3129,7 @@ class TestImport2PCRestOperation(TestBase):
             ("l0_import", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option array validation
@@ -3149,7 +3148,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_skip_disk_quota_check_option(self):
         """
         target: import create skip_disk_quota_check option object validation
@@ -3168,7 +3167,7 @@ class TestImport2PCRestOperation(TestBase):
             ("skip_disk_quota_check", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_numeric_storage_version_option(self):
         """
         target: import create storage_version option value type validation
@@ -3188,7 +3187,7 @@ class TestImport2PCRestOperation(TestBase):
             ("storage_version", "number", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_start_ts_option(self):
         """
         target: import create start_ts option value type validation
@@ -3208,7 +3207,7 @@ class TestImport2PCRestOperation(TestBase):
             ("start_ts", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_end_ts_option(self):
         """
         target: import create end_ts option value type validation
@@ -3228,7 +3227,7 @@ class TestImport2PCRestOperation(TestBase):
             ("end_ts", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_boolean_sep_option(self):
         """
         target: import create CSV sep option value type validation
@@ -3247,7 +3246,7 @@ class TestImport2PCRestOperation(TestBase):
             ("sep", "bool", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_array_nullkey_option(self):
         """
         target: import create CSV nullkey option value type validation
@@ -3266,7 +3265,7 @@ class TestImport2PCRestOperation(TestBase):
             ("nullkey", "array", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_object_ezk_option(self):
         """
         target: import create ezk option value type validation
@@ -3286,7 +3285,7 @@ class TestImport2PCRestOperation(TestBase):
             ("ezk", "object", "string", "type", "unmarshal"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_create_rejects_invalid_timeout_option(self):
         """
         target: import create timeout option validation
@@ -3550,7 +3549,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_completed_job_observability_fields_are_reported(self):
         """
         target: completed import job REST observability
@@ -3609,7 +3608,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_completed_import_survives_release_and_reload(self):
         """
         target: completed import visibility after reload/target refresh
@@ -3673,7 +3672,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_db_name_body_and_header_route_same_job_deterministically(self):
         """
         target: import REST database routing
@@ -4016,6 +4015,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
+    @pytest.mark.tags(CaseLabel.L0)
     def test_import_2pc_default_auto_commit_completed_and_visible(self):
         """
         target: default import compatibility
@@ -4065,7 +4065,7 @@ class TestImport2PCRestOperation(TestBase):
             ("auto_commit", "true", "false"),
         )
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_auto_commit_uppercase_false_stops_at_uncommitted(self):
         """
         target: auto_commit option contract
@@ -4111,7 +4111,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_empty_parquet_auto_commit_completes_with_zero_rows(self):
         """
         target: empty import file lifecycle
@@ -4220,7 +4220,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_manual_multi_file_import_accumulates_rows(self):
         """
         target: multi-file import request
@@ -4336,7 +4336,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_jsonl_file_manual_import_preserves_rows(self):
         """
         target: JSONL file import with 2PC
@@ -4393,7 +4393,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_file_with_custom_separator_manual_import_preserves_rows(self):
         """
         target: CSV file import with custom separator and 2PC
@@ -4453,7 +4453,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_nullkey_manual_import_preserves_nulls(self):
         """
         target: CSV nullkey import with 2PC
@@ -4534,7 +4534,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_numpy_field_per_file_manual_import_preserves_rows(self):
         """
         target: NumPy field-per-file import with 2PC
@@ -4591,7 +4591,7 @@ class TestImport2PCRestOperation(TestBase):
         finally:
             shutil.rmtree(local_dir, ignore_errors=True)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_invalid_file_suffix_fails_with_reason_and_no_visible_rows(self):
         """
         target: invalid import file suffix handling
@@ -4635,7 +4635,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_csv_invalid_separator_rejected_with_reason_and_no_visible_rows(self):
         """
         target: invalid CSV separator validation
@@ -4678,7 +4678,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_mixed_file_formats_across_file_groups_commits_all_rows(self):
         """
         target: mixed import file format support
@@ -4730,7 +4730,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_storage_version_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import storage_version parse contract
@@ -4776,7 +4776,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_storage_version_supported_values_reach_reader_validation(self):
         """
         target: backup import storage_version supported string values
@@ -4840,7 +4840,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_reversed_time_range_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import start_ts/end_ts guardrail
@@ -4893,7 +4893,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_camelcase_time_range_alias_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import startTs/endTs alias guardrail
@@ -4946,7 +4946,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_start_ts_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import start_ts parse guardrail
@@ -4998,7 +4998,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_backup_invalid_end_ts_fails_with_reason_and_no_visible_rows(self):
         """
         target: backup import end_ts parse guardrail
@@ -5074,7 +5074,7 @@ class TestImport2PCRestOperation(TestBase):
         self.collection_client.refresh_load(collection_name)
         assert self._query_count(collection_name) == 0
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_skip_disk_quota_check_is_ignored_for_regular_import(self):
         """
         target: skip_disk_quota_check regular import contract
@@ -5295,6 +5295,7 @@ class TestImport2PCRestOperation(TestBase):
             "committed import segments with normal segments"
         )
     )
+    @pytest.mark.tags(CaseLabel.L0)
     def test_import_2pc_manual_compaction_after_commit_preserves_rows(self):
         """
         target: manual compaction after committed import rows
@@ -5841,7 +5842,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_flat_scann_manual_import_searches_after_commit(self):
         """
         target: FLAT and SCANN index import
@@ -6081,7 +6082,7 @@ class TestImport2PCRestOperation(TestBase):
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_sparse_struct_parquet_manual_import_searches_after_commit(self):
         """
         target: SparseFloatVector parquet struct encoding with manual 2PC
@@ -6135,7 +6136,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_bm25_function_input_only_manual_import_searches_after_commit(self):
         """
         target: BM25 function output generation with manual 2PC import
@@ -6207,7 +6208,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_bm25_function_output_field_rejected_and_no_visible_rows(self):
         """
         target: BM25 function output field guardrail with manual 2PC import
@@ -6260,7 +6261,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_scalar_indexes_manual_import_filters_after_commit(self):
         """
         target: scalar indexes with manual 2PC import
@@ -6333,7 +6334,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_half_vector_types_manual_import_searches_after_commit(self):
         """
         target: Float16Vector and BFloat16Vector import with 2PC
@@ -6400,7 +6401,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_int8_vector_manual_import_searches_after_commit(self):
         """
         target: Int8Vector import with 2PC
@@ -6460,7 +6461,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_array_of_vector_manual_import_searches_after_commit(self):
         """
         target: ArrayOfVector import with 2PC
@@ -6528,7 +6529,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_geometry_timestamptz_manual_import_filters_after_commit(self):
         """
         target: Geometry and Timestamptz import with 2PC
@@ -7175,7 +7176,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_partition_key_collection_rejects_explicit_partition_name(self):
         """
         target: explicit partitionName guardrail on partition-key collection import
@@ -7270,7 +7271,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_clustering_key_collection_manual_import_survives_clustering_compaction(self):
         """
         target: clustering-key collection import and clustering compaction with manual 2PC
@@ -7546,7 +7547,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_binary_vector_byte_length_mismatch_fails_with_reason_and_no_visible_rows(self):
         """
         target: BinaryVector byte-length validation for manual import
@@ -7654,7 +7655,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_varchar_overflow_fails_with_reason_and_no_visible_rows(self):
         """
         target: varchar max_length validation for manual import
@@ -7767,7 +7768,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_field_type_mismatch_fails_with_reason_and_no_visible_rows(self):
         """
         target: field type validation for manual import
@@ -7890,7 +7891,7 @@ class TestImport2PCRestOperation(TestBase):
             if os.path.exists(file_path):
                 os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_vector_nan_inf_fails_with_reason_and_no_visible_rows(self):
         """
         target: FloatVector finite-value validation for manual import
@@ -8151,7 +8152,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_flush_during_uncommitted_keeps_import_invisible(self):
         """
         target: manual flush while import is Uncommitted
@@ -8260,7 +8261,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_delete_after_commit_removes_import_rows(self):
         """
         target: delete timestamp after import commit timestamp
@@ -8314,7 +8315,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_mixed_delete_across_commit_boundary(self):
         """
         target: mixed delete timestamps around import commit timestamp
@@ -8387,7 +8388,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_auto_id_scalar_delete_respects_commit_timestamp(self):
         """
         target: auto_id collection delete timestamp boundary with scalar filter
@@ -8518,7 +8519,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_abort_is_idempotent_for_failed_job(self):
         """
         target: abort retry idempotency for terminal failed import job
@@ -8736,7 +8737,7 @@ class TestImport2PCRestOperation(TestBase):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L2)
     def test_import_2pc_abort_rejects_completed_job(self):
         """
         target: abort terminal committed import job


### PR DESCRIPTION
Cherry-pick from master

pr: #52742
pr: #52839
pr: #53091
pr: #53302

## Summary

Backport four test improvements to the 3.0 branch:

- Tolerate expected GPU reranker score drift while preserving set and meaningful ordering checks.
- Move extended import 2PC REST scenarios from L0 to L2 without deleting coverage.
- Add regression coverage for search-by-PK input order; the corresponding 3.0 product fix is #52999.
- Pass IVF nprobe through ANN params and correct expected/actual assertion ordering in Go client tests.

issue: #52737
issue: #52862
issue: #50392

## Test Plan

- [x] Applied all four source PR patches to the latest origin/3.0 without conflicts.
- [x] git diff --check origin/3.0...HEAD
- [x] Python py_compile for all changed Python test files.
- [x] Ruff check and format check for all changed Python test files.
- [x] GO_CLIENT_SKIP_EXTERNAL_TABLE_DEPS_INSTALL=1 go test -c ./testcases
- [ ] make static-check: local environment has no supported LLVM 14-18; the command stopped before running core package checks.