### PR TITLE
fix: preserve external file properties in segment manifests

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION e7f4477)
+set( milvus-storage_VERSION 15ab3d7)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -305,6 +305,8 @@ func (t *RefreshExternalCollectionTask) GetKeptSegmentIDs() []int64 {
 
 // fragmentKey identifies the L1 data fragment. Delete overlays are handled as
 // manifest-only updates so L0 changes do not force a new target segment ID.
+// Existing file ranges are immutable by the external-table contract; overwrite
+// is unsupported. Properties are therefore not hashed to trigger segment rebuilds.
 func fragmentKey(f packed.Fragment) string {
 	return fmt.Sprintf("%s:%d:%d", f.FilePath, f.StartRow, f.EndRow)
 }

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -1325,7 +1325,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestOrganizeSegments_NewFragmentsAd
 
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_SmallFile() {
 	// File smaller than limit - should return single fragment
-	fragments := packed.SplitFileToFragments("/data/small.parquet", 500000, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(0))
+	fragments := packed.SplitFileToFragments("/data/small.parquet", 500000, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(0))
 
 	s.Len(fragments, 1)
 	s.Equal(int64(0), fragments[0].FragmentID)
@@ -1337,7 +1337,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_SmallFile(
 
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_ExactLimit() {
 	// File exactly at limit - should return single fragment
-	fragments := packed.SplitFileToFragments("/data/exact.parquet", packed.DefaultFragmentRowLimit, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(0))
+	fragments := packed.SplitFileToFragments("/data/exact.parquet", packed.DefaultFragmentRowLimit, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(0))
 
 	s.Len(fragments, 1)
 	s.Equal(int64(0), fragments[0].FragmentID)
@@ -1349,7 +1349,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_ExactLimit
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_LargeFile() {
 	// File with 2.5 million rows - should split into 3 fragments
 	totalRows := int64(2500000)
-	fragments := packed.SplitFileToFragments("/data/large.parquet", totalRows, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(0))
+	fragments := packed.SplitFileToFragments("/data/large.parquet", totalRows, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(0))
 
 	s.Len(fragments, 3)
 
@@ -1377,7 +1377,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_LargeFile(
 
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_BaseFragmentID() {
 	// Test with non-zero base fragment ID
-	fragments := packed.SplitFileToFragments("/data/test.parquet", 2500000, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(100))
+	fragments := packed.SplitFileToFragments("/data/test.parquet", 2500000, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(100))
 
 	s.Len(fragments, 3)
 	s.Equal(int64(100), fragments[0].FragmentID)
@@ -1387,7 +1387,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_BaseFragme
 
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_ZeroRows() {
 	// Empty file - should return single fragment with zero rows
-	fragments := packed.SplitFileToFragments("/data/empty.parquet", 0, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(0))
+	fragments := packed.SplitFileToFragments("/data/empty.parquet", 0, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(0))
 
 	s.Len(fragments, 1)
 	s.Equal(int64(0), fragments[0].RowCount)
@@ -1396,7 +1396,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_ZeroRows()
 func (s *RefreshExternalCollectionTaskSuite) TestSplitFileToFragments_TenMillionRows() {
 	// 10 million rows - should split into 10 fragments
 	totalRows := int64(10000000)
-	fragments := packed.SplitFileToFragments("/data/huge.parquet", totalRows, packed.DefaultFragmentRowLimit, packed.NewFragmentIDGenerator(0))
+	fragments := packed.SplitFileToFragments("/data/huge.parquet", totalRows, packed.DefaultFragmentRowLimit, nil, packed.NewFragmentIDGenerator(0))
 
 	s.Len(fragments, 10)
 

--- a/internal/storagev2/packed/column_group_entry.go
+++ b/internal/storagev2/packed/column_group_entry.go
@@ -100,24 +100,15 @@ func columnGroupEntriesFromC(cColumnGroups *C.LoonColumnGroups) ([]ColumnGroupEn
 				if file.path == nil {
 					return nil, merr.WrapErrServiceInternalMsg("nil file path in column group %d file %d", i, j)
 				}
+				properties, err := columnGroupFileProperties(file)
+				if err != nil {
+					return nil, merr.Wrapf(err, "column group %d file %d", i, j)
+				}
 				fileEntry := ColumnGroupFileEntry{
 					Path:       C.GoString(file.path),
 					StartIndex: int64(file.start_index),
 					EndIndex:   int64(file.end_index),
-				}
-				if file.num_properties > 0 {
-					if file.property_keys == nil || file.property_values == nil {
-						return nil, merr.WrapErrServiceInternalMsg("column group %d file %d has %d properties but nil keys/values", i, j, file.num_properties)
-					}
-					keys := unsafe.Slice(file.property_keys, int(file.num_properties))
-					values := unsafe.Slice(file.property_values, int(file.num_properties))
-					fileEntry.Properties = make(map[string]string, int(file.num_properties))
-					for k := range keys {
-						if keys[k] == nil || values[k] == nil {
-							continue
-						}
-						fileEntry.Properties[C.GoString(keys[k])] = C.GoString(values[k])
-					}
+					Properties: properties,
 				}
 				entry.Files = append(entry.Files, fileEntry)
 			}
@@ -125,6 +116,26 @@ func columnGroupEntriesFromC(cColumnGroups *C.LoonColumnGroups) ([]ColumnGroupEn
 		entries = append(entries, entry)
 	}
 	return entries, nil
+}
+
+// columnGroupFileProperties copies properties before the native manifest is freed.
+func columnGroupFileProperties(file *C.LoonColumnGroupFile) (map[string]string, error) {
+	if file.num_properties == 0 {
+		return nil, nil
+	}
+	if file.property_keys == nil || file.property_values == nil {
+		return nil, merr.WrapErrServiceInternalMsg("file has %d properties but nil keys/values", file.num_properties)
+	}
+	keys := unsafe.Slice(file.property_keys, int(file.num_properties))
+	values := unsafe.Slice(file.property_values, int(file.num_properties))
+	properties := make(map[string]string, len(keys))
+	for i := range keys {
+		if keys[i] == nil || values[i] == nil {
+			continue
+		}
+		properties[C.GoString(keys[i])] = C.GoString(values[i])
+	}
+	return properties, nil
 }
 
 // addColumnGroupEntries stages each serialized column group onto a loon

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -93,6 +93,7 @@ type FileInfo struct {
 	NumRows         int64
 	SourceSegmentID int64
 	Deltalogs       []*datapb.FieldBinlog
+	Properties      map[string]string `json:"properties,omitempty"`
 }
 
 // ExploreFiles scans an external directory and returns file information.
@@ -438,9 +439,14 @@ func ReadFileInfosFromManifestPath(
 			if fileArray[j].path == nil {
 				return nil, merr.WrapErrServiceInternalMsg("file path is nil in column group %d, file %d", i, j)
 			}
+			properties, err := columnGroupFileProperties(&fileArray[j])
+			if err != nil {
+				return nil, merr.Wrapf(err, "column group %d file %d", i, j)
+			}
 			fileInfos = append(fileInfos, FileInfo{
-				FilePath: C.GoString(fileArray[j].path),
-				NumRows:  int64(fileArray[j].end_index),
+				FilePath:   C.GoString(fileArray[j].path),
+				NumRows:    int64(fileArray[j].end_index),
+				Properties: properties,
 			})
 		}
 	}

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -395,7 +395,7 @@ func TestNewFragmentIDGenerator(t *testing.T) {
 
 func TestSplitFileToFragments_SmallFile(t *testing.T) {
 	gen := NewFragmentIDGenerator(0)
-	fragments := SplitFileToFragments("/data/small.parquet", 500, 1000, gen)
+	fragments := SplitFileToFragments("/data/small.parquet", 500, 1000, nil, gen)
 
 	assert.Len(t, fragments, 1)
 	assert.Equal(t, int64(0), fragments[0].FragmentID)
@@ -407,7 +407,7 @@ func TestSplitFileToFragments_SmallFile(t *testing.T) {
 
 func TestSplitFileToFragments_ExactLimit(t *testing.T) {
 	gen := NewFragmentIDGenerator(0)
-	fragments := SplitFileToFragments("/data/exact.parquet", 1000, 1000, gen)
+	fragments := SplitFileToFragments("/data/exact.parquet", 1000, 1000, nil, gen)
 
 	assert.Len(t, fragments, 1)
 	assert.Equal(t, int64(0), fragments[0].StartRow)
@@ -416,7 +416,7 @@ func TestSplitFileToFragments_ExactLimit(t *testing.T) {
 
 func TestSplitFileToFragments_LargeFile(t *testing.T) {
 	gen := NewFragmentIDGenerator(0)
-	fragments := SplitFileToFragments("/data/large.parquet", 2500, 1000, gen)
+	fragments := SplitFileToFragments("/data/large.parquet", 2500, 1000, nil, gen)
 
 	assert.Len(t, fragments, 3)
 	// Fragment 0: [0, 1000)
@@ -435,9 +435,23 @@ func TestSplitFileToFragments_LargeFile(t *testing.T) {
 	assert.Equal(t, int64(500), fragments[2].RowCount)
 }
 
+func TestSplitFileToFragments_Properties(t *testing.T) {
+	properties := map[string]string{"dataset_version": "10", "extra": "preserved"}
+	for _, tc := range []struct {
+		rows      int64
+		fragments int
+	}{{0, 1}, {500, 1}, {1000, 1}, {2500, 3}} {
+		fragments := SplitFileToFragments("/data/file.parquet", tc.rows, 1000, properties, NewFragmentIDGenerator(0))
+		require.Len(t, fragments, tc.fragments)
+		for _, fragment := range fragments {
+			assert.Equal(t, properties, fragment.Properties)
+		}
+	}
+}
+
 func TestSplitFileToFragments_FragmentIDContinuity(t *testing.T) {
 	gen := NewFragmentIDGenerator(10)
-	fragments := SplitFileToFragments("/data/f.parquet", 3000, 1000, gen)
+	fragments := SplitFileToFragments("/data/f.parquet", 3000, 1000, nil, gen)
 
 	assert.Len(t, fragments, 3)
 	assert.Equal(t, int64(10), fragments[0].FragmentID)

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -65,6 +65,7 @@ type Fragment struct {
 	EndRow     int64                 // End row index within the file (exclusive)
 	RowCount   int64                 // Number of rows (EndRow - StartRow)
 	Deltalogs  []*datapb.FieldBinlog // Source delete logs for milvus-table fragments
+	Properties map[string]string     // Immutable file properties shared by splits of the same file
 }
 
 type manifestColumnGroup struct {
@@ -73,6 +74,9 @@ type manifestColumnGroup struct {
 	Format    string
 }
 
+// External-table refresh assumes existing file ranges are immutable; overwrite
+// is unsupported. Properties are preserved for reads, but are deliberately not
+// hashed into fragment identity.
 func fragmentIdentity(f Fragment) string {
 	return fmt.Sprintf("%s:%d:%d", f.FilePath, f.StartRow, f.EndRow)
 }
@@ -307,8 +311,7 @@ func CreateMilvusTableManifestFromSegmentManifests(
 	return manifestPath, nil
 }
 
-// createColumnGroups creates a LoonColumnGroups structure from fragments.
-// This is an internal function used by CreateManifestForSegment.
+// createColumnGroups creates storage-owned column groups, including all file properties.
 func createColumnGroups(
 	columns []string,
 	format string,
@@ -333,6 +336,12 @@ func createColumnGroups(
 	cPaths := make([]*C.char, len(fragments))
 	cStartIndices := make([]C.int64_t, len(fragments))
 	cEndIndices := make([]C.int64_t, len(fragments))
+	cFileProperties := make([]C.LoonProperties, len(fragments))
+	defer func() {
+		for i := range cFileProperties {
+			C.loon_properties_free(&cFileProperties[i])
+		}
+	}()
 
 	for i, f := range fragments {
 		cPaths[i] = C.CString(f.FilePath)
@@ -345,11 +354,33 @@ func createColumnGroups(
 		}
 	}()
 
+	// Storage copies the per-file properties and owns the resulting column groups.
+	for i, fragment := range fragments {
+		if len(fragment.Properties) == 0 {
+			continue
+		}
+		cKeys := make([]*C.char, 0, len(fragment.Properties))
+		cValues := make([]*C.char, 0, len(fragment.Properties))
+		for key, value := range fragment.Properties {
+			cKeys = append(cKeys, C.CString(key))
+			cValues = append(cValues, C.CString(value))
+		}
+		result := C.loon_properties_create(&cKeys[0], &cValues[0], C.size_t(len(cKeys)), &cFileProperties[i])
+		for j := range cKeys {
+			C.free(unsafe.Pointer(cKeys[j]))
+			C.free(unsafe.Pointer(cValues[j]))
+		}
+		if err := HandleLoonFFIResult(result); err != nil {
+			return nil, merr.Wrap(err, "loon_properties_create for fragment failed")
+		}
+	}
+
 	var outColumnGroups *C.LoonColumnGroups
 	var cColumnsPtr **C.char
 	var cPathsPtr **C.char
 	var cStartIndicesPtr *C.int64_t
 	var cEndIndicesPtr *C.int64_t
+	var cFilePropertiesPtr *C.LoonProperties
 
 	if len(cColumns) > 0 {
 		cColumnsPtr = &cColumns[0]
@@ -360,6 +391,7 @@ func createColumnGroups(
 	if len(fragments) > 0 {
 		cStartIndicesPtr = &cStartIndices[0]
 		cEndIndicesPtr = &cEndIndices[0]
+		cFilePropertiesPtr = &cFileProperties[0]
 	}
 
 	result := C.loon_column_groups_create(
@@ -369,12 +401,13 @@ func createColumnGroups(
 		cPathsPtr,
 		cStartIndicesPtr,
 		cEndIndicesPtr,
+		cFilePropertiesPtr,
 		C.size_t(len(fragments)),
 		&outColumnGroups,
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, merr.WrapErrStorage(err, "loon_column_groups_create failed")
+		return nil, merr.Wrap(err, "loon_column_groups_create failed")
 	}
 
 	return outColumnGroups, nil
@@ -652,12 +685,17 @@ func readColumnGroupsFromManifest(
 					continue
 				}
 
+				properties, err := columnGroupFileProperties(file)
+				if err != nil {
+					return nil, merr.Wrapf(err, "column group %d file %d", i, j)
+				}
 				group.Fragments = append(group.Fragments, Fragment{
 					FragmentID: int64(len(group.Fragments)),
 					FilePath:   filePath,
 					StartRow:   startRow,
 					EndRow:     endRow,
 					RowCount:   endRow - startRow,
+					Properties: properties,
 				})
 			}
 		}

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -15,6 +15,7 @@
 package packed
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -30,6 +31,62 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+func TestExternalFilePropertiesRoundTrip(t *testing.T) {
+	paramtable.Init()
+	for _, tc := range []struct {
+		format     string
+		properties map[string]string
+	}{
+		{"parquet", map[string]string{"extra": "preserved"}},
+		{"lance-table", map[string]string{"dataset_version": "10", "extra": "preserved"}},
+		{"iceberg-table", map[string]string{"metadata": `[{"path":"delete.parquet","file_type":"position"}]`, "extra": "preserved"}},
+	} {
+		t.Run(tc.format, func(t *testing.T) {
+			dir := t.TempDir()
+			config := &indexpb.StorageConfig{StorageType: "local", RootPath: dir}
+			exploreBase := filepath.Join(dir, "explore")
+			filePath := filepath.Join(dir, "source.parquet")
+			exploreManifest, err := CommitManifestUpdates(exploreBase, ManifestEarliest, config, &ManifestUpdates{
+				ColumnGroups: []ColumnGroupEntry{{
+					Columns: []string{"id"}, Format: tc.format,
+					Files: []ColumnGroupFileEntry{{Path: filePath, StartIndex: 0, EndIndex: 4, Properties: tc.properties}},
+				}},
+			})
+			require.NoError(t, err)
+			_, version, err := UnmarshalManifestPath(exploreManifest)
+			require.NoError(t, err)
+			explorePath := filepath.Join(exploreBase, "_metadata", fmt.Sprintf("manifest-%d.avro", version))
+
+			fileInfos, err := ReadFileInfosFromManifestPath(explorePath, config)
+			require.NoError(t, err)
+			require.Len(t, fileInfos, 1)
+			assert.Equal(t, tc.properties, fileInfos[0].Properties)
+
+			fragments, err := FetchFragmentsFromExternalSourceWithRange(context.Background(), tc.format,
+				[]string{"id"}, "", config, 0, 1, explorePath, ExternalFetchOptions{RowLimit: 2})
+			require.NoError(t, err)
+			require.Len(t, fragments, 2)
+			for i, fragment := range fragments {
+				assert.Equal(t, tc.properties, fragment.Properties)
+				assert.Equal(t, int64(i*2), fragment.StartRow)
+				assert.Equal(t, int64(i*2+2), fragment.EndRow)
+			}
+
+			manifestPath, err := CreateManifestForSegment(filepath.Join(dir, "segment"), []string{"id"}, tc.format, fragments, config)
+			require.NoError(t, err)
+			readBack, err := ReadFragmentsFromManifest(manifestPath, config, []string{"id"})
+			require.NoError(t, err)
+			assert.Equal(t, fragments, readBack)
+
+			manifestPath, err = AppendSegmentManifestColumns(context.Background(), manifestPath, tc.format, []string{"extra_column"}, readBack, config)
+			require.NoError(t, err)
+			readBack, err = ReadFragmentsFromManifest(manifestPath, config, []string{"extra_column"})
+			require.NoError(t, err)
+			assert.Equal(t, fragments, readBack)
+		})
+	}
+}
 
 func TestDeltaLogEntry(t *testing.T) {
 	entry := DeltaLogEntry{

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -52,10 +52,12 @@ func NewFragmentIDGenerator(start int64) FragmentIDGenerator {
 // SplitFileToFragments splits a large file into multiple fragments based on row count.
 // If totalRows <= rowLimit, returns a single fragment covering the entire file.
 // Otherwise, splits the file into multiple fragments with rowLimit rows each.
+// Every fragment shares the source file's immutable properties.
 func SplitFileToFragments(
 	filePath string,
 	totalRows int64,
 	rowLimit int64,
+	properties map[string]string,
 	fragmentIDGenerator FragmentIDGenerator,
 ) []Fragment {
 	if totalRows <= rowLimit {
@@ -65,6 +67,7 @@ func SplitFileToFragments(
 			StartRow:   0,
 			EndRow:     totalRows,
 			RowCount:   totalRows,
+			Properties: properties,
 		}}
 	}
 
@@ -80,6 +83,7 @@ func SplitFileToFragments(
 			StartRow:   start,
 			EndRow:     end,
 			RowCount:   end - start,
+			Properties: properties,
 		})
 	}
 	return fragments
@@ -266,7 +270,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 			})
 			continue
 		}
-		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)...)
+		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fi.Properties, fragmentIDGenerator)...)
 	}
 	if len(fragments) == 0 {
 		return nil, merr.WrapErrServiceInternalMsg("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)


### PR DESCRIPTION
issue: #53102

External file properties were dropped between exploration and segment manifest creation, losing Lance dataset versions and Iceberg delete metadata.

Preserve all properties when reading manifests and carry the source file's properties into every fragment produced by SplitFileToFragments. Bump milvus-storage from e7f4477 to 15ab3d7 and pass per-file properties through loon_column_groups_create, retaining native allocation and destruction of column groups.

Keep fragment identity based on file path and row range under the existing immutable-file contract.