### PR TITLE
enhance: avoid batch waiting in import task scheduling

### DIFF
--- a/internal/datanode/importv2/scheduler.go
+++ b/internal/datanode/importv2/scheduler.go
@@ -38,6 +38,9 @@ type Scheduler interface {
 type scheduler struct {
 	manager TaskManager
 
+	// futures tracks in-flight file futures by task ID.
+	futures map[int64][]*conc.Future[any]
+
 	closeOnce sync.Once
 	closeChan chan struct{}
 }
@@ -45,6 +48,7 @@ type scheduler struct {
 func NewScheduler(manager TaskManager) Scheduler {
 	return &scheduler{
 		manager:   manager,
+		futures:   make(map[int64][]*conc.Future[any]),
 		closeChan: make(chan struct{}),
 	}
 }
@@ -73,6 +77,8 @@ func (s *scheduler) Start() {
 }
 
 func (s *scheduler) scheduleTasks() {
+	s.reapCompletedTasks()
+
 	tasks := s.manager.GetBy(WithStates(datapb.ImportTaskStateV2_Pending))
 	sort.Slice(tasks, func(i, j int) bool {
 		return tasks[i].GetTaskID() < tasks[j].GetTaskID()
@@ -87,22 +93,39 @@ func (s *scheduler) scheduleTasks() {
 	})
 	mlog.Info(context.TODO(), "processing tasks...", mlog.Int64s("taskIDs", taskIDs))
 
-	futures := make(map[int64][]*conc.Future[any])
 	for _, task := range tasks {
-		fs := task.Execute()
-		futures[task.GetTaskID()] = fs
+		// Execute marks the task InProgress and returns its file futures.
+		s.futures[task.GetTaskID()] = task.Execute()
+		// Reap completed tasks after each submission.
+		s.reapCompletedTasks()
 	}
+}
 
-	for taskID, fs := range futures {
-		err := conc.AwaitAll(fs...)
-		if err != nil {
+// reapCompletedTasks marks successful tasks Completed and removes failed or
+// deleted tasks from tracking without waiting for unfinished futures.
+func (s *scheduler) reapCompletedTasks() {
+	for taskID, fs := range s.futures {
+		task := s.manager.Get(taskID)
+		if task == nil {
+			delete(s.futures, taskID)
+			continue
+		}
+		if task.GetState() == datapb.ImportTaskStateV2_Failed {
+			delete(s.futures, taskID)
+			mlog.Warn(context.TODO(), "preimport/import failed", WrapLogFields(task, mlog.String("reason", task.GetReason()))...)
+			continue
+		}
+		if !lo.EveryBy(fs, func(f *conc.Future[any]) bool { return f.Done() }) {
+			continue
+		}
+		delete(s.futures, taskID)
+		if err := conc.AwaitAll(fs...); err != nil {
+			mlog.Warn(context.TODO(), "preimport/import failed", WrapLogFields(task, mlog.Err(err))...)
 			continue
 		}
 		s.manager.Update(taskID, UpdateState(datapb.ImportTaskStateV2_Completed))
 		mlog.Info(context.TODO(), "preimport/import done", mlog.FieldTaskID(taskID))
 	}
-
-	mlog.Info(context.TODO(), "all tasks completed", mlog.Int64s("taskIDs", taskIDs))
 }
 
 // Slots returns the used slots for import
@@ -118,17 +141,4 @@ func (s *scheduler) Close() {
 	s.closeOnce.Do(func() {
 		close(s.closeChan)
 	})
-}
-
-func tryFreeFutures(futures map[int64][]*conc.Future[any]) {
-	for k, fs := range futures {
-		fs = lo.Filter(fs, func(f *conc.Future[any], _ int) bool {
-			if f.Done() {
-				_, err := f.Await()
-				return err != nil
-			}
-			return true
-		})
-		futures[k] = fs
-	}
 }

--- a/internal/datanode/importv2/scheduler_test.go
+++ b/internal/datanode/importv2/scheduler_test.go
@@ -553,6 +553,192 @@ func (s *SchedulerSuite) TestScheduler_ImportFileWithFunction() {
 	s.NoError(err)
 }
 
+// fakeTask embeds ImportTask with a custom Execute function for scheduler tests.
+type fakeTask struct {
+	*ImportTask
+	manager   TaskManager
+	executeFn func() []*conc.Future[any]
+}
+
+func newFakeImportTask(taskID int64, manager TaskManager, executeFn func() []*conc.Future[any]) *fakeTask {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &fakeTask{
+		ImportTask: &ImportTask{
+			ImportTaskV2: &datapb.ImportTaskV2{
+				JobID:  taskID,
+				TaskID: taskID,
+				State:  datapb.ImportTaskStateV2_Pending,
+			},
+			ctx:     ctx,
+			cancel:  cancel,
+			req:     &datapb.ImportRequest{},
+			manager: manager,
+		},
+		manager:   manager,
+		executeFn: executeFn,
+	}
+}
+
+func (t *fakeTask) Execute() []*conc.Future[any] {
+	t.manager.Update(t.GetTaskID(), UpdateState(datapb.ImportTaskStateV2_InProgress))
+	return t.executeFn()
+}
+
+// Clone returns an ImportTask for the manager's state updates.
+func (t *fakeTask) Clone() Task {
+	return t.ImportTask.Clone()
+}
+
+func (s *SchedulerSuite) TestScheduler_ScheduleWithoutBatchBlocking() {
+	release1 := make(chan struct{})
+	started1 := make(chan struct{})
+	var once1 sync.Once
+	task1 := newFakeImportTask(1001, s.manager, func() []*conc.Future[any] {
+		once1.Do(func() { close(started1) })
+		return []*conc.Future[any]{conc.Go(func() (any, error) {
+			<-release1
+			return nil, nil
+		})}
+	})
+	s.manager.Add(task1)
+
+	go s.scheduler.Start()
+	defer s.scheduler.Close()
+
+	// Wait for task1 to start.
+	select {
+	case <-started1:
+	case <-time.After(10 * time.Second):
+		s.FailNow("task1 was not scheduled")
+	}
+
+	// Schedule task2 while task1 is still running.
+	task2 := newFakeImportTask(1002, s.manager, func() []*conc.Future[any] {
+		return []*conc.Future[any]{conc.Go(func() (any, error) {
+			return nil, nil
+		})}
+	})
+	s.manager.Add(task2)
+
+	s.Eventually(func() bool {
+		return s.manager.Get(1002).GetState() == datapb.ImportTaskStateV2_Completed
+	}, 10*time.Second, 100*time.Millisecond)
+	s.Equal(datapb.ImportTaskStateV2_InProgress, s.manager.Get(1001).GetState())
+
+	close(release1)
+	s.Eventually(func() bool {
+		return s.manager.Get(1001).GetState() == datapb.ImportTaskStateV2_Completed
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func (s *SchedulerSuite) TestScheduler_ReapCompletedTasks() {
+	doneTask := newFakeImportTask(2001, s.manager, nil)
+	blockedTask := newFakeImportTask(2002, s.manager, nil)
+	s.manager.Add(doneTask)
+	s.manager.Add(blockedTask)
+
+	release := make(chan struct{})
+	defer close(release)
+	doneFuture := conc.Go(func() (any, error) { return nil, nil })
+	blockedFuture := conc.Go(func() (any, error) {
+		<-release
+		return nil, nil
+	})
+	s.scheduler.futures[2001] = []*conc.Future[any]{doneFuture}
+	s.scheduler.futures[2002] = []*conc.Future[any]{blockedFuture}
+
+	s.Eventually(func() bool { return doneFuture.Done() }, 5*time.Second, 10*time.Millisecond)
+
+	s.scheduler.reapCompletedTasks()
+
+	_, ok := s.scheduler.futures[2001]
+	s.False(ok)
+	_, ok = s.scheduler.futures[2002]
+	s.True(ok)
+	s.Equal(datapb.ImportTaskStateV2_Completed, s.manager.Get(2001).GetState())
+	s.Equal(datapb.ImportTaskStateV2_Pending, s.manager.Get(2002).GetState())
+}
+
+func (s *SchedulerSuite) TestScheduler_ReapDropsFailedAndRemovedTasks() {
+	failedTask := newFakeImportTask(3001, s.manager, nil)
+	removedTask := newFakeImportTask(3002, s.manager, nil)
+	s.manager.Add(failedTask)
+	s.manager.Add(removedTask)
+
+	// Both tasks still have an unfinished file future.
+	release := make(chan struct{})
+	defer close(release)
+	blocked := func() *conc.Future[any] {
+		return conc.Go(func() (any, error) {
+			<-release
+			return nil, nil
+		})
+	}
+	s.scheduler.futures[3001] = []*conc.Future[any]{blocked()}
+	s.scheduler.futures[3002] = []*conc.Future[any]{blocked()}
+
+	// Mark one task Failed and remove the other.
+	s.manager.Update(3001, UpdateState(datapb.ImportTaskStateV2_Failed), UpdateReason("mock failure"))
+	s.manager.Remove(3002)
+
+	s.scheduler.reapCompletedTasks()
+
+	s.Empty(s.scheduler.futures)
+	s.Equal(datapb.ImportTaskStateV2_Failed, s.manager.Get(3001).GetState())
+	s.Nil(s.manager.Get(3002))
+}
+
+func (s *SchedulerSuite) TestScheduler_FailedTaskWithNoFuturesStaysFailed() {
+	// Simulate validation failure with no returned futures.
+	task := newFakeImportTask(3003, s.manager, nil)
+	task.executeFn = func() []*conc.Future[any] {
+		s.manager.Update(3003, UpdateState(datapb.ImportTaskStateV2_Failed), UpdateReason("validation failed"))
+		return nil
+	}
+	s.manager.Add(task)
+
+	s.scheduler.scheduleTasks()
+
+	s.Empty(s.scheduler.futures)
+	s.Equal(datapb.ImportTaskStateV2_Failed, s.manager.Get(3003).GetState())
+	s.Equal("validation failed", s.manager.Get(3003).GetReason())
+}
+
+func (s *SchedulerSuite) TestScheduler_ReapBetweenTasks() {
+	// Schedule a completed future followed by an unfinished one.
+	doneTask := newFakeImportTask(4001, s.manager, func() []*conc.Future[any] {
+		f := conc.Go(func() (any, error) { return nil, nil })
+		_, _ = f.Await()
+		return []*conc.Future[any]{f}
+	})
+	release := make(chan struct{})
+	defer close(release)
+	// Execute of the second task runs inside scheduleTasks, right after the
+	// first task was submitted. Reaping between tasks must already have marked
+	// the first task Completed at that point; reaping only after the loop
+	// would still leave it InProgress here.
+	var firstStateSeenBySecond datapb.ImportTaskStateV2
+	blockedTask := newFakeImportTask(4002, s.manager, func() []*conc.Future[any] {
+		firstStateSeenBySecond = s.manager.Get(4001).GetState()
+		return []*conc.Future[any]{conc.Go(func() (any, error) {
+			<-release
+			return nil, nil
+		})}
+	})
+	s.manager.Add(doneTask)
+	s.manager.Add(blockedTask)
+
+	s.scheduler.scheduleTasks()
+
+	s.Equal(datapb.ImportTaskStateV2_Completed, firstStateSeenBySecond)
+	s.Equal(datapb.ImportTaskStateV2_Completed, s.manager.Get(4001).GetState())
+	s.Equal(datapb.ImportTaskStateV2_InProgress, s.manager.Get(4002).GetState())
+	_, ok := s.scheduler.futures[4001]
+	s.False(ok)
+	_, ok = s.scheduler.futures[4002]
+	s.True(ok)
+}
+
 func TestScheduler(t *testing.T) {
 	suite.Run(t, new(SchedulerSuite))
 }

--- a/pkg/util/conc/future.go
+++ b/pkg/util/conc/future.go
@@ -16,8 +16,6 @@
 
 package conc
 
-import "go.uber.org/atomic"
-
 type future interface {
 	wait()
 	OK() bool
@@ -31,13 +29,11 @@ type Future[T any] struct {
 	ch    chan struct{}
 	value T
 	err   error
-	done  *atomic.Bool
 }
 
 func newFuture[T any]() *Future[T] {
 	return &Future[T]{
-		ch:   make(chan struct{}),
-		done: atomic.NewBool(false),
+		ch: make(chan struct{}),
 	}
 }
 
@@ -59,9 +55,14 @@ func (future *Future[T]) Value() T {
 	return future.value
 }
 
-// Done indicates if the fn has finished.
+// Done reports whether the future has completed without blocking.
 func (future *Future[T]) Done() bool {
-	return future.done.Load()
+	select {
+	case <-future.ch:
+		return true
+	default:
+		return false
+	}
 }
 
 // False if error occurred,
@@ -95,7 +96,6 @@ func Go[T any](fn func() (T, error)) *Future[T] {
 	go func() {
 		future.value, future.err = fn()
 		close(future.ch)
-		future.done.Store(true)
 	}()
 	return future
 }

--- a/pkg/util/conc/future_test.go
+++ b/pkg/util/conc/future_test.go
@@ -47,6 +47,21 @@ func (s *FutureSuite) TestFuture() {
 	s.Equal(10, resultFuture.Value())
 }
 
+func (s *FutureSuite) TestDone() {
+	release := make(chan struct{})
+	future := Go(func() (int, error) {
+		<-release
+		return 1, nil
+	})
+
+	s.False(future.Done())
+	close(release)
+	value, err := future.Await()
+	s.NoError(err)
+	s.Equal(1, value)
+	s.True(future.Done())
+}
+
 func (s *FutureSuite) TestBlockOnAll() {
 	cnt := atomic.NewInt32(0)
 	futures := make([]*Future[struct{}], 10)

--- a/pkg/util/conc/pool_test.go
+++ b/pkg/util/conc/pool_test.go
@@ -76,6 +76,37 @@ func TestPoolResize(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPoolFutureDone(t *testing.T) {
+	pool := NewPool[any](1)
+
+	release := make(chan struct{})
+	blocked := pool.Submit(func() (any, error) {
+		<-release
+		return nil, nil
+	})
+	assert.False(t, blocked.Done())
+	close(release)
+	assert.Eventually(t, blocked.Done, time.Second, 10*time.Millisecond)
+
+	done := pool.Submit(func() (any, error) {
+		return nil, nil
+	})
+	assert.Eventually(t, done.Done, time.Second, 10*time.Millisecond)
+}
+
+func TestPoolSubmitDoneWhenSubmitFails(t *testing.T) {
+	pool := NewPool[any](1)
+	pool.Release()
+
+	future := pool.Submit(func() (any, error) {
+		return nil, nil
+	})
+
+	_, err := future.Await()
+	assert.Error(t, err)
+	assert.True(t, future.Done())
+}
+
 func TestPoolWithPanic(t *testing.T) {
 	pool := NewPool[any](1, WithConcealPanic(true))
 
@@ -86,4 +117,5 @@ func TestPoolWithPanic(t *testing.T) {
 	// make sure error returned when conceal panic
 	_, err := future.Await()
 	assert.Error(t, err)
+	assert.True(t, future.Done())
 }


### PR DESCRIPTION
part of issue: #51161

Track in-flight futures across scheduling rounds and collect completed tasks before scheduling and after each task submission. This allows new pending tasks to be scheduled without waiting for the previous batch to finish.

Use the completion channel for Future.Done() so futures returned by Pool.Submit() correctly report completion. Preserve failed task states and discard tracking entries for failed or removed tasks.

Validation:
  - Added regression tests for incremental scheduling, task completion, and failed/removed task cleanup.
  - conc package tests passed.
  - Import tests could not run locally because rdkafka, milvus_core, and rocksdb dependencies are unavailable.
 
This change does not fully address timely task state updates: Execute() can still block on submission when the execution pool is saturated, delaying completion collection. I suggest addressing this separately in a follow-up PR.

Hope Milvus keeps getting a little better every day.
Thanks in advance for any time or advice you can spare.