### PR TITLE
fix: [3.0] decide Take output eligibility at request scope

### DIFF
--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -64,6 +64,7 @@ struct Plan {
     // collections this drives manifest-column checks, not data readiness.
     std::vector<FieldId> access_entries_;
     std::vector<std::string> target_dynamic_fields_;
+    bool take_for_output_allowed_{true};
 
  public:
     std::optional<ExtractedPlanInfo> extra_info_opt_;
@@ -132,6 +133,7 @@ struct RetrievePlan {
     // collections this drives manifest-column checks, not data readiness.
     std::vector<FieldId> access_entries_;
     std::vector<std::string> target_dynamic_fields_;
+    bool take_for_output_allowed_{true};
 };
 
 using PlanPtr = std::unique_ptr<Plan>;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5897,7 +5897,19 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         }
 
         case DataType::TEXT: {
-            // TEXT type is only supported in StorageV3 with LOB files.
+            // External TEXT columns store their source values directly,
+            // while internal StorageV3 TEXT columns store encoded LOB refs.
+            if (field_meta.is_external_field()) {
+                bulk_subscript_ptr_impl<std::string>(op_ctx,
+                                                     column.get(),
+                                                     seg_offsets,
+                                                     count,
+                                                     ret->mutable_scalars()
+                                                         ->mutable_string_data()
+                                                         ->mutable_data());
+                break;
+            }
+
             auto runtime = snapshot->runtime != nullptr
                                ? snapshot->runtime
                                : BuildRuntimeResourceState();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -9537,18 +9537,8 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     milvus::OpContext* op_ctx) const {
     auto snapshot = CapturePublishedState();
     auto schema_snapshot = snapshot->schema;
-    if (size == 0 || !snapshot->use_take_for_output) {
-        return false;
-    }
-    auto result_count_limit = SegcoreConfig::default_config()
-                                  .get_take_for_output_result_count_limit();
-    if (result_count_limit > 0 && size > result_count_limit) {
-        LOG_DEBUG(
-            "[TakeAPI] retrieve skipped take() for segment {} because "
-            "result count {} exceeds limit {}",
-            id_,
-            size,
-            result_count_limit);
+    if (size == 0 || !snapshot->use_take_for_output ||
+        !plan->take_for_output_allowed_) {
         return false;
     }
     const bool is_external_collection =
@@ -9838,22 +9828,9 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                                            milvus::OpContext* op_ctx) const {
     auto snapshot = CapturePublishedState();
     auto schema_snapshot = snapshot->schema;
-    if (size == 0 || !snapshot->use_take_for_output) {
+    if (size == 0 || !snapshot->use_take_for_output ||
+        !plan->take_for_output_allowed_) {
         return false;
-    }
-    auto result_count_limit = SegcoreConfig::default_config()
-                                  .get_take_for_output_result_count_limit();
-    if (plan->plan_node_ != nullptr) {
-        auto topk = plan->plan_node_->search_info_.topk_;
-        if (result_count_limit > 0 && topk > result_count_limit) {
-            LOG_DEBUG(
-                "[TakeAPI] search skipped take() for segment {} because "
-                "topk {} exceeds limit {}",
-                id_,
-                topk,
-                result_count_limit);
-            return false;
-        }
     }
     const bool is_external_collection =
         schema_snapshot->is_external_collection();
@@ -9885,16 +9862,6 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     }
 
     auto ctx = BuildTakeContext(seg_offsets, size);
-    if (result_count_limit > 0 &&
-        ctx.unique_offsets.size() > static_cast<size_t>(result_count_limit)) {
-        LOG_DEBUG(
-            "[TakeAPI] search skipped take() for segment {} because "
-            "unique offset count {} exceeds limit {}",
-            id_,
-            ctx.unique_offsets.size(),
-            result_count_limit);
-        return false;
-    }
     if (SegcoreConfig::default_config().get_reject_remote_vector_output() &&
         has_vector_output) {
         LogTakeFallback("search",

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <unordered_set>
@@ -227,20 +226,7 @@ class SegcoreConfig {
         return reject_remote_vector_output_;
     }
 
-    void
-    set_take_for_output_result_count_limit(int64_t value) {
-        take_for_output_result_count_limit_.store(value,
-                                                  std::memory_order_relaxed);
-    }
-
-    int64_t
-    get_take_for_output_result_count_limit() const {
-        return take_for_output_result_count_limit_.load(
-            std::memory_order_relaxed);
-    }
-
     static constexpr int64_t kDefaultMaxGroupByGroups = 100000;
-    static constexpr int64_t kDefaultTakeForOutputResultCountLimit = 10000;
 
     int64_t
     get_max_group_by_groups() const {
@@ -298,8 +284,6 @@ class SegcoreConfig {
     inline static bool enable_gis_split_fusion_ = false;
     inline static bool prefer_field_data_when_index_has_raw_data_ = false;
     inline static bool reject_remote_vector_output_ = false;
-    inline static std::atomic<int64_t> take_for_output_result_count_limit_{
-        kDefaultTakeForOutputResultCountLimit};
     inline static float interim_index_mem_expansion_rate_ = 1.15f;
     inline static int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
 };

--- a/internal/core/src/segcore/plan_c.cpp
+++ b/internal/core/src/segcore/plan_c.cpp
@@ -128,6 +128,18 @@ GetTopK(CSearchPlan plan) {
     return res;
 }
 
+int64_t
+GetGroupSize(CSearchPlan plan) {
+    auto search_plan = static_cast<milvus::query::Plan*>(plan);
+    return search_plan->plan_node_->search_info_.group_size_;
+}
+
+void
+SetSearchPlanTakeForOutputAllowed(CSearchPlan plan, bool allowed) {
+    auto search_plan = static_cast<milvus::query::Plan*>(plan);
+    search_plan->take_for_output_allowed_ = allowed;
+}
+
 CStatus
 GetFieldID(CSearchPlan plan, int64_t* field_id) {
     try {
@@ -210,6 +222,12 @@ void
 DeleteRetrievePlan(CRetrievePlan c_plan) {
     auto plan = static_cast<milvus::query::RetrievePlan*>(c_plan);
     delete plan;
+}
+
+void
+SetRetrievePlanTakeForOutputAllowed(CRetrievePlan c_plan, bool allowed) {
+    auto plan = static_cast<milvus::query::RetrievePlan*>(c_plan);
+    plan->take_for_output_allowed_ = allowed;
 }
 
 bool

--- a/internal/core/src/segcore/plan_c.h
+++ b/internal/core/src/segcore/plan_c.h
@@ -44,6 +44,12 @@ GetNumOfQueries(CPlaceholderGroup placeholder_group);
 int64_t
 GetTopK(CSearchPlan plan);
 
+int64_t
+GetGroupSize(CSearchPlan plan);
+
+void
+SetSearchPlanTakeForOutputAllowed(CSearchPlan plan, bool allowed);
+
 CStatus
 GetFieldID(CSearchPlan plan, int64_t* field_id);
 
@@ -70,6 +76,9 @@ CreateRetrievePlanByExpr(CCollection c_col,
 
 void
 DeleteRetrievePlan(CRetrievePlan plan);
+
+void
+SetRetrievePlanTakeForOutputAllowed(CRetrievePlan plan, bool allowed);
 
 bool
 ShouldIgnoreNonPk(CRetrievePlan plan);

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -120,20 +120,6 @@ SegcoreSetPreferFieldDataWhenIndexHasRawData(const bool value) {
 }
 
 extern "C" void
-SegcoreSetTakeForOutputResultCountLimit(const int64_t value) {
-    milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
-    config.set_take_for_output_result_count_limit(value);
-}
-
-extern "C" int64_t
-SegcoreGetTakeForOutputResultCountLimit() {
-    milvus::segcore::SegcoreConfig& config =
-        milvus::segcore::SegcoreConfig::default_config();
-    return config.get_take_for_output_result_count_limit();
-}
-
-extern "C" void
 SegcoreSetNlist(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -109,12 +109,6 @@ void
 SegcoreSetPreferFieldDataWhenIndexHasRawData(const bool value);
 
 void
-SegcoreSetTakeForOutputResultCountLimit(const int64_t value);
-
-int64_t
-SegcoreGetTakeForOutputResultCountLimit();
-
-void
 SegcoreCloseGlog();
 
 int32_t

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -2586,7 +2586,7 @@ TEST(ExternalTakeAccessMode, RequestGateDisabledFallsBackForExternalText) {
     ASSERT_EQ(retrieve_results->fields_data_size(), 1);
     const auto& retrieved = retrieve_results->fields_data(0);
     EXPECT_EQ(retrieved.field_id(), text_id.get());
-    const auto& retrieve_valid = GetFieldDataRowValidData(retrieved);
+    const auto& retrieve_valid = retrieved.valid_data();
     ASSERT_EQ(retrieve_valid.size(), offsets.size());
     EXPECT_TRUE(retrieve_valid[0]);
     EXPECT_FALSE(retrieve_valid[1]);
@@ -2606,7 +2606,7 @@ TEST(ExternalTakeAccessMode, RequestGateDisabledFallsBackForExternalText) {
     segment->TestFillTargetEntry(search_plan.get(), search_results);
 
     const auto& searched = *search_results.output_fields_data_.at(text_id);
-    const auto& search_valid = GetFieldDataRowValidData(searched);
+    const auto& search_valid = searched.valid_data();
     ASSERT_EQ(search_valid.size(), offsets.size());
     EXPECT_TRUE(search_valid[0]);
     EXPECT_FALSE(search_valid[1]);

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -44,8 +44,6 @@
 #include "storage/loon_ffi/external_spec_c.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
-#include "test_utils/DataGen.h"
-#include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::segcore;
@@ -72,24 +70,6 @@ class ScopedRejectRemoteVectorOutput {
 
  private:
     bool old_value_;
-};
-
-class ScopedTakeForOutputResultCountLimit {
- public:
-    explicit ScopedTakeForOutputResultCountLimit(int64_t limit)
-        : old_value_(SegcoreConfig::default_config()
-                         .get_take_for_output_result_count_limit()) {
-        SegcoreConfig::default_config().set_take_for_output_result_count_limit(
-            limit);
-    }
-
-    ~ScopedTakeForOutputResultCountLimit() {
-        SegcoreConfig::default_config().set_take_for_output_result_count_limit(
-            old_value_);
-    }
-
- private:
-    int64_t old_value_;
 };
 
 class ScopedExternalIopsConfig {
@@ -180,11 +160,6 @@ class MockTakeReader : public milvus_storage::api::Reader {
         : table_(std::move(table)) {
     }
 
-    size_t
-    take_call_count() const {
-        return take_call_count_;
-    }
-
     std::shared_ptr<milvus_storage::api::ColumnGroups>
     get_column_groups() const override {
         return nullptr;
@@ -206,7 +181,6 @@ class MockTakeReader : public milvus_storage::api::Reader {
          size_t,
          const std::shared_ptr<std::vector<std::string>>& needed_columns)
         override {
-        ++take_call_count_;
         if (!table_) {
             return arrow::Status::Invalid("no table");
         }
@@ -235,8 +209,6 @@ class MockTakeReader : public milvus_storage::api::Reader {
     }
 
  private:
-    size_t take_call_count_{0};
-
     // Select rows from table at given indices using arrow::compute::Take.
     static arrow::Result<std::shared_ptr<arrow::Table>>
     SelectRows(const std::shared_ptr<arrow::Table>& table,
@@ -1722,7 +1694,9 @@ TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackNonExternal) {
     EXPECT_FALSE(ok);
 }
 
-TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackAboveResultCountLimit) {
+// Segment-local result size does not make a second policy decision. The
+// request gate is the only result-count policy input.
+TEST(ExternalTakeTest, TryTakeForRetrieve_LargeSegmentUsesRequestGate) {
     auto [schema,
           bool_id,
           int8_id,
@@ -1736,21 +1710,21 @@ TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackAboveResultCountLimit) {
     auto table = BuildTestArrowTable();
     SegmentSealedUPtr holder;
     auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
     segment->SetUseTakeForOutputForTesting(true);
 
     auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->field_ids_ = {int64_id};
+    plan->take_for_output_allowed_ = true;
 
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
     auto results = std::make_unique<proto::segcore::RetrieveResults>();
-    std::vector<int64_t> offsets = {0, 1, 2};
+    std::vector<int64_t> offsets(10001, 0);
     bool ok = segment->TryTakeForRetrieve(
-        plan.get(), results, offsets.data(), offsets.size(), false, false);
-    EXPECT_FALSE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 0);
+        plan.get(), results, offsets.data(), 10001, false, false);
+    EXPECT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+    EXPECT_EQ(results->fields_data(0).scalars().long_data().data_size(),
+              offsets.size());
 }
 
 // Test fallback: returns false when reader is null
@@ -2384,9 +2358,9 @@ TEST(ExternalTakeTest, TryTakeForSearch_FallbackNonExternal) {
     EXPECT_FALSE(ok);
 }
 
-// A large result size is not the search topK. This falls back only because
-// the reader is absent and the plan has no vector node with a topK value.
-TEST(ExternalTakeTest, TryTakeForSearch_LargeResultFallbackNullReader) {
+// Segment-local result size does not make a second policy decision. The
+// request gate is the only result-count policy input.
+TEST(ExternalTakeTest, TryTakeForSearch_LargeSegmentUsesRequestGate) {
     auto [schema,
           bool_id,
           int8_id,
@@ -2397,17 +2371,23 @@ TEST(ExternalTakeTest, TryTakeForSearch_LargeResultFallbackNullReader) {
           double_id,
           varchar_id,
           vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
     SegmentSealedUPtr holder;
     auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
 
     auto plan = std::make_unique<query::Plan>(schema);
     plan->target_entries_ = {int64_id};
+    plan->take_for_output_allowed_ = true;
 
     SearchResult results;
     std::vector<int64_t> offsets(10001, 0);
     bool ok = segment->TestTryTakeForSearch(
         plan.get(), offsets.data(), 10001, results);
-    EXPECT_FALSE(ok);
+    EXPECT_TRUE(ok);
+    auto& field_data = results.output_fields_data_.at(int64_id);
+    EXPECT_EQ(field_data->scalars().long_data().data_size(), offsets.size());
 }
 
 // Unsupported data type (ARRAY) in search → clears results, returns false
@@ -2428,7 +2408,7 @@ TEST(ExternalTakeTest, TryTakeForSearch_UnsupportedType) {
     EXPECT_TRUE(results.output_fields_data_.empty());
 }
 
-// ---------- Access mode threshold logic tests ----------
+// ---------- Access mode and request gate tests ----------
 
 // use_take_for_output=false: TryTakeForRetrieve returns false
 TEST(ExternalTakeAccessMode, RetrieveDisabledReturnsFalse) {
@@ -2489,7 +2469,7 @@ TEST(ExternalTakeAccessMode, RetrieveEnabledUsesTake) {
     EXPECT_EQ(results->fields_data(0).scalars().long_data().data_size(), size);
 }
 
-TEST(ExternalTakeAccessMode, RetrieveUsesTakeAtResultCountLimit) {
+TEST(ExternalTakeAccessMode, RetrieveRequestGateDisabledReturnsFalse) {
     auto [schema,
           bool_id,
           int8_id,
@@ -2503,88 +2483,19 @@ TEST(ExternalTakeAccessMode, RetrieveUsesTakeAtResultCountLimit) {
     auto table = BuildTestArrowTable();
     SegmentSealedUPtr holder;
     auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
     segment->SetUseTakeForOutputForTesting(true);
 
     auto plan = std::make_unique<query::RetrievePlan>(schema);
     plan->field_ids_ = {int64_id};
+    plan->take_for_output_allowed_ = false;
 
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
     auto results = std::make_unique<proto::segcore::RetrieveResults>();
-    std::vector<int64_t> offsets = {0, 1};
+    int64_t offset = 0;
     bool ok = segment->TryTakeForRetrieve(
-        plan.get(), results, offsets.data(), offsets.size(), false, false);
-    EXPECT_TRUE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 1);
-}
-
-TEST(ExternalTakeAccessMode,
-     RetrieveFallsBackToBulkSubscriptAboveResultCountLimit) {
-    auto schema = std::make_shared<Schema>();
-    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
-    schema->set_primary_field_id(pk_id);
-    auto dataset = DataGen(schema, kTestRows);
-    auto holder = CreateSealedWithFieldDataLoaded(schema, dataset);
-    auto* segment = dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
-    ASSERT_NE(segment, nullptr);
-
-    auto reader = std::make_unique<MockTakeReader>(nullptr);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
-    segment->SetUseTakeForOutputForTesting(true);
-
-    auto plan = std::make_unique<query::RetrievePlan>(schema);
-    plan->field_ids_ = {pk_id};
-
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
-    std::vector<int64_t> offsets = {0, 1, 3};
-    auto results = segment->Retrieve(nullptr,
-                                     plan.get(),
-                                     offsets.data(),
-                                     offsets.size(),
-                                     folly::CancellationToken());
-
-    EXPECT_EQ(reader_ptr->take_call_count(), 0);
-    ASSERT_EQ(results->fields_data_size(), 1);
-    auto expected = dataset.get_col<int64_t>(pk_id);
-    auto& long_data = results->fields_data(0).scalars().long_data();
-    ASSERT_EQ(long_data.data_size(), 3);
-    EXPECT_EQ(long_data.data(0), expected[0]);
-    EXPECT_EQ(long_data.data(1), expected[1]);
-    EXPECT_EQ(long_data.data(2), expected[3]);
-}
-
-TEST(ExternalTakeAccessMode, RetrieveUsesTakeWhenResultCountLimitDisabled) {
-    auto [schema,
-          bool_id,
-          int8_id,
-          int16_id,
-          int32_id,
-          int64_id,
-          float_id,
-          double_id,
-          varchar_id,
-          vec_id] = BuildExternalSchema();
-    auto table = BuildTestArrowTable();
-    SegmentSealedUPtr holder;
-    auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
-    segment->SetUseTakeForOutputForTesting(true);
-
-    auto plan = std::make_unique<query::RetrievePlan>(schema);
-    plan->field_ids_ = {int64_id};
-
-    ScopedTakeForOutputResultCountLimit scoped_limit(0);
-    auto results = std::make_unique<proto::segcore::RetrieveResults>();
-    std::vector<int64_t> offsets = {0, 1, 2};
-    bool ok = segment->TryTakeForRetrieve(
-        plan.get(), results, offsets.data(), offsets.size(), false, false);
-    EXPECT_TRUE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 1);
+        plan.get(), results, &offset, 1, false, false);
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(results->fields_data_size(), 0);
 }
 
 TEST(ExternalTakeAccessMode, RetrieveRejectRemoteVectorOutputReturnsFalse) {
@@ -2679,7 +2590,7 @@ TEST(ExternalTakeAccessMode, SearchEnabledUsesTake) {
     EXPECT_EQ(int64_arr->scalars().long_data().data(2), 40000);
 }
 
-TEST(ExternalTakeAccessMode, SearchUsesTakeAtResultCountLimit) {
+TEST(ExternalTakeAccessMode, SearchRequestGateDisabledReturnsFalse) {
     auto [schema,
           bool_id,
           int8_id,
@@ -2693,122 +2604,18 @@ TEST(ExternalTakeAccessMode, SearchUsesTakeAtResultCountLimit) {
     auto table = BuildTestArrowTable();
     SegmentSealedUPtr holder;
     auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
     segment->SetUseTakeForOutputForTesting(true);
 
     auto plan = std::make_unique<query::Plan>(schema);
-    plan->plan_node_ = std::make_unique<query::VectorPlanNode>();
-    plan->plan_node_->search_info_.topk_ = 2;
     plan->target_entries_ = {int64_id};
+    plan->take_for_output_allowed_ = false;
 
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
-    SearchResult results;
-    int64_t offset = 0;
-    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
-    EXPECT_TRUE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 1);
-}
-
-TEST(ExternalTakeAccessMode, SearchSkipsTakeAboveResultCountLimit) {
-    auto [schema,
-          bool_id,
-          int8_id,
-          int16_id,
-          int32_id,
-          int64_id,
-          float_id,
-          double_id,
-          varchar_id,
-          vec_id] = BuildExternalSchema();
-    auto table = BuildTestArrowTable();
-    SegmentSealedUPtr holder;
-    auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
-    segment->SetUseTakeForOutputForTesting(true);
-
-    auto plan = std::make_unique<query::Plan>(schema);
-    plan->plan_node_ = std::make_unique<query::VectorPlanNode>();
-    plan->plan_node_->search_info_.topk_ = 3;
-    plan->target_entries_ = {int64_id};
-
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
     SearchResult results;
     int64_t offset = 0;
     bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
     EXPECT_FALSE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 0);
-}
-
-TEST(ExternalTakeAccessMode,
-     FillTargetEntryFallsBackAboveUniqueOffsetCountLimit) {
-    auto schema = std::make_shared<Schema>();
-    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
-    schema->set_primary_field_id(pk_id);
-    auto dataset = DataGen(schema, kTestRows);
-    auto holder = CreateSealedWithFieldDataLoaded(schema, dataset);
-    auto* segment = dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
-    ASSERT_NE(segment, nullptr);
-
-    auto reader = std::make_unique<MockTakeReader>(nullptr);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
-    segment->SetUseTakeForOutputForTesting(true);
-
-    auto plan = std::make_unique<query::Plan>(schema);
-    plan->plan_node_ = std::make_unique<query::VectorPlanNode>();
-    plan->plan_node_->search_info_.topk_ = 2;
-    plan->target_entries_ = {pk_id};
-
-    ScopedTakeForOutputResultCountLimit scoped_limit(2);
-    SearchResult results;
-    results.distances_ = {0.1F, 0.2F, 0.3F};
-    results.seg_offsets_ = {0, 1, 3};
-
-    segment->TestFillTargetEntry(plan.get(), results);
-
-    EXPECT_EQ(reader_ptr->take_call_count(), 0);
-    auto& field_data = results.output_fields_data_.at(pk_id);
-    auto expected = dataset.get_col<int64_t>(pk_id);
-    ASSERT_EQ(field_data->scalars().long_data().data_size(), 3);
-    EXPECT_EQ(field_data->scalars().long_data().data(0), expected[0]);
-    EXPECT_EQ(field_data->scalars().long_data().data(1), expected[1]);
-    EXPECT_EQ(field_data->scalars().long_data().data(2), expected[3]);
-}
-
-TEST(ExternalTakeAccessMode, SearchUsesTakeWhenResultCountLimitDisabled) {
-    auto [schema,
-          bool_id,
-          int8_id,
-          int16_id,
-          int32_id,
-          int64_id,
-          float_id,
-          double_id,
-          varchar_id,
-          vec_id] = BuildExternalSchema();
-    auto table = BuildTestArrowTable();
-    SegmentSealedUPtr holder;
-    auto* segment = CreateExternalSegment(holder, schema);
-    auto reader = std::make_unique<MockTakeReader>(table);
-    auto* reader_ptr = reader.get();
-    segment->SetReaderForTesting(std::move(reader));
-    segment->SetUseTakeForOutputForTesting(true);
-
-    auto plan = std::make_unique<query::Plan>(schema);
-    plan->plan_node_ = std::make_unique<query::VectorPlanNode>();
-    plan->plan_node_->search_info_.topk_ = 10001;
-    plan->target_entries_ = {int64_id};
-
-    ScopedTakeForOutputResultCountLimit scoped_limit(0);
-    SearchResult results;
-    int64_t offset = 0;
-    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
-    EXPECT_TRUE(ok);
-    EXPECT_EQ(reader_ptr->take_call_count(), 1);
+    EXPECT_TRUE(results.output_fields_data_.empty());
 }
 
 TEST(ExternalTakeAccessMode, SearchRejectRemoteVectorOutputReturnsFalse) {

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "common/ChunkWriter.h"
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/FieldMeta.h"
@@ -44,6 +45,7 @@
 #include "storage/loon_ffi/external_spec_c.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
+#include "test_utils/cachinglayer_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::segcore;
@@ -1025,6 +1027,58 @@ CreateExternalSegment(SegmentSealedUPtr& holder,
                       int64_t segment_id = 1) {
     holder = CreateSealedSegment(schema, nullptr, segment_id);
     return dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
+}
+
+std::shared_ptr<ChunkedColumnInterface>
+BuildExternalTextColumn(const FieldMeta& field_meta) {
+    arrow::BinaryBuilder builder;
+    EXPECT_TRUE(builder.Append("external text 0").ok());
+    EXPECT_TRUE(builder.AppendNull().ok());
+    EXPECT_TRUE(builder.Append("external text 2").ok());
+    auto array = builder.Finish().ValueOrDie();
+
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        create_chunk(field_meta, arrow::ArrayVector{std::move(array)}));
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{3}, "", std::move(chunks));
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    return MakeChunkedColumnBase(DataType::TEXT, std::move(slot), field_meta);
+}
+
+void
+LoadExternalTextColumnForTesting(ChunkedSegmentSealedImpl* segment,
+                                 const SchemaPtr& schema,
+                                 FieldId field_id) {
+    auto current = segment->TestGetPublishedStateSnapshot();
+    auto runtime = segment->TestCloneMutableRuntimeResourceState();
+
+    ChunkedSegmentSealedImpl::StateDelta initial_delta;
+    initial_delta.schema = current->schema;
+    initial_delta.load_info = current->load_info;
+    initial_delta.runtime = segment->TestFreezeRuntimeResourceState(runtime);
+    initial_delta.commit_ts = current->commit_ts;
+    auto staged = segment->TestBuildNextPublishedState(current, initial_delta);
+
+    ChunkedSegmentSealedImpl::StateDelta final_delta;
+    final_delta.schema = current->schema;
+    final_delta.load_info = current->load_info;
+    final_delta.commit_ts = current->commit_ts;
+
+    auto column = BuildExternalTextColumn(schema->operator[](field_id));
+    segment->TestStageLoadFieldDataThenPublish(field_id,
+                                               column,
+                                               3,
+                                               DataType::TEXT,
+                                               schema,
+                                               runtime,
+                                               staged.get(),
+                                               current,
+                                               final_delta,
+                                               [] {});
 }
 
 // Mock Reader that always returns an error from take().
@@ -2496,6 +2550,72 @@ TEST(ExternalTakeAccessMode, RetrieveRequestGateDisabledReturnsFalse) {
         plan.get(), results, &offset, 1, false, false);
     EXPECT_FALSE(ok);
     EXPECT_EQ(results->fields_data_size(), 0);
+}
+
+TEST(ExternalTakeAccessMode, RequestGateDisabledFallsBackForExternalText) {
+    auto info = BuildExternalSchema();
+    auto text_id = FieldId(109);
+    info.schema->AddField(FieldMeta(FieldName("text_col"),
+                                    text_id,
+                                    DataType::TEXT,
+                                    65535,
+                                    true,
+                                    std::nullopt,
+                                    "text_col"));
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetUseTakeForOutputForTesting(true);
+    LoadExternalTextColumnForTesting(segment, info.schema, text_id);
+
+    auto retrieve_plan = std::make_unique<query::RetrievePlan>(info.schema);
+    retrieve_plan->field_ids_ = {text_id};
+    retrieve_plan->take_for_output_allowed_ = false;
+
+    auto retrieve_results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+    static_cast<SegmentInternalInterface*>(segment)->FillTargetEntry(
+        nullptr,
+        retrieve_plan.get(),
+        retrieve_results,
+        offsets.data(),
+        offsets.size(),
+        false,
+        false);
+
+    ASSERT_EQ(retrieve_results->fields_data_size(), 1);
+    const auto& retrieved = retrieve_results->fields_data(0);
+    EXPECT_EQ(retrieved.field_id(), text_id.get());
+    const auto& retrieve_valid = GetFieldDataRowValidData(retrieved);
+    ASSERT_EQ(retrieve_valid.size(), offsets.size());
+    EXPECT_TRUE(retrieve_valid[0]);
+    EXPECT_FALSE(retrieve_valid[1]);
+    EXPECT_TRUE(retrieve_valid[2]);
+    const auto& retrieve_text = retrieved.scalars().string_data().data();
+    ASSERT_EQ(retrieve_text.size(), offsets.size());
+    EXPECT_EQ(retrieve_text[0], "external text 0");
+    EXPECT_TRUE(retrieve_text[1].empty());
+    EXPECT_EQ(retrieve_text[2], "external text 2");
+
+    auto search_plan = std::make_unique<query::Plan>(info.schema);
+    search_plan->target_entries_ = {text_id};
+    search_plan->take_for_output_allowed_ = false;
+    SearchResult search_results;
+    search_results.seg_offsets_ = offsets;
+    search_results.distances_.resize(offsets.size());
+    segment->TestFillTargetEntry(search_plan.get(), search_results);
+
+    const auto& searched = *search_results.output_fields_data_.at(text_id);
+    const auto& search_valid = GetFieldDataRowValidData(searched);
+    ASSERT_EQ(search_valid.size(), offsets.size());
+    EXPECT_TRUE(search_valid[0]);
+    EXPECT_FALSE(search_valid[1]);
+    EXPECT_TRUE(search_valid[2]);
+    const auto& search_text = searched.scalars().string_data().data();
+    ASSERT_EQ(search_text.size(), offsets.size());
+    EXPECT_EQ(search_text[0], "external text 0");
+    EXPECT_TRUE(search_text[1].empty());
+    EXPECT_EQ(search_text[2], "external text 2");
 }
 
 TEST(ExternalTakeAccessMode, RetrieveRejectRemoteVectorOutputReturnsFalse) {

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -1559,7 +1559,8 @@ TEST(Indexing, DiskAnnEmbListBuildWithDataset) {
     int64_t partition_id = 2;
     int64_t segment_id = 3;
     int64_t field_id = 100;
-    int64_t build_id = 1000;
+    // Test shards share the remote files root, so uploads need unique IDs.
+    int64_t build_id = 5304601;
     int64_t index_version = 1;
 
     StorageConfig storage_config = get_default_local_storage_config();
@@ -1668,7 +1669,8 @@ TEST(Indexing, DiskAnnEmbListBuildFromBinlog) {
     int64_t partition_id = 2;
     int64_t segment_id = 3;
     int64_t field_id = 100;
-    int64_t build_id = 1000;
+    // Keep uploads separate from the concurrent BuildWithDataset test.
+    int64_t build_id = 5304602;
     int64_t index_version = 1;
 
     // Generate VECTOR_ARRAY field data with variable-length emb_lists

--- a/internal/querynodev2/tasks/query_stream_task.go
+++ b/internal/querynodev2/tasks/query_stream_task.go
@@ -3,10 +3,13 @@ package tasks
 import (
 	"context"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 )
 
@@ -68,6 +71,13 @@ func (t *QueryStreamTask) Execute() error {
 		return err
 	}
 	defer retrievePlan.Delete()
+	plan := &planpb.PlanNode{}
+	if err := proto.Unmarshal(t.req.Req.GetSerializedExprPlan(), plan); err != nil {
+		return err
+	}
+	retrievePlan.SetTakeForOutputAllowed(requestAllowsTakeForOutput(
+		retrieveTakeForOutputResultCount(t.req.GetReq(), plan),
+	))
 
 	srv := streamrpc.NewResultCacheServer(t.srv, t.minMsgSize, t.maxMsgSize)
 	defer srv.Flush()

--- a/internal/querynodev2/tasks/query_stream_task.go
+++ b/internal/querynodev2/tasks/query_stream_task.go
@@ -75,9 +75,9 @@ func (t *QueryStreamTask) Execute() error {
 	if err := proto.Unmarshal(t.req.Req.GetSerializedExprPlan(), plan); err != nil {
 		return err
 	}
-	retrievePlan.SetTakeForOutputAllowed(requestAllowsTakeForOutput(
-		retrieveTakeForOutputResultCount(t.req.GetReq(), plan),
-	))
+	resultCount := retrieveTakeForOutputResultCount(t.req.GetReq(), plan)
+	takeAllowed := requestAllowsTakeForOutput(resultCount)
+	retrievePlan.SetTakeForOutputAllowed(takeAllowed)
 
 	srv := streamrpc.NewResultCacheServer(t.srv, t.minMsgSize, t.maxMsgSize)
 	defer srv.Flush()

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -119,6 +119,9 @@ func (t *QueryTask) Execute() error {
 		return err
 	}
 	defer retrievePlan.Delete()
+	retrievePlan.SetTakeForOutputAllowed(requestAllowsTakeForOutput(
+		retrieveTakeForOutputResultCount(t.req.GetReq(), t.plan),
+	))
 
 	results, pinnedSegments, err := segments.Retrieve(t.ctx, t.segmentManager, retrievePlan, t.req)
 	defer t.segmentManager.Segment.Unpin(pinnedSegments)

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -119,9 +119,9 @@ func (t *QueryTask) Execute() error {
 		return err
 	}
 	defer retrievePlan.Delete()
-	retrievePlan.SetTakeForOutputAllowed(requestAllowsTakeForOutput(
-		retrieveTakeForOutputResultCount(t.req.GetReq(), t.plan),
-	))
+	resultCount := retrieveTakeForOutputResultCount(t.req.GetReq(), t.plan)
+	takeAllowed := requestAllowsTakeForOutput(resultCount)
+	retrievePlan.SetTakeForOutputAllowed(takeAllowed)
 
 	results, pinnedSegments, err := segments.Retrieve(t.ctx, t.segmentManager, retrievePlan, t.req)
 	defer t.segmentManager.Segment.Unpin(pinnedSegments)

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -35,21 +35,22 @@ var (
 )
 
 type SearchTask struct {
-	ctx              context.Context
-	collection       *segments.Collection
-	segmentManager   *segments.Manager
-	req              *querypb.SearchRequest
-	result           *internalpb.SearchResults
-	merged           bool
-	groupSize        int64
-	topk             int64
-	nq               int64
-	placeholderGroup []byte
-	originTopks      []int64
-	originNqs        []int64
-	others           []*SearchTask
-	notifier         chan error
-	serverID         int64
+	ctx                  context.Context
+	collection           *segments.Collection
+	segmentManager       *segments.Manager
+	req                  *querypb.SearchRequest
+	result               *internalpb.SearchResults
+	merged               bool
+	groupSize            int64
+	topk                 int64
+	nq                   int64
+	placeholderGroup     []byte
+	originTopks          []int64
+	originNqs            []int64
+	takeForOutputAllowed []bool
+	others               []*SearchTask
+	notifier             chan error
+	serverID             int64
 
 	tr           *timerecord.TimeRecorder
 	scheduleSpan trace.Span
@@ -158,6 +159,24 @@ func (t *SearchTask) Execute() error {
 		return err
 	}
 	defer searchReq.Delete()
+	t.takeForOutputAllowed = make([]bool, len(t.originNqs))
+	groupSize := searchReq.Plan().GetGroupSize()
+	// Use each original request's output topK. The optimizer may lower the
+	// C++ plan topK used for segment search without lowering the final output
+	// contract, and task merging must not turn several requests into one limit.
+	for i := range t.originNqs {
+		t.takeForOutputAllowed[i] = requestAllowsTakeForOutput(
+			searchTakeForOutputResultCount(
+				t.originNqs[i],
+				t.originTopks[i],
+				groupSize,
+			),
+		)
+	}
+	// A merged task carries one C++ plan but materializes each original
+	// request separately. Keep Take disabled until the corresponding request
+	// decision is installed immediately before late materialization.
+	searchReq.Plan().SetTakeForOutputAllowed(false)
 
 	var (
 		results          []*segments.SearchResult

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -35,22 +35,21 @@ var (
 )
 
 type SearchTask struct {
-	ctx                  context.Context
-	collection           *segments.Collection
-	segmentManager       *segments.Manager
-	req                  *querypb.SearchRequest
-	result               *internalpb.SearchResults
-	merged               bool
-	groupSize            int64
-	topk                 int64
-	nq                   int64
-	placeholderGroup     []byte
-	originTopks          []int64
-	originNqs            []int64
-	takeForOutputAllowed []bool
-	others               []*SearchTask
-	notifier             chan error
-	serverID             int64
+	ctx              context.Context
+	collection       *segments.Collection
+	segmentManager   *segments.Manager
+	req              *querypb.SearchRequest
+	result           *internalpb.SearchResults
+	merged           bool
+	groupSize        int64
+	topk             int64
+	nq               int64
+	placeholderGroup []byte
+	originTopks      []int64
+	originNqs        []int64
+	others           []*SearchTask
+	notifier         chan error
+	serverID         int64
 
 	tr           *timerecord.TimeRecorder
 	scheduleSpan trace.Span
@@ -159,24 +158,12 @@ func (t *SearchTask) Execute() error {
 		return err
 	}
 	defer searchReq.Delete()
-	t.takeForOutputAllowed = make([]bool, len(t.originNqs))
-	groupSize := searchReq.Plan().GetGroupSize()
-	// Use each original request's output topK. The optimizer may lower the
-	// C++ plan topK used for segment search without lowering the final output
-	// contract, and task merging must not turn several requests into one limit.
-	for i := range t.originNqs {
-		t.takeForOutputAllowed[i] = requestAllowsTakeForOutput(
-			searchTakeForOutputResultCount(
-				t.originNqs[i],
-				t.originTopks[i],
-				groupSize,
-			),
-		)
-	}
-	// A merged task carries one C++ plan but materializes each original
-	// request separately. Keep Take disabled until the corresponding request
-	// decision is installed immediately before late materialization.
-	searchReq.Plan().SetTakeForOutputAllowed(false)
+	// Use the merged NQ and maximum requested topK as the group's output
+	// upper bound; the optimizer may lower the C++ plan topK. Keep this
+	// decision unchanged when materializing each original request's output.
+	resultCount := searchTakeForOutputResultCount(t.nq, t.topk, searchReq.Plan().GetGroupSize())
+	takeAllowed := requestAllowsTakeForOutput(resultCount)
+	searchReq.Plan().SetTakeForOutputAllowed(takeAllowed)
 
 	var (
 		results          []*segments.SearchResult

--- a/internal/querynodev2/tasks/search_task_go_reduce.go
+++ b/internal/querynodev2/tasks/search_task_go_reduce.go
@@ -362,6 +362,11 @@ func (t *SearchTask) materializeAndAssignResult(
 	if err != nil {
 		return err
 	}
+	takeForOutputAllowed := false
+	if i < len(t.takeForOutputAllowed) {
+		takeForOutputAllowed = t.takeForOutputAllowed[i]
+	}
+	plan.SetTakeForOutputAllowed(takeForOutputAllowed)
 	if err := lateMaterializeOutputFields(t.ctx, results, plan, reduced.Sources, searchResultData); err != nil {
 		return err
 	}

--- a/internal/querynodev2/tasks/search_task_go_reduce.go
+++ b/internal/querynodev2/tasks/search_task_go_reduce.go
@@ -362,11 +362,6 @@ func (t *SearchTask) materializeAndAssignResult(
 	if err != nil {
 		return err
 	}
-	takeForOutputAllowed := false
-	if i < len(t.takeForOutputAllowed) {
-		takeForOutputAllowed = t.takeForOutputAllowed[i]
-	}
-	plan.SetTakeForOutputAllowed(takeForOutputAllowed)
 	if err := lateMaterializeOutputFields(t.ctx, results, plan, reduced.Sources, searchResultData); err != nil {
 		return err
 	}

--- a/internal/querynodev2/tasks/search_task_go_reduce_test.go
+++ b/internal/querynodev2/tasks/search_task_go_reduce_test.go
@@ -1327,6 +1327,101 @@ func TestExecuteMergedSubTasks(t *testing.T) {
 	t.Logf("merged slicing OK: sub-task NQs=%v, topK=%d", subTaskNqs, topK)
 }
 
+func TestExecuteSearchGroupTakeForOutputDecision(t *testing.T) {
+	ts := setupTestSegments(t, 2, 100, setupOpts{SkipSearchReq: true})
+	defer ts.cleanup()
+
+	for _, tc := range []struct {
+		name      string
+		topKs     []int64
+		planTopK  int64
+		groupSize int64
+		limit     int64
+		allowed   bool
+	}{
+		{"single request", []int64{5}, 5, 0, 5, true},
+		{"merged at limit", []int64{5, 5}, 5, 0, 10, true},
+		{"merged exceeds limit", []int64{5, 5}, 5, 0, 9, false},
+		{"limit disabled", []int64{5, 5}, 5, 0, 0, true},
+		{"maximum topK upper bound", []int64{3, 5}, 5, 0, 8, false},
+		{"optimizer lowered plan topK", []int64{5, 5}, 3, 0, 9, false},
+		{"group by exceeds limit", []int64{5, 5}, 5, 3, 29, false},
+		{"group by at limit", []int64{5, 5}, 5, 3, 30, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			params := paramtable.Get()
+			limitKey := params.QueryNodeCfg.TakeForOutputResultCountLimit.Key
+			oldLimit := params.QueryNodeCfg.TakeForOutputResultCountLimit.GetValue()
+			require.NoError(t, params.Save(limitKey, strconv.FormatInt(tc.limit, 10)))
+			t.Cleanup(func() { require.NoError(t, params.Save(limitKey, oldLimit)) })
+
+			var receiver *SearchTask
+			for _, topK := range tc.topKs {
+				req, err := mock_segcore.GenQueryRequest(
+					ts.collection.GetCCollection(), ts.segIDs, 1, tc.planTopK, testCollectionID)
+				require.NoError(t, err)
+				// Identical execution plans may retain different requested TopKs
+				// after optimization. Merge must budget the maximum requested one.
+				req.Req.Topk = topK
+				var plan planpb.PlanNode
+				require.NoError(t, proto.Unmarshal(req.GetReq().GetSerializedExprPlan(), &plan))
+				plan.OutputFieldIds = []int64{103}
+				if tc.groupSize > 0 {
+					plan.GetVectorAnns().QueryInfo.GroupByFieldId = 103
+					plan.GetVectorAnns().QueryInfo.GroupSize = tc.groupSize
+				}
+				req.Req.SerializedExprPlan, err = proto.Marshal(&plan)
+				require.NoError(t, err)
+				task := NewSearchTask(t.Context(), ts.collection, ts.manager, req, 1)
+				if receiver == nil {
+					receiver = task
+				} else {
+					require.True(t, receiver.Merge(task))
+				}
+			}
+
+			var decisions []bool
+			var setAllowed func(*segcore.SearchPlan, bool)
+			setter := mockey.Mock((*segcore.SearchPlan).SetTakeForOutputAllowed).To(
+				func(plan *segcore.SearchPlan, allowed bool) {
+					decisions = append(decisions, allowed)
+					setAllowed(plan, allowed)
+				}).Origin(&setAllowed).Build()
+			t.Cleanup(func() { setter.UnPatch() })
+
+			var searchHistorical func(context.Context, *segments.Manager, *segments.SearchRequest, int64, []int64, []int64) ([]*segments.SearchResult, []segments.Segment, error)
+			searcher := mockey.Mock(segments.SearchHistorical).To(
+				func(ctx context.Context, manager *segments.Manager, req *segments.SearchRequest, collectionID int64, partitionIDs, segmentIDs []int64) ([]*segments.SearchResult, []segments.Segment, error) {
+					require.Equal(t, []bool{tc.allowed}, decisions, "decide once before segment fan-out")
+					// A config refresh after the decision must not change later slices.
+					refreshedLimit := "0"
+					if tc.allowed {
+						refreshedLimit = "1"
+					}
+					require.NoError(t, params.Save(limitKey, refreshedLimit))
+					return searchHistorical(ctx, manager, req, collectionID, partitionIDs, segmentIDs)
+				}).Origin(&searchHistorical).Build()
+			t.Cleanup(func() { searcher.UnPatch() })
+
+			require.NoError(t, receiver.PreExecute())
+			require.NoError(t, receiver.Execute())
+			require.Equal(t, []bool{tc.allowed}, decisions, "output slices must not overwrite the group decision")
+			for i, topK := range tc.topKs {
+				result := receiver.subTaskAt(i).SearchResult()
+				require.NotNil(t, result)
+				require.Equal(t, topK, result.GetTopK())
+				data := result.GetResultData()
+				if data == nil {
+					data = &schemapb.SearchResultData{}
+					require.NoError(t, proto.Unmarshal(result.GetSlicedBlob(), data))
+				}
+				require.NotEmpty(t, data.GetScores())
+				require.Len(t, data.GetFieldsData(), 1, "exercise late output materialization")
+			}
+		})
+	}
+}
+
 func TestExecuteMergedSubTasks_MixedTopKWithL1Rerank(t *testing.T) {
 	const (
 		numSegments = 2

--- a/internal/querynodev2/tasks/search_task_test.go
+++ b/internal/querynodev2/tasks/search_task_test.go
@@ -19,18 +19,96 @@ package tasks
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"math/rand"
 	"testing"
 
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 )
+
+func TestTakeForOutputRequestDecision(t *testing.T) {
+	t.Run("request limit", func(t *testing.T) {
+		assert.True(t, takeForOutputAllowed(10000, 10000))
+		assert.False(t, takeForOutputAllowed(10001, 10000))
+		assert.False(t, takeForOutputAllowed(unknownTakeForOutputResultCount, 10000))
+		assert.True(t, takeForOutputAllowed(unknownTakeForOutputResultCount, 0))
+	})
+
+	t.Run("search count", func(t *testing.T) {
+		assert.Equal(t, int64(600), searchTakeForOutputResultCount(10, 20, 3))
+		assert.Equal(t, int64(200), searchTakeForOutputResultCount(10, 20, 0))
+		assert.Equal(t, int64(0), searchTakeForOutputResultCount(0, 20, 1))
+		assert.Equal(t, unknownTakeForOutputResultCount, searchTakeForOutputResultCount(-1, 20, 1))
+		assert.Equal(t, int64(math.MaxInt64), searchTakeForOutputResultCount(math.MaxInt64, 2, 1))
+	})
+
+	t.Run("retrieve primary key term", func(t *testing.T) {
+		plan := &planpb.PlanNode{
+			Node: &planpb.PlanNode_Query{
+				Query: &planpb.QueryPlanNode{
+					Predicates: &planpb.Expr{
+						Expr: &planpb.Expr_TermExpr{
+							TermExpr: &planpb.TermExpr{
+								ColumnInfo: &planpb.ColumnInfo{IsPrimaryKey: true},
+								Values: []*planpb.GenericValue{
+									{}, {}, {},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		req := &internalpb.RetrieveRequest{Limit: -1}
+		assert.Equal(t, int64(3), retrieveTakeForOutputResultCount(req, plan))
+		req.Limit = 0
+		assert.Equal(t, int64(3), retrieveTakeForOutputResultCount(req, plan))
+		req.Limit = 2
+		assert.Equal(t, int64(2), retrieveTakeForOutputResultCount(req, plan))
+	})
+
+	t.Run("retrieve limit and unknown", func(t *testing.T) {
+		assert.Equal(t, int64(128), retrieveTakeForOutputResultCount(
+			&internalpb.RetrieveRequest{Limit: 128},
+			&planpb.PlanNode{},
+		))
+		nonPrimaryKeyPlan := &planpb.PlanNode{
+			Node: &planpb.PlanNode_Query{
+				Query: &planpb.QueryPlanNode{
+					Predicates: &planpb.Expr{
+						Expr: &planpb.Expr_TermExpr{
+							TermExpr: &planpb.TermExpr{
+								ColumnInfo: &planpb.ColumnInfo{},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, int64(128), retrieveTakeForOutputResultCount(
+			&internalpb.RetrieveRequest{Limit: 128},
+			nonPrimaryKeyPlan,
+		))
+		assert.Equal(t, unknownTakeForOutputResultCount, retrieveTakeForOutputResultCount(
+			&internalpb.RetrieveRequest{Limit: -1},
+			&planpb.PlanNode{},
+		))
+		assert.Equal(t, unknownTakeForOutputResultCount, retrieveTakeForOutputResultCount(
+			&internalpb.RetrieveRequest{Limit: 0},
+			&planpb.PlanNode{},
+		))
+		assert.Equal(t, unknownTakeForOutputResultCount, retrieveTakeForOutputResultCount(nil, nil))
+	})
+}
 
 type SearchTaskSuite struct {
 	suite.Suite

--- a/internal/querynodev2/tasks/take_for_output.go
+++ b/internal/querynodev2/tasks/take_for_output.go
@@ -1,0 +1,84 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"math"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+const unknownTakeForOutputResultCount int64 = -1
+
+func saturatingMultiplyNonNegative(left, right int64) int64 {
+	if left < 0 || right < 0 {
+		return unknownTakeForOutputResultCount
+	}
+	if left == 0 || right == 0 {
+		return 0
+	}
+	if left > math.MaxInt64/right {
+		return math.MaxInt64
+	}
+	return left * right
+}
+
+func searchTakeForOutputResultCount(nq, topK, groupSize int64) int64 {
+	if groupSize <= 0 {
+		groupSize = 1
+	}
+	return saturatingMultiplyNonNegative(
+		saturatingMultiplyNonNegative(nq, topK),
+		groupSize,
+	)
+}
+
+func retrieveTakeForOutputResultCount(req *internalpb.RetrieveRequest, plan *planpb.PlanNode) int64 {
+	// Zero is the protobuf default and is left unset by internal requests such
+	// as Delete QueryStream, so only a positive limit is a known upper bound.
+	if plan != nil {
+		term := plan.GetQuery().GetPredicates().GetTermExpr()
+		if term != nil &&
+			term.GetColumnInfo().GetIsPrimaryKey() &&
+			!term.GetIsInField() {
+			termCount := int64(len(term.GetValues()))
+			if req != nil && req.GetLimit() > 0 {
+				return min(termCount, req.GetLimit())
+			}
+			return termCount
+		}
+	}
+
+	if req != nil && req.GetLimit() > 0 {
+		return req.GetLimit()
+	}
+	return unknownTakeForOutputResultCount
+}
+
+func takeForOutputAllowed(resultCount, limit int64) bool {
+	if limit == 0 {
+		return true
+	}
+	return resultCount >= 0 && resultCount <= limit
+}
+
+func requestAllowsTakeForOutput(resultCount int64) bool {
+	limit := paramtable.Get().QueryNodeCfg.TakeForOutputResultCountLimit.GetAsInt64()
+	return takeForOutputAllowed(resultCount, limit)
+}

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -776,11 +776,6 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
-		paramtable.Get().QueryNodeCfg.TakeForOutputResultCountLimit.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			SyncTakeForOutputResultCountLimit(paramtable.Get())
-			return nil
-		})
-
 		paramtable.Get().QueryNodeCfg.InterimIndexGrowingBuildThreadRate.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			rate, err := strconv.ParseFloat(newValue, 32)
 			if err != nil {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -70,7 +70,6 @@ func TestSetupCoreConfigChangeCallback(t *testing.T) {
 
 	assert.NoError(t, pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32"))
 	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
-
 }
 
 // TestRegisterArrowIOThreadPoolWatchers verifies the lifted helper registers

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -71,12 +71,6 @@ func TestSetupCoreConfigChangeCallback(t *testing.T) {
 	assert.NoError(t, pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32"))
 	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
 
-	defer func() {
-		assert.NoError(t, pt.Reset(pt.QueryNodeCfg.TakeForOutputResultCountLimit.Key))
-		SyncTakeForOutputResultCountLimit(pt)
-	}()
-	assert.NoError(t, pt.Save(pt.QueryNodeCfg.TakeForOutputResultCountLimit.Key, "2048"))
-	assert.Equal(t, int64(2048), getTakeForOutputResultCountLimit())
 }
 
 // TestRegisterArrowIOThreadPoolWatchers verifies the lifted helper registers

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -88,7 +88,6 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 
 	SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
 	SyncEnableGrowingSourceFlush(ctx, paramtable.Get())
-	SyncTakeForOutputResultCountLimit(paramtable.Get())
 
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)
@@ -269,16 +268,4 @@ func SyncEnableGrowingSourceFlush(ctx context.Context, params *paramtable.Compon
 	if v {
 		mlog.Info(ctx, "enableGrowingSourceFlush=true: growing segments retain raw field chunks for StorageV3 growing-source flush")
 	}
-}
-
-// SyncTakeForOutputResultCountLimit pushes the maximum search topK or retrieve
-// result row count allowed to use take() for output fields into segcore. A
-// value of 0 disables the limit.
-func SyncTakeForOutputResultCountLimit(params *paramtable.ComponentParam) {
-	limit := params.QueryNodeCfg.TakeForOutputResultCountLimit.GetAsInt64()
-	C.SegcoreSetTakeForOutputResultCountLimit(C.int64_t(limit))
-}
-
-func getTakeForOutputResultCountLimit() int64 {
-	return int64(C.SegcoreGetTakeForOutputResultCountLimit())
 }

--- a/internal/util/segcore/plan.go
+++ b/internal/util/segcore/plan.go
@@ -62,6 +62,15 @@ func (plan *SearchPlan) GetTopK() int64 {
 	return int64(topK)
 }
 
+func (plan *SearchPlan) GetGroupSize() int64 {
+	groupSize := C.GetGroupSize(plan.cSearchPlan)
+	return int64(groupSize)
+}
+
+func (plan *SearchPlan) SetTakeForOutputAllowed(allowed bool) {
+	C.SetSearchPlanTakeForOutputAllowed(plan.cSearchPlan, C.bool(allowed))
+}
+
 func (plan *SearchPlan) setMetricType(metricType string) {
 	cmt := C.CString(metricType)
 	defer C.free(unsafe.Pointer(cmt))
@@ -229,6 +238,10 @@ func (plan *RetrievePlan) ShouldIgnoreNonPk() bool {
 
 func (plan *RetrievePlan) SetIgnoreNonPk(ignore bool) {
 	plan.ignoreNonPk = ignore
+}
+
+func (plan *RetrievePlan) SetTakeForOutputAllowed(allowed bool) {
+	C.SetRetrievePlanTakeForOutputAllowed(plan.cRetrievePlan, C.bool(allowed))
 }
 
 func (plan *RetrievePlan) IsIgnoreNonPk() bool {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5527,7 +5527,7 @@ user-task-polling:
 		Key:          "queryNode.takeForOutput.resultCountLimit",
 		Version:      "3.0.0",
 		DefaultValue: defaultTakeForOutputResultCountLimit,
-		Doc:          `Maximum search topK, unique search offset count, or retrieve result row count that can use take() for output fields. Set to 0 to disable the limit`,
+		Doc:          `Maximum request-level output result count allowed to use take() for output fields. Set to 0 to disable the limit`,
 		Export:       false,
 		Formatter: func(v string) string {
 			limit, err := strconv.ParseInt(v, 10, 64)


### PR DESCRIPTION
issue: #53045
pr: #53046

## Summary

Backport the five commits from the master Take output fix to `3.0`.

- Decide Take output eligibility before segment execution. Search uses
  one decision for the merged group's combined output bound; Query and
  QueryStream carry their request decision through the retrieve plan.
- Keep unknown retrieve cardinality on the fallback path when the limit
  is positive. A zero limit continues to disable the count restriction.
- Read external TEXT values directly on output fallback while preserving
  internal StorageV3 LOB decoding.
- Include the source branch's DiskANN test upload-path isolation and
  manifest translator counter rename for unity builds.

## Backport differences

Source head: `982b64c0550737d8f28d0edf96db1e2e2dd0e40b`.
Target base: `d1fbb1e8c1dd2336c537bbc6ce2d21d9fd107a0e`.

Two mechanical conflicts were adapted:

- Remove only the obsolete Take config assertions in initcore tests;
  do not import master-only adjacent config tests.
- Preserve 3.0's non-const local `gen` variable while renaming the
  manifest translator counter.

The other three commits applied cleanly. Range-diff confirmed no other
code adaptations, and the changed-file lists match the source branch.

## Validation

- `git diff --check`: passed.
- `gofmt -l` on changed Go files: no output.
- `TestTakeForOutputRequestDecision`: passed with `-tags dynamic,test`,
  `-gcflags='all=-N -l'`, and existing core artifacts in this worktree.
- All five commits carry the developer's Signed-off-by.
- C++ was not rebuilt for 3.0. C++ runtime, merged-group integration,
  and parallel DiskANN execution remain for CI; prior master validation
  is not claimed as validation of this backport.
