### PR TITLE
enhance: [3.0] align Go SDK v3.0.0 client with master features

### DIFF
--- a/client/common/version.go
+++ b/client/common/version.go
@@ -18,5 +18,5 @@ package common
 
 const (
 	// SDKVersion const value for current version
-	SDKVersion = `3.0.0-beta`
+	SDKVersion = `3.0.0`
 )

--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/samber/lo"
+
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
@@ -77,20 +79,24 @@ func (f *Function) WithType(funcType FunctionType) *Function {
 }
 
 func (f *Function) WithParam(key string, value any) *Function {
-	// Handle slices by converting to JSON format
+	f.Params[key] = paramValueToString(value)
+	return f
+}
+
+// paramValueToString renders a Function/FunctionScore param value on the wire:
+// slices are JSON-encoded, everything else uses its default string form.
+func paramValueToString(value any) string {
 	valueType := reflect.TypeOf(value)
 	if valueType == nil {
-		f.Params[key] = "null"
-	} else if valueType.Kind() == reflect.Slice {
-		if jsonBytes, err := json.Marshal(value); err == nil {
-			f.Params[key] = string(jsonBytes)
-		} else {
-			f.Params[key] = fmt.Sprintf("%v", value)
-		}
-	} else {
-		f.Params[key] = fmt.Sprintf("%v", value)
+		return "null"
 	}
-	return f
+	if valueType.Kind() == reflect.Slice {
+		if jsonBytes, err := json.Marshal(value); err == nil {
+			return string(jsonBytes)
+		}
+		return fmt.Sprintf("%v", value)
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 // ProtoMessage returns corresponding schemapb.FunctionSchema
@@ -122,4 +128,80 @@ func (f *Function) ReadProto(p *schemapb.FunctionSchema) *Function {
 	f.outputFieldIDs = p.GetOutputFieldIds()
 
 	return f
+}
+
+// FunctionScore models the search-time FunctionScore message: a set of scoring
+// Functions (e.g. boost rankers) plus score-option params such as boost_mode
+// and function_mode.
+type FunctionScore struct {
+	Functions []*Function
+	Params    map[string]string
+}
+
+func NewFunctionScore() *FunctionScore {
+	return &FunctionScore{
+		Params: make(map[string]string),
+	}
+}
+
+func (fs *FunctionScore) AddFunction(f *Function) *FunctionScore {
+	fs.Functions = append(fs.Functions, f)
+	return fs
+}
+
+func (fs *FunctionScore) WithParam(key string, value any) *FunctionScore {
+	fs.Params[key] = paramValueToString(value)
+	return fs
+}
+
+// Clone returns a deep copy of fs: functions and params are copied so the
+// returned score does not share mutable state with the source.
+func (fs *FunctionScore) Clone() *FunctionScore {
+	nf := NewFunctionScore()
+	for _, f := range fs.Functions {
+		nf.AddFunction(f.Clone())
+	}
+	for k, v := range fs.Params {
+		nf.Params[k] = v
+	}
+	return nf
+}
+
+// Clone returns a deep copy of f.
+func (f *Function) Clone() *Function {
+	nf := &Function{
+		Name:             f.Name,
+		Description:      f.Description,
+		Type:             f.Type,
+		InputFieldNames:  append([]string(nil), f.InputFieldNames...),
+		OutputFieldNames: append([]string(nil), f.OutputFieldNames...),
+		Params:           make(map[string]string, len(f.Params)),
+		id:               f.id,
+		inputFieldIDs:    append([]int64(nil), f.inputFieldIDs...),
+		outputFieldIDs:   append([]int64(nil), f.outputFieldIDs...),
+	}
+	for k, v := range f.Params {
+		nf.Params[k] = v
+	}
+	return nf
+}
+
+// ProtoMessage returns corresponding schemapb.FunctionScore
+func (fs *FunctionScore) ProtoMessage() *schemapb.FunctionScore {
+	r := &schemapb.FunctionScore{
+		Params: MapKvPairs(fs.Params),
+	}
+	for _, f := range fs.Functions {
+		r.Functions = append(r.Functions, f.ProtoMessage())
+	}
+	return r
+}
+
+// ReadProto parses proto FunctionScore
+func (fs *FunctionScore) ReadProto(p *schemapb.FunctionScore) *FunctionScore {
+	fs.Functions = lo.Map(p.GetFunctions(), func(fn *schemapb.FunctionSchema, _ int) *Function {
+		return NewFunction().ReadProto(fn)
+	})
+	fs.Params = KvPairsMap(p.GetParams())
+	return fs
 }

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -80,3 +80,58 @@ func TestFunctionWithParamSliceHandling(t *testing.T) {
 	f = NewFunction().WithParam("string_key", "string_value")
 	assert.Equal(t, "string_value", f.Params["string_key"])
 }
+
+func TestFunctionScoreSchema(t *testing.T) {
+	boostFn := NewFunction().
+		WithName("title_boost").
+		WithType(FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("filter", "text_match(title, \"ai\")").
+		WithParam("weight", 2.0)
+	weightedFn := NewFunction().
+		WithName("recency_boost").
+		WithType(FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 1.5)
+
+	fs := NewFunctionScore().
+		AddFunction(boostFn).
+		AddFunction(weightedFn).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
+
+	proto := fs.ProtoMessage()
+	assert.Len(t, proto.GetFunctions(), 2)
+	assert.Equal(t, map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, KvPairsMap(proto.GetParams()))
+	assert.Equal(t, boostFn.Params, KvPairsMap(proto.GetFunctions()[0].GetParams()))
+	assert.Equal(t, weightedFn.Params, KvPairsMap(proto.GetFunctions()[1].GetParams()))
+
+	nf := NewFunctionScore().ReadProto(proto)
+	assert.Equal(t, fs.Params, nf.Params)
+	assert.Len(t, nf.Functions, 2)
+	for i, fn := range fs.Functions {
+		assert.Equal(t, fn.Name, nf.Functions[i].Name)
+		assert.Equal(t, fn.Type, nf.Functions[i].Type)
+		assert.Equal(t, fn.Params, nf.Functions[i].Params)
+	}
+}
+
+func TestFunctionScoreClone(t *testing.T) {
+	fs := NewFunctionScore().
+		AddFunction(NewFunction().WithName("boost").WithType(FunctionTypeRerank).
+			WithParam("reranker", "boost").WithParam("weight", 2.0)).
+		WithParam("boost_mode", "sum")
+
+	clone := fs.Clone()
+	assert.Equal(t, fs, clone)
+
+	fs.AddFunction(NewFunction().WithName("second"))
+	assert.Len(t, clone.Functions, 1, "clone must not share the source Functions slice")
+
+	clone.AddFunction(NewFunction().WithName("clone_only"))
+	assert.Len(t, fs.Functions, 2, "source must not see functions added to the clone")
+
+	fs.WithParam("function_mode", "multiply")
+	_, ok := clone.Params["function_mode"]
+	assert.False(t, ok, "clone must not share the source Params map")
+}

--- a/client/index/common.go
+++ b/client/index/common.go
@@ -47,9 +47,13 @@ const (
 	IvfSQ8     IndexType = "IVF_SQ8"
 	IvfRabitQ  IndexType = "IVF_RABITQ"
 	HNSW       IndexType = "HNSW"
+	HNSWSQ     IndexType = "HNSW_SQ"
+	HNSWPQ     IndexType = "HNSW_PQ"
+	HNSWPRQ    IndexType = "HNSW_PRQ"
 	IvfHNSW    IndexType = "IVF_HNSW"
 	AUTOINDEX  IndexType = "AUTOINDEX"
 	DISKANN    IndexType = "DISKANN"
+	AISAQ      IndexType = "AISAQ"
 	SCANN      IndexType = "SCANN"
 	MinHashLSH IndexType = "MINHASH_LSH"
 
@@ -67,5 +71,7 @@ const (
 	Sorted   IndexType = "STL_SORT"
 	Inverted IndexType = "INVERTED"
 	BITMAP   IndexType = "BITMAP"
+	NGRAM    IndexType = "NGRAM"
+	FMINDEX  IndexType = "FMINDEX"
 	RTREE    IndexType = "RTREE"
 )

--- a/client/index/disk_ann.go
+++ b/client/index/disk_ann.go
@@ -16,6 +16,8 @@
 
 package index
 
+import "strconv"
+
 const (
 	diskANNSearchListKey = `search_list`
 )
@@ -60,4 +62,143 @@ func (ap diskANNParam) Params() map[string]any {
 	result := ap.baseAnnParam.params
 	result[diskANNSearchListKey] = ap.searchList
 	return result
+}
+
+// WithBeamwidth sets the maximum number of IO requests issued per search
+// iteration.
+func (ap diskANNParam) WithBeamwidth(beamwidth int) diskANNParam {
+	ap.params[aisaqBeamwidthKey] = beamwidth
+	return ap
+}
+
+// AISAQ-specific params (knowhere AisaqConfig). Everything AISAQ inherits from
+// DiskANNConfig keeps its server-side default, exactly as NewDiskANNIndex does.
+const (
+	aisaqInlinePQKey            = `inline_pq`
+	aisaqPQCacheSizeKey         = `pq_cache_size`
+	aisaqRearrangeKey           = `rearrange`
+	aisaqPQReadIOEngineKey      = `pq_read_io_engine`
+	aisaqNumEntryPointsKey      = `num_entry_points`
+	aisaqPQReadPageCacheSizeKey = `pq_read_page_cache_size`
+	aisaqBeamwidthKey           = `beamwidth`
+	aisaqVectorsBeamwidthKey    = `vectors_beamwidth`
+)
+
+var _ Index = &aisaqIndex{}
+
+// aisaqIndex is a DiskANN variant that keeps PQ codes inline with the graph to
+// cut the number of random reads per hop. Every build param has a server-side
+// default, so the constructor takes only the metric type and the rest are
+// opt-in.
+type aisaqIndex struct {
+	baseIndex
+
+	params map[string]string
+}
+
+func (idx *aisaqIndex) Params() map[string]string {
+	result := map[string]string{
+		MetricTypeKey: string(idx.metricType),
+		IndexTypeKey:  string(AISAQ),
+	}
+	// An unset param must stay absent: every one of these is range-checked
+	// server-side, so sending a zero would be rejected rather than treated as
+	// "use the default".
+	for k, v := range idx.params {
+		result[k] = v
+	}
+	return result
+}
+
+// WithInlinePQ sets how many compressed vectors are stored inline in a node.
+// Capped by the graph's max degree; range [0, 2048].
+func (idx *aisaqIndex) WithInlinePQ(inlinePQ int) *aisaqIndex {
+	idx.params[aisaqInlinePQKey] = strconv.Itoa(inlinePQ)
+	return idx
+}
+
+// WithPQCacheSize sets the compressed-vector cache size in bytes.
+func (idx *aisaqIndex) WithPQCacheSize(bytes int) *aisaqIndex {
+	idx.params[aisaqPQCacheSizeKey] = strconv.Itoa(bytes)
+	return idx
+}
+
+// WithRearrange enables the compressed-vector reordering search optimization.
+func (idx *aisaqIndex) WithRearrange(rearrange bool) *aisaqIndex {
+	idx.params[aisaqRearrangeKey] = strconv.FormatBool(rearrange)
+	return idx
+}
+
+// WithPQReadIOEngine selects the IO engine used to read PQ vectors, either
+// "aio" (server default) or "uring".
+func (idx *aisaqIndex) WithPQReadIOEngine(engine string) *aisaqIndex {
+	idx.params[aisaqPQReadIOEngineKey] = engine
+	return idx
+}
+
+// WithNumEntryPoints sets how many entry points are generated and stored when
+// the graph is built. This is a build param (knowhere marks it for_train), not
+// a per-search knob.
+func (idx *aisaqIndex) WithNumEntryPoints(numEntryPoints int) *aisaqIndex {
+	idx.params[aisaqNumEntryPointsKey] = strconv.Itoa(numEntryPoints)
+	return idx
+}
+
+// WithPQReadPageCacheSize sets the per-thread read-page cache size in bytes.
+// This one is honored at both build and search time.
+func (idx *aisaqIndex) WithPQReadPageCacheSize(bytes int) *aisaqIndex {
+	idx.params[aisaqPQReadPageCacheSizeKey] = strconv.Itoa(bytes)
+	return idx
+}
+
+func NewAISAQIndex(metricType MetricType) *aisaqIndex {
+	return &aisaqIndex{
+		baseIndex: baseIndex{
+			metricType: metricType,
+			indexType:  AISAQ,
+		},
+		params: make(map[string]string),
+	}
+}
+
+// aisaqAnnParam carries DiskANN's search_list plus the two beam widths AISAQ
+// adds on top of it.
+type aisaqAnnParam struct {
+	baseAnnParam
+	searchList int
+}
+
+func (ap *aisaqAnnParam) Params() map[string]any {
+	result := ap.baseAnnParam.params
+	result[diskANNSearchListKey] = ap.searchList
+	return result
+}
+
+// WithBeamwidth sets the maximum number of IO requests issued per search
+// iteration.
+func (ap *aisaqAnnParam) WithBeamwidth(beamwidth int) *aisaqAnnParam {
+	ap.params[aisaqBeamwidthKey] = beamwidth
+	return ap
+}
+
+// WithVectorsBeamwidth sets the beam width used for the compressed vectors.
+func (ap *aisaqAnnParam) WithVectorsBeamwidth(beamwidth int) *aisaqAnnParam {
+	ap.params[aisaqVectorsBeamwidthKey] = beamwidth
+	return ap
+}
+
+// WithPQReadPageCacheSize sets the per-thread read-page cache size in bytes for
+// this search.
+func (ap *aisaqAnnParam) WithPQReadPageCacheSize(bytes int) *aisaqAnnParam {
+	ap.params[aisaqPQReadPageCacheSizeKey] = bytes
+	return ap
+}
+
+func NewAISAQAnnParam(searchList int) *aisaqAnnParam {
+	return &aisaqAnnParam{
+		baseAnnParam: baseAnnParam{
+			params: make(map[string]any),
+		},
+		searchList: searchList,
+	}
 }

--- a/client/index/disk_ann_test.go
+++ b/client/index/disk_ann_test.go
@@ -1,0 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestAISAQ(t *testing.T) {
+	result := NewAISAQIndex(entity.L2).Params()
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.EqualValues(t, AISAQ, result[IndexTypeKey])
+
+	// Every build param is range-checked server-side, so an unset one must stay
+	// absent rather than being sent as a zero.
+	assert.Len(t, result, 2)
+}
+
+func TestAISAQBuildParams(t *testing.T) {
+	result := NewAISAQIndex(entity.L2).
+		WithInlinePQ(8).
+		WithPQCacheSize(1 << 20).
+		WithRearrange(true).
+		WithPQReadIOEngine("uring").
+		WithNumEntryPoints(4).
+		WithPQReadPageCacheSize(4096).
+		Params()
+
+	assert.Equal(t, "8", result[aisaqInlinePQKey])
+	assert.Equal(t, "1048576", result[aisaqPQCacheSizeKey])
+	assert.Equal(t, "true", result[aisaqRearrangeKey])
+	assert.Equal(t, "uring", result[aisaqPQReadIOEngineKey])
+	assert.Equal(t, "4", result[aisaqNumEntryPointsKey])
+	assert.Equal(t, "4096", result[aisaqPQReadPageCacheSizeKey])
+}
+
+func TestAISAQAnnParam(t *testing.T) {
+	ap := NewAISAQAnnParam(100)
+	result := ap.Params()
+	assert.Equal(t, 100, result[diskANNSearchListKey])
+	assert.NotContains(t, result, aisaqBeamwidthKey)
+	assert.NotContains(t, result, aisaqVectorsBeamwidthKey)
+
+	result = ap.WithBeamwidth(8).WithVectorsBeamwidth(2).WithPQReadPageCacheSize(4096).Params()
+	assert.Equal(t, 8, result[aisaqBeamwidthKey])
+	assert.Equal(t, 2, result[aisaqVectorsBeamwidthKey])
+	assert.Equal(t, 4096, result[aisaqPQReadPageCacheSizeKey])
+}

--- a/client/index/gpu.go
+++ b/client/index/gpu.go
@@ -36,6 +36,7 @@ func NewGPUBruteForceIndex(metricType MetricType) Index {
 	return gpuBruteForceIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUBruteForce,
 		},
 	}
 }
@@ -48,12 +49,13 @@ type gpuIVFFlatIndex struct {
 }
 
 func (idx gpuIVFFlatIndex) Params() map[string]string {
+	// nlist is not reachable through the constructor, so it is zero here; an
+	// absent key lets the server apply its default, while "0" is below the
+	// accepted range and fails the build. Use WithExtraIndexParams to set it.
 	return map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
 		IndexTypeKey:  string(GPUIvfFlat),
-		// build param
-		ivfNlistKey: strconv.Itoa(idx.nlist),
 	}
 }
 
@@ -61,6 +63,7 @@ func NewGPUIVPFlatIndex(metricType MetricType) Index {
 	return gpuIVFFlatIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUIvfFlat,
 		},
 	}
 }
@@ -75,28 +78,30 @@ type gpuIVFPQIndex struct {
 }
 
 func (idx gpuIVFPQIndex) Params() map[string]string {
-	return map[string]string{
+	result := map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
-		IndexTypeKey:  string(GPUIvfFlat),
-		// build params
-		ivfNlistKey: strconv.Itoa(idx.nlist),
-		ivfPQMKey:   strconv.Itoa(idx.m),
-		ivfPQNbits:  strconv.Itoa(idx.nbits),
+		IndexTypeKey:  string(GPUIvfPQ),
 	}
+	// nlist / m / nbits have never been reachable through the constructor, so
+	// they are zero here; emitting them is worse than omitting them, because
+	// zero is below every accepted range while an absent key lets the server
+	// apply its default. Set them with WithExtraIndexParams if needed.
+	return result
 }
 
 func NewGPUIVPPQIndex(metricType MetricType) Index {
 	return gpuIVFPQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUIvfPQ,
 		},
 	}
 }
 
 const (
 	cagraInterGraphDegreeKey = `intermediate_graph_degree`
-	cagraGraphDegreeKey      = `"graph_degree"`
+	cagraGraphDegreeKey      = `graph_degree`
 )
 
 type gpuCagra struct {
@@ -105,11 +110,13 @@ type gpuCagra struct {
 	graphDegree             int
 }
 
+var _ Index = gpuCagra{}
+
 func (idx gpuCagra) Params() map[string]string {
 	return map[string]string{
 		// build meta
 		MetricTypeKey: string(idx.metricType),
-		IndexTypeKey:  string(GPUIvfFlat),
+		IndexTypeKey:  string(GPUCagra),
 		// build params
 		cagraInterGraphDegreeKey: strconv.Itoa(idx.intermediateGraphDegree),
 		cagraGraphDegreeKey:      strconv.Itoa(idx.graphDegree),
@@ -123,6 +130,7 @@ func NewGPUCagraIndex(metricType MetricType,
 	return gpuCagra{
 		baseIndex: baseIndex{
 			metricType: metricType,
+			indexType:  GPUCagra,
 		},
 		intermediateGraphDegree: intermediateGraphDegree,
 		graphDegree:             graphDegree,

--- a/client/index/gpu_test.go
+++ b/client/index/gpu_test.go
@@ -1,0 +1,77 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+// Each GPU builder must report its own type, both on the wire and through
+// IndexType(). GPU_IVF_PQ and GPU_CAGRA used to send GPU_IVF_FLAT, and none of
+// them set baseIndex.indexType at all.
+func TestGPUIndexTypes(t *testing.T) {
+	type testCase struct {
+		tag    string
+		idx    Index
+		expect IndexType
+	}
+
+	for _, tc := range []testCase{
+		{tag: "brute_force", idx: NewGPUBruteForceIndex(entity.L2), expect: GPUBruteForce},
+		{tag: "ivf_flat", idx: NewGPUIVPFlatIndex(entity.L2), expect: GPUIvfFlat},
+		{tag: "ivf_pq", idx: NewGPUIVPPQIndex(entity.L2), expect: GPUIvfPQ},
+		{tag: "cagra", idx: NewGPUCagraIndex(entity.L2, 128, 64), expect: GPUCagra},
+	} {
+		t.Run(tc.tag, func(t *testing.T) {
+			assert.EqualValues(t, tc.expect, tc.idx.Params()[IndexTypeKey])
+			assert.EqualValues(t, tc.expect, tc.idx.IndexType())
+			assert.EqualValues(t, entity.L2, tc.idx.Params()[MetricTypeKey])
+		})
+	}
+}
+
+func TestGPUUnsetBuildParamsAreOmitted(t *testing.T) {
+	// nlist / m / nbits are unreachable through these constructors, so they sat
+	// at zero and were emitted as "0" — below every accepted range, which fails
+	// the build. An absent key lets the server apply its default instead.
+	flat := NewGPUIVPFlatIndex(entity.L2).Params()
+	assert.NotContains(t, flat, ivfNlistKey)
+
+	pq := NewGPUIVPPQIndex(entity.L2).Params()
+	assert.NotContains(t, pq, ivfNlistKey)
+	assert.NotContains(t, pq, ivfPQMKey)
+	assert.NotContains(t, pq, ivfPQNbits)
+
+	// They remain reachable without changing the constructor signature.
+	withNlist := WithExtraIndexParams(NewGPUIVPFlatIndex(entity.L2), map[string]string{
+		ivfNlistKey: "1024",
+	}).Params()
+	assert.Equal(t, "1024", withNlist[ivfNlistKey])
+}
+
+func TestGPUCagraGraphDegreeKey(t *testing.T) {
+	result := NewGPUCagraIndex(entity.L2, 128, 64).Params()
+	// The key used to be declared as `"graph_degree"` — backquotes around a
+	// string that itself contains the quote characters.
+	assert.Equal(t, "64", result["graph_degree"])
+	assert.NotContains(t, result, `"graph_degree"`)
+	assert.Equal(t, "128", result[cagraInterGraphDegreeKey])
+}

--- a/client/index/hnsw.go
+++ b/client/index/hnsw.go
@@ -74,3 +74,233 @@ func (ap hsnwAnnParam) Params() map[string]any {
 	result[hnswEfKey] = ap.ef
 	return result
 }
+
+// WithSeedEf sets the ef used to seed an iterator search (knowhere
+// FaissHnswConfig::seed_ef). Server default 40.
+func (ap hsnwAnnParam) WithSeedEf(seedEf int) hsnwAnnParam {
+	ap.params[hnswSeedEfKey] = seedEf
+	return ap
+}
+
+// The quantized HNSW variants share M / efConstruction with plain HNSW and add
+// their own quantizer params. Note that `M` (graph degree) and `m` (number of
+// PQ sub-quantizers) are two different params — the case is significant.
+//
+// refine is only valid on these three. Plain HNSW maps to knowhere's
+// FaissHnswFlatConfig, whose CheckAndAdjust rejects the build outright with
+// "refine is not supported for this index" if refine or refine_type is set.
+const (
+	hnswSQTypeKey  = `sq_type`
+	hnswPQMKey     = `m`
+	hnswPQNbitsKey = `nbits`
+	hnswPRQNrqKey  = `nrq`
+
+	hnswRefineKey     = `refine`
+	hnswRefineTypeKey = `refine_type`
+	hnswRefineKKey    = `refine_k`
+	hnswSeedEfKey     = `seed_ef`
+)
+
+// hnswQuantIndex carries what the three quantized HNSW variants have in common:
+// the graph params and the optional refine index. Refine keeps full-precision
+// vectors alongside the quantized ones and re-ranks with them, trading storage
+// for recall.
+type hnswQuantIndex struct {
+	baseIndex
+
+	m              int
+	efConstruction int
+	refine         bool
+	refineType     string
+}
+
+func (idx hnswQuantIndex) commonParams(indexType IndexType) map[string]string {
+	result := map[string]string{
+		MetricTypeKey:      string(idx.metricType),
+		IndexTypeKey:       string(indexType),
+		hnswMKey:           strconv.Itoa(idx.m),
+		hsnwEfConstruction: strconv.Itoa(idx.efConstruction),
+	}
+	// Only emitted once the caller opts in, so an index built without refine
+	// does not carry an empty refine_type the server would reject.
+	if idx.refine {
+		result[hnswRefineKey] = strconv.FormatBool(idx.refine)
+		result[hnswRefineTypeKey] = idx.refineType
+	}
+	return result
+}
+
+var _ Index = &hnswSQIndex{}
+
+type hnswSQIndex struct {
+	hnswQuantIndex
+
+	sqType string
+}
+
+func (idx *hnswSQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWSQ)
+	result[hnswSQTypeKey] = idx.sqType
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswSQIndex) WithRefineType(refineType string) *hnswSQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWSQIndex creates an HNSW index whose vectors are scalar-quantized.
+// sqType is the quantizer: knowhere accepts sq4u / sq6 / sq8 / fp16 / bf16,
+// and its default is SQ8.
+func NewHNSWSQIndex(metricType MetricType, m int, efConstruction int, sqType string) *hnswSQIndex {
+	return &hnswSQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWSQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		sqType: sqType,
+	}
+}
+
+var _ Index = &hnswPQIndex{}
+
+type hnswPQIndex struct {
+	hnswQuantIndex
+
+	pqM   int
+	nbits int
+}
+
+func (idx *hnswPQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWPQ)
+	result[hnswPQMKey] = strconv.Itoa(idx.pqM)
+	result[hnswPQNbitsKey] = strconv.Itoa(idx.nbits)
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswPQIndex) WithRefineType(refineType string) *hnswPQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWPQIndex creates an HNSW index whose vectors are product-quantized.
+// pqM is the number of sub-quantizers (server default 32) and nbits the bits
+// per sub-quantizer, in [1, 24] (server default 8).
+func NewHNSWPQIndex(metricType MetricType, m int, efConstruction int, pqM int, nbits int) *hnswPQIndex {
+	return &hnswPQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWPQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		pqM:   pqM,
+		nbits: nbits,
+	}
+}
+
+var _ Index = &hnswPRQIndex{}
+
+type hnswPRQIndex struct {
+	hnswQuantIndex
+
+	pqM   int
+	nrq   int
+	nbits int
+}
+
+func (idx *hnswPRQIndex) Params() map[string]string {
+	result := idx.commonParams(HNSWPRQ)
+	result[hnswPQMKey] = strconv.Itoa(idx.pqM)
+	result[hnswPRQNrqKey] = strconv.Itoa(idx.nrq)
+	result[hnswPQNbitsKey] = strconv.Itoa(idx.nbits)
+	return result
+}
+
+// WithRefineType enables the refine index and sets its precision. knowhere
+// accepts sq4u / sq6 / sq8 / fp16 / bf16 / fp32 / flat.
+func (idx *hnswPRQIndex) WithRefineType(refineType string) *hnswPRQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWPRQIndex creates an HNSW index whose vectors are quantized with a
+// product-residual quantizer. pqM is the number of splits (server default 2),
+// nrq the number of residual quantizers, in [1, 16] (server default 2), and
+// nbits the bits per sub-quantizer, in [1, 24] (server default 8).
+func NewHNSWPRQIndex(metricType MetricType, m int, efConstruction int, pqM int, nrq int, nbits int) *hnswPRQIndex {
+	return &hnswPRQIndex{
+		hnswQuantIndex: hnswQuantIndex{
+			baseIndex: baseIndex{
+				metricType: metricType,
+				indexType:  HNSWPRQ,
+			},
+			m:              m,
+			efConstruction: efConstruction,
+		},
+		pqM:   pqM,
+		nrq:   nrq,
+		nbits: nbits,
+	}
+}
+
+// hnswQuantAnnParam is the search-time param set the three quantized variants
+// share: `ef` as for plain HNSW, plus refine_k (how many candidates the refine
+// index re-ranks) and seed_ef (used by the iterator).
+type hnswQuantAnnParam struct {
+	baseAnnParam
+	ef int
+}
+
+func (ap *hnswQuantAnnParam) Params() map[string]any {
+	result := ap.baseAnnParam.params
+	result[hnswEfKey] = ap.ef
+	return result
+}
+
+// WithRefineK sets how many candidates the refine index re-ranks, as a
+// multiple of the requested top-k: knowhere types it CFG_FLOAT and passes it
+// straight through as faiss::IndexRefineSearchParameters::k_factor, so
+// fractional values such as 1.5 are meaningful. Only useful on an index built
+// with WithRefineType.
+func (ap *hnswQuantAnnParam) WithRefineK(refineK float64) *hnswQuantAnnParam {
+	ap.params[hnswRefineKKey] = refineK
+	return ap
+}
+
+// WithSeedEf sets the ef used to seed an iterator search.
+func (ap *hnswQuantAnnParam) WithSeedEf(seedEf int) *hnswQuantAnnParam {
+	ap.params[hnswSeedEfKey] = seedEf
+	return ap
+}
+
+func newHNSWQuantAnnParam(ef int) *hnswQuantAnnParam {
+	return &hnswQuantAnnParam{
+		baseAnnParam: baseAnnParam{
+			params: make(map[string]any),
+		},
+		ef: ef,
+	}
+}
+
+// NewHNSWSQAnnParam creates the search params for an HNSW_SQ index.
+func NewHNSWSQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }
+
+// NewHNSWPQAnnParam creates the search params for an HNSW_PQ index.
+func NewHNSWPQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }
+
+// NewHNSWPRQAnnParam creates the search params for an HNSW_PRQ index.
+func NewHNSWPRQAnnParam(ef int) *hnswQuantAnnParam { return newHNSWQuantAnnParam(ef) }

--- a/client/index/hnsw_test.go
+++ b/client/index/hnsw_test.go
@@ -1,0 +1,107 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
+
+func TestHNSWSQ(t *testing.T) {
+	idx := NewHNSWSQIndex(entity.COSINE, 16, 200, "SQ8")
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.COSINE, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWSQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	assert.Equal(t, "SQ8", result[hnswSQTypeKey])
+}
+
+func TestHNSWPQ(t *testing.T) {
+	idx := NewHNSWPQIndex(entity.L2, 16, 200, 32, 8)
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWPQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	// `M` is the graph degree, `m` the number of PQ sub-quantizers: distinct
+	// params that differ only in case, so assert both survive the map.
+	assert.Equal(t, "32", result[hnswPQMKey])
+	assert.NotEqual(t, result[hnswMKey], result[hnswPQMKey])
+	assert.Equal(t, "8", result[hnswPQNbitsKey])
+}
+
+func TestHNSWPRQ(t *testing.T) {
+	idx := NewHNSWPRQIndex(entity.IP, 16, 200, 2, 2, 8)
+
+	result := idx.Params()
+	assert.EqualValues(t, entity.IP, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWPRQ, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "200", result[hsnwEfConstruction])
+	assert.Equal(t, "2", result[hnswPQMKey])
+	assert.Equal(t, "2", result[hnswPRQNrqKey])
+	assert.Equal(t, "8", result[hnswPQNbitsKey])
+}
+
+func TestHNSWQuantizedRefine(t *testing.T) {
+	// Refine must stay absent unless the caller opts in: an index built without
+	// it would otherwise carry an empty refine_type the server rejects.
+	for _, result := range []map[string]string{
+		NewHNSWSQIndex(entity.L2, 16, 200, "SQ8").Params(),
+		NewHNSWPQIndex(entity.L2, 16, 200, 32, 8).Params(),
+		NewHNSWPRQIndex(entity.L2, 16, 200, 2, 2, 8).Params(),
+	} {
+		assert.NotContains(t, result, hnswRefineKey)
+		assert.NotContains(t, result, hnswRefineTypeKey)
+	}
+
+	result := NewHNSWSQIndex(entity.L2, 16, 200, "SQ8").WithRefineType("FP32").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "FP32", result[hnswRefineTypeKey])
+
+	result = NewHNSWPQIndex(entity.L2, 16, 200, 32, 8).WithRefineType("SQ8").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "SQ8", result[hnswRefineTypeKey])
+
+	result = NewHNSWPRQIndex(entity.L2, 16, 200, 2, 2, 8).WithRefineType("BF16").Params()
+	assert.Equal(t, "true", result[hnswRefineKey])
+	assert.Equal(t, "BF16", result[hnswRefineTypeKey])
+}
+
+func TestHNSWQuantizedAnnParam(t *testing.T) {
+	for _, ap := range []*hnswQuantAnnParam{
+		NewHNSWSQAnnParam(64),
+		NewHNSWPQAnnParam(64),
+		NewHNSWPRQAnnParam(64),
+	} {
+		result := ap.Params()
+		assert.Equal(t, 64, result[hnswEfKey])
+		assert.NotContains(t, result, hnswRefineKKey)
+		assert.NotContains(t, result, hnswSeedEfKey)
+
+		result = ap.WithRefineK(1.5).WithSeedEf(32).Params()
+		// refine_k is knowhere's k_factor (CFG_FLOAT), so fractions must survive.
+		assert.Equal(t, 1.5, result[hnswRefineKKey])
+		assert.Equal(t, 32, result[hnswSeedEfKey])
+	}
+}

--- a/client/index/index.go
+++ b/client/index/index.go
@@ -76,8 +76,55 @@ func (gi GenericIndex) WithMetricType(metricType MetricType) {
 func NewGenericIndex(name string, params map[string]string) GenericIndex {
 	return GenericIndex{
 		baseIndex: baseIndex{
-			name: name,
+			name:      name,
+			indexType: IndexType(params[IndexTypeKey]),
 		},
 		params: params,
+	}
+}
+
+var _ Index = extraParamIndex{}
+
+// Keys the extra-param wrapper refuses to touch: they define which index is
+// being built, and letting them be overridden would put Params() and
+// IndexType() into disagreement.
+var reservedIndexParamKeys = map[string]struct{}{
+	IndexTypeKey:  {},
+	MetricTypeKey: {},
+}
+
+type extraParamIndex struct {
+	Index
+	extra map[string]string
+}
+
+func (idx extraParamIndex) Params() map[string]string {
+	result := idx.Index.Params()
+	for k, v := range idx.extra {
+		if _, reserved := reservedIndexParamKeys[k]; reserved {
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// WithExtraIndexParams merges additional raw build params into whatever `idx`
+// produces. index_type and metric_type are reserved and silently ignored:
+// overriding them would make Params() disagree with IndexType(), so use the
+// constructor for the index you actually want. Any other key overrides.
+//
+// The typed constructors model the params each index most needs, not every one
+// the engine accepts, and they necessarily trail the engine as it gains new
+// ones. This is the escape hatch for the rest — the build-side counterpart of
+// baseAnnParam.WithExtraParam — so reaching for a param the constructor does
+// not expose does not mean giving up the constructor for NewGenericIndex and a
+// hand-built map.
+//
+// Params are forwarded verbatim; the server validates names and ranges.
+func WithExtraIndexParams(idx Index, extra map[string]string) Index {
+	return extraParamIndex{
+		Index: idx,
+		extra: extra,
 	}
 }

--- a/client/index/index_test.go
+++ b/client/index/index_test.go
@@ -16,8 +16,63 @@
 
 package index
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+)
 
 func TestGenericIndex(t *testing.T) {
-	// idx := NewGenericIndex("auto_scalar_index")
+	params := map[string]string{
+		IndexTypeKey: string(FMINDEX),
+		"custom_key": "custom_value",
+	}
+	idx := NewGenericIndex("fm_index", params)
+
+	assert.Equal(t, "fm_index", idx.Name())
+	assert.EqualValues(t, FMINDEX, idx.IndexType())
+	assert.Equal(t, params, idx.Params())
+
+	idxWithoutType := NewGenericIndex("legacy_index", map[string]string{"custom_key": "custom_value"})
+	assert.Empty(t, idxWithoutType.IndexType())
+}
+
+func TestWithExtraIndexParams(t *testing.T) {
+	// A param the typed constructor does not model must reach the wire without
+	// giving up the constructor.
+	idx := WithExtraIndexParams(NewHNSWIndex(entity.L2, 16, 200), map[string]string{
+		"refine":      "true",
+		"refine_type": "fp32",
+	})
+
+	result := idx.Params()
+	assert.EqualValues(t, HNSW, result[IndexTypeKey])
+	assert.Equal(t, "16", result[hnswMKey])
+	assert.Equal(t, "true", result["refine"])
+	assert.Equal(t, "fp32", result["refine_type"])
+	assert.EqualValues(t, HNSW, idx.IndexType())
+
+	// Extras win on collision, and the wrapped index is left untouched.
+	base := NewHNSWIndex(entity.L2, 16, 200)
+	wrapped := WithExtraIndexParams(base, map[string]string{hnswMKey: "32"})
+	assert.Equal(t, "32", wrapped.Params()[hnswMKey])
+	assert.Equal(t, "16", base.Params()[hnswMKey])
+}
+
+func TestWithExtraIndexParamsReservedKeys(t *testing.T) {
+	// Overriding index_type would make Params() disagree with IndexType(), so
+	// the reserved keys are ignored rather than honored.
+	idx := WithExtraIndexParams(NewHNSWIndex(entity.L2, 16, 200), map[string]string{
+		IndexTypeKey:  string(IvfFlat),
+		MetricTypeKey: string(entity.IP),
+		"refine_k":    "64",
+	})
+
+	result := idx.Params()
+	assert.EqualValues(t, HNSW, result[IndexTypeKey])
+	assert.EqualValues(t, HNSW, idx.IndexType())
+	assert.EqualValues(t, entity.L2, result[MetricTypeKey])
+	assert.Equal(t, "64", result["refine_k"])
 }

--- a/client/index/ivf.go
+++ b/client/index/ivf.go
@@ -26,8 +26,12 @@ const (
 	ivfRefineKey     = `refine`
 	ivfRefineTypeKey = `refine_type`
 
-	ivfRbqQueryBitsKey = `rbq_query_bits`
+	// knowhere's IvfRaBitQConfig declares the field as rbq_bits_query and
+	// KNOWHERE_CONFIG_DECLARE_FIELD stringifies the field name into the JSON
+	// key, so the transposed spelling reached no consumer.
+	ivfRbqQueryBitsKey = `rbq_bits_query`
 	ivfRbqRefineKKey   = `refine_k`
+	ivfRbqBitsKey      = `rbq_bits`
 )
 
 var _ Index = ivfFlatIndex{}
@@ -121,6 +125,8 @@ type ivfRabitQIndex struct {
 	baseIndex
 
 	nlist      int
+	rbqBits    int
+	rbqBitsSet bool
 	refine     bool
 	refineType string
 }
@@ -132,11 +138,24 @@ func (idx *ivfRabitQIndex) Params() map[string]string {
 		ivfNlistKey:   strconv.Itoa(idx.nlist),
 	}
 
+	// Forwarded as given once set, so an out-of-range value is rejected by the
+	// server rather than silently falling back to the default.
+	if idx.rbqBitsSet {
+		result[ivfRbqBitsKey] = strconv.Itoa(idx.rbqBits)
+	}
 	if idx.refine {
 		result[ivfRefineKey] = strconv.FormatBool(idx.refine)
 		result[ivfRefineTypeKey] = idx.refineType
 	}
 	return result
+}
+
+// WithRbqBits sets how many bits each dimension is quantized to at build time,
+// in [1, 9]. The server default is 1, applied when this is never called.
+func (idx *ivfRabitQIndex) WithRbqBits(rbqBits int) *ivfRabitQIndex {
+	idx.rbqBits = rbqBits
+	idx.rbqBitsSet = true
+	return idx
 }
 
 func (idx *ivfRabitQIndex) WithRefineType(refineType string) *ivfRabitQIndex {
@@ -149,7 +168,9 @@ func NewIvfRabitQIndex(metricType MetricType, nlist int) *ivfRabitQIndex {
 	return &ivfRabitQIndex{
 		baseIndex: baseIndex{
 			metricType: metricType,
-			indexType:  BinIvfFlat,
+			// Params() has always emitted IVF_RABITQ; indexType was left on
+			// BinIvfFlat, so IndexType() reported BIN_IVF_FLAT for a RaBitQ index.
+			indexType: IvfRabitQ,
 		},
 
 		nlist: nlist,

--- a/client/index/ivf_test.go
+++ b/client/index/ivf_test.go
@@ -53,8 +53,26 @@ func TestIvfRabitQAnnParam(t *testing.T) {
 	ap = ap.WithRabitQueryBits(8)
 	result = ap.Params()
 	assert.Equal(t, 8, result[ivfRbqQueryBitsKey])
+	// Pin the wire name: knowhere reads rbq_bits_query, and a transposed key
+	// silently leaves the search on the default instead of erroring.
+	assert.Equal(t, 8, result["rbq_bits_query"])
 
 	ap = ap.WithRefineK(256)
 	result = ap.Params()
 	assert.Equal(t, 256, result[ivfRbqRefineKKey])
+}
+
+func TestIvfRabitQBits(t *testing.T) {
+	idx := NewIvfRabitQIndex(entity.COSINE, 128)
+	// Params() has always reported IVF_RABITQ; IndexType() used to disagree.
+	assert.EqualValues(t, IvfRabitQ, idx.IndexType())
+	assert.EqualValues(t, IvfRabitQ, idx.Params()[IndexTypeKey])
+
+	// Never set: absent, so the server's default applies.
+	assert.NotContains(t, idx.Params(), ivfRbqBitsKey)
+	assert.Equal(t, "5", idx.WithRbqBits(5).Params()[ivfRbqBitsKey])
+
+	// Explicitly set to an out-of-range value: forwarded so the server rejects
+	// it, instead of being mistaken for "unset".
+	assert.Equal(t, "0", NewIvfRabitQIndex(entity.COSINE, 128).WithRbqBits(0).Params()[ivfRbqBitsKey])
 }

--- a/client/index/scalar.go
+++ b/client/index/scalar.go
@@ -16,9 +16,23 @@
 
 package index
 
+import "strconv"
+
+// Scalar index build param keys. The server rejects unknown or out-of-range
+// values, so these mirror the checkers in internal/util/indexparamcheck.
+const (
+	ngramMinGramKey = `min_gram`
+	ngramMaxGramKey = `max_gram`
+
+	fmIndexSaSampleRateKey = `fm_sa_sample_rate`
+	fmIndexBlockBytesKey   = `fm_block_bytes`
+)
+
 type scalarIndex struct {
 	name      string
 	indexType IndexType
+	// extra build params; nil for the index types that take none
+	params map[string]string
 }
 
 func (idx scalarIndex) Name() string {
@@ -30,9 +44,13 @@ func (idx scalarIndex) IndexType() IndexType {
 }
 
 func (idx scalarIndex) Params() map[string]string {
-	return map[string]string{
+	result := map[string]string{
 		IndexTypeKey: string(idx.indexType),
 	}
+	for k, v := range idx.params {
+		result[k] = v
+	}
+	return result
 }
 
 var _ Index = scalarIndex{}
@@ -58,5 +76,85 @@ func NewSortedIndex() Index {
 func NewBitmapIndex() Index {
 	return scalarIndex{
 		indexType: BITMAP,
+	}
+}
+
+// NewNgramIndex creates an NGRAM index for VARCHAR fields and JSON paths. By
+// indexing every n-gram in [minGram, maxGram] it accelerates the substring
+// operators — LIKE prefix / infix / suffix and regex match. TEXT_MATCH is a
+// different index (TextMatchIndex) and is not served by this one.
+// Both bounds are mandatory: the server rejects an NGRAM index that omits
+// either, so there is no default to fall back to.
+func NewNgramIndex(minGram, maxGram int) Index {
+	return scalarIndex{
+		indexType: NGRAM,
+		params: map[string]string{
+			ngramMinGramKey: strconv.Itoa(minGram),
+			ngramMaxGramKey: strconv.Itoa(maxGram),
+		},
+	}
+}
+
+var _ Index = &FMIndex{}
+
+// FMIndex is the pre-defined index model for the FM-index scalar index: an
+// exact byte-level substring index for VARCHAR that answers anchored LIKE
+// (prefix / infix / suffix) with no candidate recheck.
+//
+// Both build params are optional; leave them unset to take the server defaults.
+type FMIndex struct {
+	scalarIndex
+
+	// Recorded verbatim once a setter is called. Gating on a positive value
+	// instead would make an explicitly invalid argument indistinguishable from
+	// an omitted one, and quietly build with the default rather than letting
+	// the server reject it.
+	buildParams map[string]string
+}
+
+// WithIndexName setup the index name of FMIndex.
+func (idx *FMIndex) WithIndexName(name string) *FMIndex {
+	idx.name = name
+	return idx
+}
+
+// WithSaSampleRate sets the suffix-array sampling rate, trading index size
+// against locate latency (it does not affect count-only queries). Must be in
+// [4, 256]; the server default is 8.
+func (idx *FMIndex) WithSaSampleRate(rate int) *FMIndex {
+	idx.buildParams[fmIndexSaSampleRateKey] = strconv.Itoa(rate)
+	return idx
+}
+
+// WithBlockBytes sets the rank-directory block granularity in bytes. Must be a
+// power of two in [8, 128]; the server default is 64. Larger blocks shrink the
+// resident directory at no throughput cost up to ~64.
+func (idx *FMIndex) WithBlockBytes(blockBytes int) *FMIndex {
+	idx.buildParams[fmIndexBlockBytesKey] = strconv.Itoa(blockBytes)
+	return idx
+}
+
+// Params implements Index interface
+// returns the create index related parameters.
+func (idx *FMIndex) Params() map[string]string {
+	result := map[string]string{
+		IndexTypeKey: string(idx.indexType),
+	}
+	// A param the caller never set stays absent so the server applies its own
+	// default; one the caller did set is forwarded as given, valid or not, so
+	// the server's range check is what reports the mistake.
+	for k, v := range idx.buildParams {
+		result[k] = v
+	}
+	return result
+}
+
+// NewFMIndex creates an `FMIndex` with the server's default build params.
+func NewFMIndex() *FMIndex {
+	return &FMIndex{
+		scalarIndex: scalarIndex{
+			indexType: FMINDEX,
+		},
+		buildParams: make(map[string]string),
 	}
 }

--- a/client/index/scalar_test.go
+++ b/client/index/scalar_test.go
@@ -39,6 +39,8 @@ func (s *ScalarIndexSuite) TestConstructors() {
 		{tag: "Sorted", input: NewSortedIndex(), expectIndexType: Sorted},
 		{tag: "Inverted", input: NewInvertedIndex(), expectIndexType: Inverted},
 		{tag: "Bitmap", input: NewBitmapIndex(), expectIndexType: BITMAP},
+		{tag: "Ngram", input: NewNgramIndex(2, 3), expectIndexType: NGRAM},
+		{tag: "FMIndex", input: NewFMIndex(), expectIndexType: FMINDEX},
 	}
 
 	for _, tc := range testcases {
@@ -56,6 +58,36 @@ func (s *ScalarIndexSuite) TestConstructors() {
 			}
 		})
 	}
+}
+
+func (s *ScalarIndexSuite) TestNgramParams() {
+	// Both bounds are mandatory server-side, so they must always be emitted.
+	params := NewNgramIndex(2, 4).Params()
+	s.Equal("2", params[ngramMinGramKey])
+	s.Equal("4", params[ngramMaxGramKey])
+}
+
+func (s *ScalarIndexSuite) TestFMIndexInvalidValuesAreSentVerbatim() {
+	// An explicitly invalid argument must reach the server, which rejects it,
+	// rather than being swallowed and silently building with the default.
+	params := NewFMIndex().WithSaSampleRate(-1).WithBlockBytes(0).Params()
+	s.Equal("-1", params[fmIndexSaSampleRateKey])
+	s.Equal("0", params[fmIndexBlockBytesKey])
+}
+
+func (s *ScalarIndexSuite) TestFMIndexParams() {
+	// Unset build params must stay absent so the server applies its defaults
+	// instead of receiving a zero.
+	params := NewFMIndex().Params()
+	s.NotContains(params, fmIndexSaSampleRateKey)
+	s.NotContains(params, fmIndexBlockBytesKey)
+
+	idx := NewFMIndex().WithSaSampleRate(16).WithBlockBytes(32).WithIndexName("fm_idx")
+	params = idx.Params()
+	s.Equal("16", params[fmIndexSaSampleRateKey])
+	s.Equal("32", params[fmIndexBlockBytesKey])
+	s.EqualValues(FMINDEX, params[IndexTypeKey])
+	s.Equal("fm_idx", idx.Name())
 }
 
 func TestScalarIndexes(t *testing.T) {

--- a/client/index/sparse.go
+++ b/client/index/sparse.go
@@ -6,6 +6,11 @@ import (
 
 const (
 	dropRatio = `drop_ratio_build`
+
+	sparseDropRatioSearchKey  = `drop_ratio_search`
+	sparseSearchAlgoKey       = `search_algo`
+	sparseRefineFactorKey     = `refine_factor`
+	sparseDimMaxScoreRatioKey = `dim_max_score_ratio`
 )
 
 var _ Index = sparseInvertedIndex{}
@@ -75,5 +80,26 @@ func NewSparseAnnParam() sparseAnnParam {
 }
 
 func (b sparseAnnParam) WithDropRatio(dropRatio float64) {
-	b.WithExtraParam("drop_ratio_search", dropRatio)
+	b.WithExtraParam(sparseDropRatioSearchKey, dropRatio)
+}
+
+// WithSearchAlgo overrides the traversal algorithm for this search. Defaults to
+// "INHERIT", i.e. whatever the index was built with.
+func (b sparseAnnParam) WithSearchAlgo(algo string) sparseAnnParam {
+	b.WithExtraParam(sparseSearchAlgoKey, algo)
+	return b
+}
+
+// WithRefineFactor sets how many extra candidates are gathered before refining
+// against the full values. Server default 1.
+func (b sparseAnnParam) WithRefineFactor(refineFactor int) sparseAnnParam {
+	b.WithExtraParam(sparseRefineFactorKey, refineFactor)
+	return b
+}
+
+// WithDimMaxScoreRatio tunes the block-max pruning threshold. Server default
+// 1.05.
+func (b sparseAnnParam) WithDimMaxScoreRatio(ratio float64) sparseAnnParam {
+	b.WithExtraParam(sparseDimMaxScoreRatioKey, ratio)
+	return b
 }

--- a/client/milvusclient/index_test.go
+++ b/client/milvusclient/index_test.go
@@ -151,15 +151,17 @@ func (s *IndexSuite) TestDescribeIndex() {
 				Status: merr.Success(),
 				IndexDescriptions: []*milvuspb.IndexDescription{
 					{IndexName: indexName, Params: []*commonpb.KeyValuePair{
-						{Key: index.IndexTypeKey, Value: string(index.HNSW)},
+						{Key: index.IndexTypeKey, Value: string(index.FMINDEX)},
 					}},
 				},
 			}, nil
 		}).Once()
 
-		index, err := s.client.DescribeIndex(ctx, NewDescribeIndexOption(collectionName, indexName))
+		indexDesc, err := s.client.DescribeIndex(ctx, NewDescribeIndexOption(collectionName, indexName))
 		s.NoError(err)
-		s.Equal(indexName, index.Name())
+		s.Equal(indexName, indexDesc.Name())
+		s.EqualValues(index.FMINDEX, indexDesc.IndexType())
+		s.EqualValues(index.FMINDEX, indexDesc.Params()[index.IndexTypeKey])
 	})
 
 	s.Run("no_index_found", func() {

--- a/client/milvusclient/interceptors.go
+++ b/client/milvusclient/interceptors.go
@@ -18,6 +18,8 @@ package milvusclient
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"strconv"
 	"time"
 
@@ -40,7 +42,90 @@ const (
 
 	// ClientRequestMsecKey temp const value, TODO use common package def after upgrading milvus/pkg version
 	ClientRequestMsecKey string = "client-request-unixmsec"
+
+	// ClientRequestIDKey carries a caller-supplied ID used to correlate a request with the
+	// server-side logs it produces. The server parses it as an OpenTelemetry TraceID and
+	// adopts it as the trace ID for the request, but only when no W3C `traceparent` was
+	// propagated. See pkg/tracer/client_request_id_propagator.go.
+	//
+	// The value MUST be a 32-character lowercase hex string (a 16-byte OTel TraceID);
+	// anything else is ignored by the server.
+	ClientRequestIDKey string = "client_request_id"
+
+	// traceIDHexLen is the encoded length of a 16-byte OpenTelemetry TraceID.
+	traceIDHexLen = 32
 )
+
+// clientRequestIDKeyType is the context key used to carry a caller-supplied request ID.
+type clientRequestIDKeyType struct{}
+
+// WithClientRequestID returns a context that makes the SDK send `id` as the
+// client_request_id header on every request issued with it. The server adopts `id` as the
+// trace ID for those requests, so it shows up in Milvus server logs and can be used to
+// find everything a specific client call did -- the same mechanism pymilvus exposes via
+// CallContext(client_request_id=...).
+//
+// `id` must be a 32-character lowercase hex OpenTelemetry TraceID (as produced by
+// trace.TraceID.String()); NewClientRequestID generates a conforming one. An invalid value
+// is dropped rather than sent, because the server would silently ignore it anyway.
+//
+// This is opt-in by design, because the SDK cannot assume what the server does with the
+// header. Servers that predate the clientRequestIDSampler fix turn it into an unsampled
+// remote parent, which their ParentBased sampler maps to NeverSample -- so on those, a
+// request carrying this header is excluded from tracing entirely, whatever
+// trace.sampleFraction says. Fixed servers sample it as a root span, so the ratio applies
+// normally. Sending it unconditionally would therefore silently disable tracing against
+// any older cluster.
+//
+// Either way this is for log correlation, not a substitute for W3C traceparent
+// propagation: it carries no sampling decision and no parent span.
+func WithClientRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, clientRequestIDKeyType{}, id)
+}
+
+// NewClientRequestID returns a random, well-formed ID suitable for WithClientRequestID.
+// It returns "" if the system entropy source fails.
+func NewClientRequestID() string {
+	return newClientRequestID()
+}
+
+// isValidTraceIDHex reports whether s is a well-formed, non-zero 32-char hex TraceID.
+// It mirrors trace.TraceIDFromHex on the server so an invalid value is never put on the
+// wire, where it would be silently dropped anyway.
+func isValidTraceIDHex(s string) bool {
+	if len(s) != traceIDHexLen {
+		return false
+	}
+	nonZero := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+		case ch >= 'a' && ch <= 'f':
+		default:
+			return false
+		}
+		if ch != '0' {
+			nonZero = true
+		}
+	}
+	return nonZero
+}
+
+// newClientRequestID returns a random 32-char hex TraceID, or "" if the system entropy
+// source fails (in which case the header is simply omitted).
+func newClientRequestID() string {
+	var buf [traceIDHexLen / 2]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return ""
+	}
+	id := hex.EncodeToString(buf[:])
+	if !isValidTraceIDHex(id) {
+		// All-zero read: not a valid TraceID for the server.
+		return ""
+	}
+	return id
+}
 
 // withClientMetadata applies the client's metadata enrichment (static headers,
 // connection state, and per-request extras) to an outgoing context. It is shared
@@ -91,7 +176,21 @@ func (c *Client) state(ctx context.Context) context.Context {
 
 func (c *Client) extraInfo(ctx context.Context) context.Context {
 	ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestMsecKey, strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if requestID := clientRequestIDFromContext(ctx); requestID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestIDKey, requestID)
+	}
 	return ctx
+}
+
+// clientRequestIDFromContext returns the caller-supplied request ID, or "" when none was
+// set or it is malformed. Nothing is generated here: sending an ID the caller did not ask
+// for would opt every request out of server-side trace sampling (see WithClientRequestID).
+func clientRequestIDFromContext(ctx context.Context) string {
+	id, ok := ctx.Value(clientRequestIDKeyType{}).(string)
+	if !ok || !isValidTraceIDHex(id) {
+		return ""
+	}
+	return id
 }
 
 // ref: https://github.com/grpc-ecosystem/go-grpc-middleware

--- a/client/milvusclient/interceptors_test.go
+++ b/client/milvusclient/interceptors_test.go
@@ -69,6 +69,95 @@ func TestRateLimitInterceptor(t *testing.T) {
 	assert.Equal(t, uint(1), uint(mockInvokeTimes))
 }
 
+func TestIsValidTraceIDHex(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid", "4bf92f3577b34da6a3ce929d0e0e4736", true},
+		{"all zero", "00000000000000000000000000000000", false},
+		{"too short", "4bf92f3577b34da6a3ce929d0e0e473", false},
+		{"too long", "4bf92f3577b34da6a3ce929d0e0e47366", false},
+		{"empty", "", false},
+		{"uppercase rejected", "4BF92F3577B34DA6A3CE929D0E0E4736", false},
+		{"non hex", "4bf92f3577b34da6a3ce929d0e0e473g", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isValidTraceIDHex(tc.input))
+		})
+	}
+}
+
+func TestNewClientRequestID(t *testing.T) {
+	id := newClientRequestID()
+	assert.Len(t, id, traceIDHexLen)
+	assert.True(t, isValidTraceIDHex(id), "generated id must be parseable by the server")
+
+	// IDs must differ per call, otherwise every request collapses onto one trace.
+	assert.NotEqual(t, id, newClientRequestID())
+}
+
+func TestClientRequestIDFromContext(t *testing.T) {
+	t.Run("caller supplied id wins", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+		assert.Equal(t, want, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("malformed id is dropped", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "not-a-trace-id")
+		assert.Empty(t, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("no id yields empty", func(t *testing.T) {
+		assert.Empty(t, clientRequestIDFromContext(context.Background()))
+	})
+}
+
+func TestExtraInfoInjectsClientRequestID(t *testing.T) {
+	c := &Client{}
+
+	// The header is opt-in: sending it unrequested would opt the request out of
+	// server-side trace sampling, since the server maps it to an unsampled remote parent.
+	t.Run("absent unless requested", func(t *testing.T) {
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(context.Background()))
+		assert.True(t, ok)
+
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+		// The timestamp header is unconditional and must still be present.
+		assert.Len(t, md.Get(ClientRequestMsecKey), 1)
+	})
+
+	t.Run("propagates caller supplied id", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{want}, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("malformed id is not sent", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "bogus")
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("NewClientRequestID round trips", func(t *testing.T) {
+		id := NewClientRequestID()
+		ctx := WithClientRequestID(context.Background(), id)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{id}, md.Get(ClientRequestIDKey))
+	})
+}
+
 func TestMetadataStreamInterceptor(t *testing.T) {
 	c := &Client{
 		metadataHeaders: map[string]string{

--- a/client/milvusclient/read_example_test.go
+++ b/client/milvusclient/read_example_test.go
@@ -523,19 +523,29 @@ func ExampleClient_Search_textMatch() {
 	q := "artificial intelligence"
 	expr := "text_match(" + titleField + ", \"" + q + "\", minimum_should_match=2) OR text_match(" + textField + ", \"" + q + "\", minimum_should_match=2)"
 
-	boost := entity.NewFunction().
+	titleBoost := entity.NewFunction().
 		WithName("title_boost").
 		WithType(entity.FunctionTypeRerank).
 		WithParam("reranker", "boost").
 		WithParam("filter", "text_match("+titleField+", \""+q+"\", minimum_should_match=2)").
 		WithParam("weight", "2.0")
+	textBoost := entity.NewFunction().
+		WithName("text_boost").
+		WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", "1.5")
+	functionScore := entity.NewFunctionScore().
+		AddFunction(titleBoost).
+		AddFunction(textBoost).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
 
 	vectors := []entity.Vector{entity.Text(q)}
 	rs, err := cli.Search(ctx, milvusclient.NewSearchOption(collectionName, 5, vectors).
 		WithANNSField(textSparse).
 		WithFilter(expr).
 		WithOutputFields("id", titleField, textField).
-		WithFunctionReranker(boost))
+		WithFunctionScore(functionScore))
 	if err != nil {
 		log.Fatal("failed to search: ", err.Error())
 	}

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -90,6 +90,148 @@ func (s *SearchOptionSuite) TestBasic() {
 	s.Error(err)
 }
 
+func (s *SearchOptionSuite) TestFunctionScore() {
+	collName := "search_opt_function_score"
+	topK := 10
+
+	boostFn1 := entity.NewFunction().WithName("boost1").WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 2.0).
+		WithParam("filter", "int64_field > 0")
+	boostFn2 := entity.NewFunction().WithName("boost2").WithType(entity.FunctionTypeRerank).
+		WithParam("reranker", "boost").
+		WithParam("weight", 0.5)
+
+	score := entity.NewFunctionScore().
+		AddFunction(boostFn1).
+		AddFunction(boostFn2).
+		WithParam("boost_mode", "sum").
+		WithParam("function_mode", "multiply")
+
+	s.Run("search", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(score).
+			Request()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Equal(map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, entity.KvPairsMap(fs.GetParams()))
+		s.Equal("boost", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["reranker"])
+		s.Equal("2", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["weight"])
+		s.Equal("int64_field > 0", entity.KvPairsMap(fs.GetFunctions()[0].GetParams())["filter"])
+	})
+
+	s.Run("search_with_function_reranker_appends", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionReranker(boostFn1).
+			WithFunctionReranker(boostFn2).
+			Request()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Empty(fs.GetParams())
+	})
+
+	s.Run("hybrid_search", func() {
+		req, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(score).
+			HybridRequest()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Equal(map[string]string{"boost_mode": "sum", "function_mode": "multiply"}, entity.KvPairsMap(fs.GetParams()))
+	})
+
+	s.Run("hybrid_search_with_function_rerankers_appends", func() {
+		req, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionRerankers(boostFn1).
+			WithFunctionRerankers(boostFn2).
+			HybridRequest()
+		s.Require().NoError(err)
+
+		fs := req.GetFunctionScore()
+		s.Require().NotNil(fs)
+		s.Len(fs.GetFunctions(), 2)
+		s.Empty(fs.GetParams())
+	})
+
+	s.Run("no_function_score", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			Request()
+		s.Require().NoError(err)
+		s.Nil(req.GetFunctionScore())
+	})
+
+	s.Run("shared_score_not_aliased", func() {
+		shared := entity.NewFunctionScore().
+			AddFunction(boostFn1).
+			WithParam("boost_mode", "sum")
+
+		optA := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(shared)
+		optB := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(shared)
+
+		// mutating the shared score after building options must not leak into them
+		shared.AddFunction(boostFn2)
+		shared.WithParam("function_mode", "multiply")
+
+		reqA, err := optA.Request()
+		s.Require().NoError(err)
+		fsA := reqA.GetFunctionScore()
+		s.Len(fsA.GetFunctions(), 1, "options must not accumulate functions from a shared score")
+		s.Equal(map[string]string{"boost_mode": "sum"}, entity.KvPairsMap(fsA.GetParams()))
+
+		reqB, err := optB.Request()
+		s.Require().NoError(err)
+		s.Len(reqB.GetFunctionScore().GetFunctions(), 1)
+	})
+
+	s.Run("empty_score_errors", func() {
+		empty := entity.NewFunctionScore().WithParam("boost_mode", "sum")
+
+		_, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionScore(empty).
+			Request()
+		s.Error(err)
+		s.Contains(err.Error(), "no functions")
+
+		_, err = NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(empty).
+			HybridRequest()
+		s.Error(err)
+		s.Contains(err.Error(), "no functions")
+	})
+
+	s.Run("nil_score_noop", func() {
+		req, err := NewSearchOption(collName, topK, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithANNSField("vector").
+			WithFunctionReranker(boostFn1).
+			WithFunctionScore(nil).
+			Request()
+		s.Require().NoError(err)
+		s.Nil(req.GetFunctionScore(), "nil score must clear any accumulated functions")
+
+		hybridReq, err := NewHybridSearchOption(collName, topK, NewAnnRequest("vector", topK, entity.FloatVector([]float32{0.1, 0.2}))).
+			WithFunctionScore(nil).
+			HybridRequest()
+		s.Require().NoError(err)
+		s.Nil(hybridReq.GetFunctionScore())
+	})
+}
+
 func (s *SearchOptionSuite) TestWithNamespace() {
 	collName := "namespace_read_option"
 	namespace := "tenant_a"

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -84,7 +84,7 @@ type AnnRequest struct {
 	offset          int
 	templateParams  map[string]any
 
-	functionRerankers []*entity.Function
+	functionScore *entity.FunctionScore
 }
 
 func NewAnnRequest(annField string, limit int, vectors ...entity.Vector) *AnnRequest {
@@ -173,11 +173,11 @@ func (r *AnnRequest) searchRequest() (*milvuspb.SearchRequest, error) {
 		request.ExprTemplateValues[key] = tmplVal
 	}
 
-	if len(r.functionRerankers) > 0 {
-		request.FunctionScore = &schemapb.FunctionScore{}
-		for _, fr := range r.functionRerankers {
-			request.FunctionScore.Functions = append(request.FunctionScore.Functions, fr.ProtoMessage())
+	if r.functionScore != nil {
+		if len(r.functionScore.Functions) == 0 {
+			return nil, errors.New("FunctionScore has no functions")
 		}
+		request.FunctionScore = r.functionScore.ProtoMessage()
 	}
 
 	return request, nil
@@ -337,8 +337,30 @@ func (r *AnnRequest) WithIgnoreGrowing(ignoreGrowing bool) *AnnRequest {
 	return r
 }
 
+// WithFunctionReranker adds a scoring Function to the request. On a hybrid
+// search the score is attached to this sub-request and applied to this leg on
+// the server (server support for per-sub-request FunctionScore is in flight,
+// see https://github.com/milvus-io/milvus/issues/52956); to apply the same
+// score to every leg today, use HybridSearchOption.WithFunctionRerankers or
+// HybridSearchOption.WithFunctionScore instead.
 func (r *AnnRequest) WithFunctionReranker(fr *entity.Function) *AnnRequest {
-	r.functionRerankers = append(r.functionRerankers, fr)
+	if r.functionScore == nil {
+		r.functionScore = entity.NewFunctionScore()
+	}
+	r.functionScore.AddFunction(fr)
+	return r
+}
+
+// WithFunctionScore sets the search FunctionScore (functions plus score
+// options such as boost_mode / function_mode). It replaces any functions
+// accumulated via WithFunctionReranker, and stores a copy so the caller's
+// FunctionScore is never mutated or shared with other options.
+func (r *AnnRequest) WithFunctionScore(fs *entity.FunctionScore) *AnnRequest {
+	if fs == nil {
+		r.functionScore = nil
+		return r
+	}
+	r.functionScore = fs.Clone()
 	return r
 }
 
@@ -461,6 +483,11 @@ func (opt *searchOption) WithFunctionReranker(fr *entity.Function) *searchOption
 	return opt
 }
 
+func (opt *searchOption) WithFunctionScore(fs *entity.FunctionScore) *searchOption {
+	opt.annRequest.WithFunctionScore(fs)
+	return opt
+}
+
 // NewSearchOption creates a new search option for traditional vector search.
 // Provide the query vectors to search for similar vectors in the collection.
 // For search by primary key IDs, use NewSearchByIDsOption instead.
@@ -556,10 +583,10 @@ type hybridSearchOption struct {
 	useDefaultConsistency bool
 	consistencyLevel      entity.ConsistencyLevel
 
-	limit             int
-	offset            int
-	reranker          Reranker
-	functionRerankers []*entity.Function
+	limit         int
+	offset        int
+	reranker      Reranker
+	functionScore *entity.FunctionScore
 }
 
 func (opt *hybridSearchOption) WithConsistencyLevel(cl entity.ConsistencyLevel) *hybridSearchOption {
@@ -593,8 +620,28 @@ func (opt *hybridSearchOption) WithReranker(reranker Reranker) *hybridSearchOpti
 	return opt
 }
 
+// WithFunctionRerankers adds a scoring Function applied to every leg of the
+// hybrid search on the server. For per-sub-request scores (server support in
+// flight, see https://github.com/milvus-io/milvus/issues/52956), attach the
+// Function to the sub-request's AnnRequest instead.
 func (opt *hybridSearchOption) WithFunctionRerankers(functionReranker *entity.Function) *hybridSearchOption {
-	opt.functionRerankers = append(opt.functionRerankers, functionReranker)
+	if opt.functionScore == nil {
+		opt.functionScore = entity.NewFunctionScore()
+	}
+	opt.functionScore.AddFunction(functionReranker)
+	return opt
+}
+
+// WithFunctionScore sets the search FunctionScore (functions plus score
+// options such as boost_mode / function_mode). It replaces any functions
+// accumulated via WithFunctionRerankers, and stores a copy so the caller's
+// FunctionScore is never mutated or shared with other options.
+func (opt *hybridSearchOption) WithFunctionScore(fs *entity.FunctionScore) *hybridSearchOption {
+	if fs == nil {
+		opt.functionScore = nil
+		return opt
+	}
+	opt.functionScore = fs.Clone()
 	return opt
 }
 
@@ -633,11 +680,11 @@ func (opt *hybridSearchOption) HybridRequest() (*milvuspb.HybridSearchRequest, e
 		RankParams:            params,
 	}
 
-	if len(opt.functionRerankers) > 0 {
-		r.FunctionScore = &schemapb.FunctionScore{}
-		for _, fr := range opt.functionRerankers {
-			r.FunctionScore.Functions = append(r.FunctionScore.Functions, fr.ProtoMessage())
+	if opt.functionScore != nil {
+		if len(opt.functionScore.Functions) == 0 {
+			return nil, errors.New("FunctionScore has no functions")
 		}
+		r.FunctionScore = opt.functionScore.ProtoMessage()
 	}
 
 	return r, nil

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -21,13 +21,18 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -35,25 +40,50 @@ import (
 	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
 
+const (
+	telemetryHistoryRetention    = time.Hour
+	maxTelemetryHistorySnapshots = 4096
+	// Retain a small quantile sketch per operation/window for mathematically valid
+	// history percentiles. At the one-hour hard snapshot cap this stays in the same
+	// memory range as the C++ implementation while preserving sub-percentile detail.
+	telemetryHistorySamplesPerWindow = 128
+)
+
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
-	// Enabled controls whether telemetry collection is active
+	// Enabled controls telemetry at connection startup. An initial false value is an
+	// explicit opt-out and starts no heartbeat. When an already-running client is
+	// dynamically disabled by the server, operation collection and metric payloads
+	// stop while the command heartbeat stays active for ACKs and later re-enable.
 	Enabled bool
-	// HeartbeatInterval is how often to send heartbeats to server (default: 30 seconds)
-	// Snapshot period aligns with heartbeat interval
+	// HeartbeatInterval is how often to send heartbeats to server (default: 10 seconds).
+	//
+	// It is also the metrics window: each heartbeat carries the operations since the last
+	// one. The coordinator answers a telemetry query from the window before the newest, so
+	// what a caller reads is between one and two intervals old -- ten to twenty seconds at
+	// the default. Raising it cuts the coordinator's heartbeat load, which scales with the
+	// number of connected clients rather than with traffic, at the cost of that staleness.
 	HeartbeatInterval time.Duration
 	// SamplingRate is the sampling rate for all operations (0.0-1.0, default: 1.0 = 100%)
 	// Can be dynamically adjusted
 	SamplingRate float64
 	// ErrorMaxCount is the maximum number of errors to keep
 	ErrorMaxCount int
+	// ClientID identifies this client to the server across process restarts.
+	//
+	// When empty, a random UUID is generated per Client, which means the server sees a
+	// brand-new client on every restart: telemetry history fragments and `client:<id>`
+	// scoped commands cannot target a long-lived client. Set it to a stable value (e.g.
+	// a pod name, or hostname+role) to get continuity. It must be unique per process --
+	// reusing one value across processes collapses them into a single server-side entry.
+	ClientID string
 }
 
 // DefaultTelemetryConfig returns the default telemetry configuration
 func DefaultTelemetryConfig() *TelemetryConfig {
 	return &TelemetryConfig{
 		Enabled:           true,
-		HeartbeatInterval: 30 * time.Second,
+		HeartbeatInterval: 10 * time.Second,
 		SamplingRate:      1.0, // 100% sampling by default
 		ErrorMaxCount:     100,
 	}
@@ -261,11 +291,20 @@ func (c *OperationMetricsCollector) Record(collection string, latencyUs int64, s
 // IMPORTANT: P99 is calculated here atomically before clearing the sample buffer
 // This prevents the race condition where sendHeartbeat could calculate P99 from a cleared buffer
 func (c *OperationMetricsCollector) GetMetrics() *Metrics {
+	metrics, _ := c.getMetricsAndHistorySamples()
+	return metrics
+}
+
+// getMetricsAndHistorySamples atomically snapshots both the public interval metrics and
+// a bounded internal latency sketch before resetting the collector. A percentile cannot
+// be combined from per-window percentiles, so history aggregation needs samples from the
+// underlying distributions rather than a weighted average of their P99 values.
+func (c *OperationMetricsCollector) getMetricsAndHistorySamples() (*Metrics, []int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	if c.requestCount == 0 {
-		return nil
+		return nil, nil
 	}
 
 	avgLatency := float64(c.totalLatency) / float64(c.requestCount) / 1000.0
@@ -282,6 +321,10 @@ func (c *OperationMetricsCollector) GetMetrics() *Metrics {
 		P99LatencyMs: p99Latency,
 		MaxLatencyMs: maxLatency,
 	}
+	historySamples := retainHistoryLatencySamples(
+		copyValidLatencySamples(c.latencySamples, c.totalSamples, c.bufferSize),
+		telemetryHistorySamplesPerWindow,
+	)
 
 	// Reset counters for next period
 	c.requestCount = 0
@@ -292,7 +335,7 @@ func (c *OperationMetricsCollector) GetMetrics() *Metrics {
 	c.sampleIndex = 0
 	c.totalSamples = 0
 
-	return metrics
+	return metrics, historySamples
 }
 
 // GetMetricsSnapshot returns current metrics WITHOUT resetting counters
@@ -378,6 +421,43 @@ func calculateP99FromSamples(samples []int64, totalSamples int64, bufferSize int
 	return float64(sorted[index])
 }
 
+func copyValidLatencySamples(samples []int64, totalSamples int64, bufferSize int) []int64 {
+	if totalSamples <= 0 || bufferSize <= 0 {
+		return nil
+	}
+	count := min(bufferSize, len(samples))
+	if totalSamples < int64(count) {
+		count = int(totalSamples)
+	}
+	result := make([]int64, count)
+	// Ring order is irrelevant because the history sketch is sorted below.
+	copy(result, samples[:count])
+	return result
+}
+
+// retainHistoryLatencySamples turns the collector's recent ring into an evenly spaced
+// quantile sketch. Including both endpoints is important for tail percentiles, while the
+// fixed cap prevents one-hour history from retaining 1000 samples for every operation in
+// every heartbeat window.
+func retainHistoryLatencySamples(samples []int64, limit int) []int64 {
+	if len(samples) == 0 || limit <= 0 {
+		return nil
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	if len(samples) <= limit {
+		return samples
+	}
+	if limit == 1 {
+		return []int64{samples[len(samples)-1]}
+	}
+	retained := make([]int64, limit)
+	for index := range retained {
+		source := index * (len(samples) - 1) / (limit - 1)
+		retained[index] = samples[source]
+	}
+	return retained
+}
+
 // GetP99Latency calculates P99 latency from current samples (in milliseconds)
 // Used primarily for testing; in production, P99 is computed in GetMetrics() during snapshot creation
 func (c *OperationMetricsCollector) GetP99Latency() float64 {
@@ -431,8 +511,14 @@ type ClientTelemetryManager struct {
 	configMu sync.RWMutex // Protects config access
 	client   *Client
 
-	// Unique client ID (UUID), generated once at startup, stable across reconnections
+	// Unique client ID, resolved once at construction. Stable for the lifetime of this
+	// Client (and therefore across gRPC reconnects). It only survives a process restart
+	// when the caller pins it via TelemetryConfig.ClientID; otherwise it is a fresh UUID.
 	clientID string
+
+	// clientIDStable records whether clientID came from TelemetryConfig.ClientID (and so
+	// survives a restart) rather than being generated for this process.
+	clientIDStable bool
 
 	// Metrics collectors per operation
 	mu         sync.RWMutex
@@ -476,8 +562,29 @@ type ClientTelemetryManager struct {
 	// Startup state - indicates if telemetry manager has started
 	ready atomic.Bool
 
-	// Deterministic sampling counter
-	samplingCounter uint64
+	// unsupportedStreak counts consecutive heartbeats rejected with codes.Unimplemented.
+	// It backs off the heartbeat interval instead of latching telemetry off: a client
+	// load-balances across proxies, so during a rolling upgrade a single heartbeat can
+	// land on an old one while the rest of the cluster already supports the service.
+	// Disabling permanently on one such answer would never recover. Reset by any
+	// successful heartbeat.
+	unsupportedStreak atomic.Int64
+
+	// lastHeartbeatErr records the most recent heartbeat failure. The client module has
+	// no logger, so this is the only way to surface an otherwise silent best-effort
+	// failure; read it with LastHeartbeatError().
+	lastHeartbeatErr   error
+	lastHeartbeatErrMu sync.RWMutex
+
+	// lastSnapshotEnd is the end of the most recent snapshot window, in Unix milliseconds,
+	// so the next one can start where it left off instead of assuming the configured
+	// interval elapsed. Zero until the first snapshot.
+	lastSnapshotEnd atomic.Int64
+
+	// samplingAccum carries the fractional sampling rate between calls, in samplingScale
+	// units: each operation adds the rate and the one that pushes it past a whole unit is
+	// the one sampled. See shouldSample.
+	samplingAccum uint64
 }
 
 // CommandHandler handles a specific command type from the server
@@ -488,6 +595,11 @@ type MetricsSnapshot struct {
 	Timestamp int64               // Unix timestamp in milliseconds (start of snapshot period)
 	EndTime   int64               // Unix timestamp in milliseconds (end of snapshot period)
 	Metrics   []*OperationMetrics // Metrics for all operations
+
+	// historyLatencySamples is an internal per-operation quantile sketch in microseconds.
+	// It is deliberately absent from heartbeat/detail payloads and exists only so a history
+	// query can calculate the percentile of the combined distribution.
+	historyLatencySamples map[string][]int64
 }
 
 // NewClientTelemetryManager creates a new client telemetry manager
@@ -496,10 +608,19 @@ func NewClientTelemetryManager(client *Client, config *TelemetryConfig) *ClientT
 		config = DefaultTelemetryConfig()
 	}
 
+	// Prefer a caller-supplied stable ID so the server can correlate this client across
+	// process restarts; fall back to a per-process UUID.
+	clientID := config.ClientID
+	clientIDStable := clientID != ""
+	if clientID == "" {
+		clientID = uuid.New().String()
+	}
+
 	tm := &ClientTelemetryManager{
 		config:             config,
 		client:             client,
-		clientID:           uuid.New().String(),
+		clientID:           clientID,
+		clientIDStable:     clientIDStable,
 		collectors:         make(map[string]*OperationMetricsCollector),
 		commandHandlers:    make(map[string]CommandHandler),
 		executedCommands:   make(map[string]int64),
@@ -527,7 +648,8 @@ func (m *ClientTelemetryManager) Start() {
 	// Mark as ready immediately - no blocking initial heartbeat
 	m.ready.Store(true)
 
-	// Start background heartbeat loop (snapshot creation is done inside heartbeatLoop)
+	// The heartbeat is also the command control plane. Keep it running while metrics
+	// are disabled so the server receives ACKs and can later re-enable collection.
 	m.wg.Add(1)
 	go m.heartbeatLoop()
 }
@@ -545,7 +667,12 @@ func (m *ClientTelemetryManager) buildClientInfo() *commonpb.ClientInfo {
 		LocalTime:  time.Now().String(),
 		Host:       hostname,
 		Reserved: map[string]string{
-			"client_id": m.clientID, // Always send stable UUID to prevent ID collisions
+			"client_id": m.clientID,
+			// Tell the server whether this ID survives a restart. It only does when the
+			// caller pinned it via TelemetryConfig.ClientID; a generated UUID does not.
+			// The server needs this to decide whether a client-scoped persistent config
+			// would keep matching.
+			"client_id_stable": strconv.FormatBool(m.clientIDStable),
 		},
 	}
 	if m.client != nil {
@@ -581,7 +708,7 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 	// Use time.After instead of ticker to dynamically adapt to interval changes
 	// This allows server-pushed config to take effect immediately
 	for {
-		interval := m.getHeartbeatInterval()
+		interval := m.nextHeartbeatDelay()
 		select {
 		case <-m.stopCh:
 			return
@@ -592,54 +719,82 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 	}
 }
 
+// maxUnsupportedBackoff caps the heartbeat interval while the server keeps answering
+// Unimplemented. Large enough that talking to an old cluster costs almost nothing, small
+// enough that a client notices an upgrade without being restarted.
+const maxUnsupportedBackoff = 30 * time.Minute
+
+// nextHeartbeatDelay returns how long to wait before the next heartbeat: the configured
+// interval normally, backed off while the server keeps reporting Unimplemented.
+//
+// The backoff doubles per consecutive rejection and is capped, so a client against a
+// server without the service settles at one probe per maxUnsupportedBackoff rather than
+// one per interval -- and still recovers on its own once the server gains the service.
+func (m *ClientTelemetryManager) nextHeartbeatDelay() time.Duration {
+	interval := m.getHeartbeatInterval()
+
+	streak := m.unsupportedStreak.Load()
+	if streak <= 0 {
+		return interval
+	}
+
+	backoff := interval
+	for i := int64(0); i < streak && backoff < maxUnsupportedBackoff; i++ {
+		backoff *= 2
+	}
+	if backoff > maxUnsupportedBackoff {
+		backoff = maxUnsupportedBackoff
+	}
+	if backoff < interval {
+		// A client configured to heartbeat less often than the cap must not start
+		// heartbeating *more* often because the server is rejecting it.
+		return interval
+	}
+	return backoff
+}
+
+// IsSupported reports whether the server is currently known *not* to implement
+// ClientTelemetryService. It is optimistic: it returns true before the first heartbeat has
+// been sent, because nothing is known yet, so true means "no evidence of an old server"
+// rather than "confirmed supported". Use LastHeartbeatError to tell those apart.
+//
+// It goes false while the server answers codes.Unimplemented and returns true again on the
+// first reply, so it reflects current reachability rather than a permanent verdict -- a
+// client may be load-balanced across proxies that differ mid upgrade.
+func (m *ClientTelemetryManager) IsSupported() bool {
+	return m.unsupportedStreak.Load() == 0
+}
+
+// LastHeartbeatError returns the most recent heartbeat failure, or nil if the last
+// heartbeat succeeded. Heartbeats are best-effort and never surfaced through the normal
+// API, so this is the supported way to diagnose a client that is not reporting.
+func (m *ClientTelemetryManager) LastHeartbeatError() error {
+	m.lastHeartbeatErrMu.RLock()
+	defer m.lastHeartbeatErrMu.RUnlock()
+	return m.lastHeartbeatErr
+}
+
+func (m *ClientTelemetryManager) setLastHeartbeatError(err error) {
+	m.lastHeartbeatErrMu.Lock()
+	defer m.lastHeartbeatErrMu.Unlock()
+	m.lastHeartbeatErr = err
+}
+
 // sendHeartbeat sends a heartbeat to the server
 func (m *ClientTelemetryManager) sendHeartbeat() {
 	m.configMu.RLock()
 	enabled := m.config.Enabled
 	m.configMu.RUnlock()
 
-	if !enabled {
-		return
-	}
-
-	if m.client == nil || m.client.service == nil {
+	if m.client == nil || m.client.telemetryService == nil {
 		return
 	}
 
 	// Get metrics from the latest snapshot (P99 already calculated during snapshot creation)
 	var metrics []*commonpb.OperationMetrics
-	latestSnapshot := m.GetLatestSnapshot()
-	if latestSnapshot != nil {
-		enabledCollections, allEnabled := m.snapshotEnabledCollections()
-
-		// Convert snapshot metrics to proto format
-		for _, opMetrics := range latestSnapshot.Metrics {
-			protoCollMetrics := make(map[string]*commonpb.Metrics)
-			// Only include metrics for enabled collections
-			// Use "*" wildcard to enable all collections
-			for coll, cm := range opMetrics.CollectionMetrics {
-				if allEnabled || enabledCollections[coll] {
-					protoCollMetrics[coll] = &commonpb.Metrics{
-						RequestCount: cm.RequestCount,
-						SuccessCount: cm.SuccessCount,
-						ErrorCount:   cm.ErrorCount,
-						AvgLatencyMs: cm.AvgLatencyMs,
-						P99LatencyMs: cm.P99LatencyMs,
-					}
-				}
-			}
-
-			metrics = append(metrics, &commonpb.OperationMetrics{
-				Operation: opMetrics.Operation,
-				Global: &commonpb.Metrics{
-					RequestCount: opMetrics.Global.RequestCount,
-					SuccessCount: opMetrics.Global.SuccessCount,
-					ErrorCount:   opMetrics.Global.ErrorCount,
-					AvgLatencyMs: opMetrics.Global.AvgLatencyMs,
-					P99LatencyMs: opMetrics.Global.P99LatencyMs, // Use P99 from snapshot
-				},
-				CollectionMetrics: protoCollMetrics,
-			})
+	if enabled {
+		if latestSnapshot := m.GetLatestSnapshot(); latestSnapshot != nil {
+			metrics = m.toProtoOperationMetrics(latestSnapshot.Metrics)
 		}
 	}
 
@@ -662,19 +817,37 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 		LastCommandTimestamp: m.lastCommandTimestamp.Load(),
 	}
 
-	// Send heartbeat with 30s fixed interval (no retry - telemetry is best effort)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req)
+	// Telemetry is best-effort: opt out of the client-wide retry interceptor so a failing
+	// heartbeat costs exactly one RPC instead of up to 6 with backoff. The next heartbeat
+	// is the retry.
+	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req, grpc_retry.Disable())
 	if err != nil {
-		// Log error but continue - telemetry is best-effort
+		m.setLastHeartbeatError(err)
+		// Unimplemented means *this* server does not offer the service. That may be the
+		// whole cluster, or it may be one stale proxy during a rolling upgrade, so back
+		// off rather than give up: the interval grows with the streak and snaps back on
+		// the first success.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			m.unsupportedStreak.Add(1)
+		}
 		return
 	}
 
-	if !merr.Ok(resp.GetStatus()) {
+	// Reaching a reply at all proves the server implements the service: an unimplemented
+	// method never returns a business status. Clear the backoff before inspecting that
+	// status, so a server that is reachable but unhealthy -- a coordinator still starting,
+	// a rate limit -- does not leave the client stuck at an inflated interval left over
+	// from some earlier Unimplemented.
+	m.unsupportedStreak.Store(0)
+
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		m.setLastHeartbeatError(err)
 		return
 	}
+	m.setLastHeartbeatError(nil)
 
 	// Clear sent replies only after successful heartbeat
 	m.clearPendingProtoReplies(len(replies))
@@ -688,7 +861,10 @@ func (m *ClientTelemetryManager) getHeartbeatInterval() time.Duration {
 	interval := m.config.HeartbeatInterval
 	m.configMu.RUnlock()
 	if interval <= 0 {
-		return 30 * time.Second
+		// Matches DefaultTelemetryConfig: a config built field by field can leave this
+		// zero, and falling back to a different number than the documented default would
+		// make the interval depend on how the config was constructed.
+		return DefaultTelemetryConfig().HeartbeatInterval
 	}
 	return interval
 }
@@ -716,8 +892,27 @@ func (m *ClientTelemetryManager) snapshotEnabledCollections() (map[string]bool, 
 	return snapshot, false
 }
 
-const samplingDenominator = 10000
+// samplingScale is the fixed-point unit for accumulating a fractional sampling rate. A
+// rate becomes an integer step of samplingScale units, so the smallest rate that still
+// samples is 1e-9 -- far below anything an operator would set, which is the point: a
+// configured rate must never round down to "off".
+const samplingScale = 1_000_000_000
 
+// shouldSample decides whether this operation is recorded, spreading the sampled ones
+// evenly rather than in runs.
+//
+// Each call adds the rate to a shared accumulator and samples on the call that carries it
+// across a whole unit: at 0.25 that is every fourth operation, at 0.1 every tenth. What
+// matters is that the ratio holds over any stretch of calls, not only over a long one --
+// metrics are reported per heartbeat window, and a window is tens or hundreds of
+// operations. A scheme that sampled a contiguous run and then dropped one would give the
+// right long-run ratio while making every individual window either complete or empty.
+//
+// The accumulator is shared, so concurrent callers reorder which of them observes a
+// crossing, but each crossing is observed exactly once: atomic.AddUint64 hands every caller
+// a distinct interval, and the step is smaller than one unit, so no interval spans two
+// crossings. The count of sampled operations is therefore exact, not statistical, which is
+// also why this needs no random source.
 func (m *ClientTelemetryManager) shouldSample(samplingRate float64) bool {
 	if samplingRate >= 1.0 {
 		return true
@@ -726,60 +921,61 @@ func (m *ClientTelemetryManager) shouldSample(samplingRate float64) bool {
 		return false
 	}
 
-	threshold := uint64(samplingRate * float64(samplingDenominator))
-	if threshold == 0 {
-		return false
+	step := uint64(samplingRate * float64(samplingScale))
+	if step == 0 {
+		// A rate too small to represent still means "sample rarely", never "sample never":
+		// silently disabling telemetry for a positive rate is the one outcome nobody could
+		// have intended.
+		step = 1
 	}
 
-	counter := atomic.AddUint64(&m.samplingCounter, 1)
-	return counter%samplingDenominator < threshold
+	after := atomic.AddUint64(&m.samplingAccum, step)
+	before := after - step
+	return after/samplingScale != before/samplingScale
 }
 
-// collectProtoMetrics collects all operation metrics and converts to proto format
-func (m *ClientTelemetryManager) collectProtoMetrics() []*commonpb.OperationMetrics {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+// toProtoOperationMetrics converts collected metrics into their proto form, dropping
+// collection-level entries for collections that are not currently enabled ("*" enables
+// all). This is the single conversion path used for everything put on the wire.
+func (m *ClientTelemetryManager) toProtoOperationMetrics(opMetricsList []*OperationMetrics) []*commonpb.OperationMetrics {
+	if len(opMetricsList) == 0 {
+		return nil
+	}
 
 	enabledCollections, allEnabled := m.snapshotEnabledCollections()
 
-	var result []*commonpb.OperationMetrics
-	for opName, collector := range m.collectors {
-		globalMetrics := collector.GetMetrics()
-		if globalMetrics == nil {
-			continue
-		}
-
-		collMetrics := collector.GetCollectionMetrics()
-
+	result := make([]*commonpb.OperationMetrics, 0, len(opMetricsList))
+	for _, opMetrics := range opMetricsList {
 		protoCollMetrics := make(map[string]*commonpb.Metrics)
-		// Only include metrics for enabled collections
-		// Use "*" wildcard to enable all collections
-		for coll, cm := range collMetrics {
+		for coll, cm := range opMetrics.CollectionMetrics {
 			if allEnabled || enabledCollections[coll] {
-				protoCollMetrics[coll] = &commonpb.Metrics{
-					RequestCount: cm.RequestCount,
-					SuccessCount: cm.SuccessCount,
-					ErrorCount:   cm.ErrorCount,
-					AvgLatencyMs: cm.AvgLatencyMs,
-					P99LatencyMs: cm.P99LatencyMs,
-				}
+				protoCollMetrics[coll] = toProtoMetrics(cm)
 			}
 		}
 
 		result = append(result, &commonpb.OperationMetrics{
-			Operation: opName,
-			Global: &commonpb.Metrics{
-				RequestCount: globalMetrics.RequestCount,
-				SuccessCount: globalMetrics.SuccessCount,
-				ErrorCount:   globalMetrics.ErrorCount,
-				AvgLatencyMs: globalMetrics.AvgLatencyMs,
-				P99LatencyMs: globalMetrics.P99LatencyMs,
-			},
+			Operation:         opMetrics.Operation,
+			Global:            toProtoMetrics(opMetrics.Global),
 			CollectionMetrics: protoCollMetrics,
 		})
 	}
 
 	return result
+}
+
+// toProtoMetrics converts a single metrics bucket to proto form.
+func toProtoMetrics(metrics *Metrics) *commonpb.Metrics {
+	if metrics == nil {
+		return nil
+	}
+	return &commonpb.Metrics{
+		RequestCount: metrics.RequestCount,
+		SuccessCount: metrics.SuccessCount,
+		ErrorCount:   metrics.ErrorCount,
+		AvgLatencyMs: metrics.AvgLatencyMs,
+		P99LatencyMs: metrics.P99LatencyMs,
+		MaxLatencyMs: metrics.MaxLatencyMs,
+	}
 }
 
 // getPendingProtoRepliesSnapshot returns a snapshot of pending replies without clearing.
@@ -887,12 +1083,12 @@ func (m *ClientTelemetryManager) processProtoCommands(commands []*commonpb.Clien
 		}
 	}
 
-	// Clean up old entries from executedCommands map
-	// Commands with CreateTime <= lastTS are now filtered by timestamp comparison
-	// Using <= ensures commands with same millisecond timestamp are also cleaned up
+	// Clean up entries older than the new cursor. Commands at the cursor still pass
+	// the timestamp check, so retain their IDs to keep equal-timestamp redeliveries
+	// idempotent across any number of retries.
 	m.executedCommandsMu.Lock()
 	for cmdID, ts := range m.executedCommands {
-		if ts <= lastTS {
+		if ts < maxCommandTS {
 			delete(m.executedCommands, cmdID)
 		}
 	}
@@ -959,14 +1155,23 @@ func (m *ClientTelemetryManager) updateLastCommandTimestamp(ts int64) {
 
 // collectMetrics collects all operation metrics (local types, for testing)
 func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
+	metrics, _ := m.collectMetricsWithHistorySamples()
+	return metrics
+}
+
+func (m *ClientTelemetryManager) collectMetricsWithHistorySamples() ([]*OperationMetrics, map[string][]int64) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	var result []*OperationMetrics
+	historySamples := make(map[string][]int64)
 	for opName, collector := range m.collectors {
-		globalMetrics := collector.GetMetrics()
+		globalMetrics, samples := collector.getMetricsAndHistorySamples()
 		if globalMetrics == nil {
 			continue
+		}
+		if len(samples) > 0 {
+			historySamples[opName] = samples
 		}
 
 		collMetrics := collector.GetCollectionMetrics()
@@ -978,105 +1183,24 @@ func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
 		})
 	}
 
-	return result
+	return result, historySamples
 }
 
-// getPendingReplies gets and clears pending command replies (local types, for testing)
-func (m *ClientTelemetryManager) getPendingReplies() []*CommandReply {
-	m.pendingRepliesMu.Lock()
-	defer m.pendingRepliesMu.Unlock()
-
-	var result []*CommandReply
-	for _, r := range m.pendingReplies {
-		result = append(result, &CommandReply{
-			CommandId:    r.GetCommandId(),
-			Success:      r.GetSuccess(),
-			ErrorMessage: r.GetErrorMessage(),
-			Payload:      r.GetPayload(),
-		})
-	}
-	m.pendingReplies = nil
-	return result
-}
-
-// processCommands processes commands (local types, for testing)
-// Commands are only executed once using timestamp-based deduplication:
-// - Commands with CreateTime < lastCommandTimestamp are filtered by timestamp (already processed)
-// - Commands with CreateTime >= lastCommandTimestamp use ID-based tracking for same-millisecond deduplication
-func (m *ClientTelemetryManager) processCommands(commands []*ClientCommand) {
-	hasPersistent := false
-	lastTS := m.lastCommandTimestamp.Load()
-	maxCommandTS := lastTS
-
-	// First, process all commands
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			hasPersistent = true
+// handleCommand handles a single command. Command handlers are extensible user callbacks
+// invoked by the background heartbeat goroutine, so a panic must not take down either that
+// goroutine or the caller's whole process. Convert it into the same failed reply used for an
+// ordinary handler error and let later commands and heartbeats continue.
+func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) (reply *CommandReply) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			reply = &CommandReply{
+				CommandId:    cmd.CommandId,
+				Success:      false,
+				ErrorMessage: "command handler panicked: " + panicValueString(recovered),
+			}
 		}
-		if cmd.CreateTime > maxCommandTS {
-			maxCommandTS = cmd.CreateTime
-		}
+	}()
 
-		// Timestamp-based deduplication: commands older than lastTS are already processed
-		if cmd.CreateTime < lastTS {
-			// Already processed in a previous cycle - skip
-			continue
-		}
-
-		// For commands at or after lastTS, check map for same-millisecond duplicates
-		m.executedCommandsMu.RLock()
-		_, alreadyExecuted := m.executedCommands[cmd.CommandId]
-		m.executedCommandsMu.RUnlock()
-
-		if alreadyExecuted {
-			// Skip execution but still generate a success reply
-			continue
-		}
-
-		// Handle the command
-		reply := m.handleCommand(cmd)
-
-		// Track command with its timestamp for later cleanup
-		m.executedCommandsMu.Lock()
-		m.executedCommands[cmd.CommandId] = cmd.CreateTime
-		m.executedCommandsMu.Unlock()
-
-		if reply != nil {
-			m.pendingRepliesMu.Lock()
-			m.pendingReplies = append(m.pendingReplies, &commonpb.CommandReply{
-				CommandId:    reply.CommandId,
-				Success:      reply.Success,
-				ErrorMessage: reply.ErrorMessage,
-				Payload:      reply.Payload,
-			})
-			m.pendingRepliesMu.Unlock()
-		}
-	}
-
-	// Clean up old entries from executedCommands map
-	// Commands with CreateTime <= lastTS are now filtered by timestamp comparison
-	// Using <= ensures commands with same millisecond timestamp are also cleaned up
-	m.executedCommandsMu.Lock()
-	for cmdID, ts := range m.executedCommands {
-		if ts <= lastTS {
-			delete(m.executedCommands, cmdID)
-		}
-	}
-	m.executedCommandsMu.Unlock()
-
-	// Update config hash AFTER all commands are processed
-	// This ensures partial processing doesn't lead to lost configs on reconnect
-	if hasPersistent {
-		m.configHashMu.Lock()
-		m.configHash = m.calculateConfigHash(commands)
-		m.configHashMu.Unlock()
-	}
-
-	m.updateLastCommandTimestamp(maxCommandTS)
-}
-
-// handleCommand handles a single command
-func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply {
 	m.commandHandlersMu.RLock()
 	handler, ok := m.commandHandlers[cmd.CommandType]
 	m.commandHandlersMu.RUnlock()
@@ -1092,30 +1216,15 @@ func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply
 	return handler(cmd)
 }
 
-// calculateConfigHash calculates a hash for persistent commands (local types)
-func (m *ClientTelemetryManager) calculateConfigHash(commands []*ClientCommand) string {
-	if len(commands) == 0 {
-		return ""
-	}
-
-	var commandStrs []string
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			commandStrs = append(commandStrs, cmd.CommandId+":"+cmd.CommandType)
-		}
-	}
-
-	if len(commandStrs) == 0 {
-		return ""
-	}
-
-	sort.Strings(commandStrs)
-
-	h := sha256.New()
-	for _, str := range commandStrs {
-		h.Write([]byte(str))
-	}
-	return hex.EncodeToString(h.Sum(nil))[:16]
+func panicValueString(value any) (result string) {
+	// A panic value can implement Stringer/Error with another panicking method. Keep a safe
+	// type-only fallback so formatting a malicious callback failure cannot escape the boundary.
+	result = fmt.Sprintf("%T", value)
+	defer func() {
+		_ = recover()
+	}()
+	result = fmt.Sprint(value)
+	return result
 }
 
 // RegisterCommandHandler registers a handler for a command type
@@ -1282,20 +1391,49 @@ func (m *ClientTelemetryManager) createSnapshot() {
 
 	// Collect current metrics (and reset counters)
 	// P99 is calculated here, before samples are cleared
-	metrics := m.collectMetrics()
+	metrics, historySamples := m.collectMetricsWithHistorySamples()
 
 	now := time.Now().UnixMilli()
+
+	// The window starts where the previous one ended, not one configured interval ago.
+	// Counters accumulate until they are collected, so the window has to be the time
+	// actually covered. Assuming HeartbeatInterval is wrong whenever the loop did not run
+	// on schedule: the Unimplemented backoff can stretch a gap to 30 minutes, and a
+	// server-pushed interval change moves it too. Labeling half an hour of traffic as a
+	// 30 second window makes every rate derived from it, and every history query that
+	// filters on the range, wrong by the same factor.
+	start := m.lastSnapshotEnd.Load()
+	if start == 0 || start > now {
+		// First snapshot of this process, or the clock moved backwards. Fall back to the
+		// configured interval -- it is the best guess available for a window with no
+		// predecessor.
+		start = now - heartbeatInterval.Milliseconds()
+	}
+	m.lastSnapshotEnd.Store(now)
+
 	snapshot := &MetricsSnapshot{
-		Timestamp: now - heartbeatInterval.Milliseconds(), // Start of the snapshot period
-		EndTime:   now,                                    // End of the snapshot period
-		Metrics:   metrics,
+		Timestamp:             start, // Start of the snapshot period
+		EndTime:               now,   // End of the snapshot period
+		Metrics:               metrics,
+		historyLatencySamples: historySamples,
 	}
 
-	// Add to snapshot list (keep only the most recent 120 = 1 hour at 30s intervals)
+	// Retain one hour by timestamp instead of assuming a fixed heartbeat interval. The
+	// interval is dynamically configurable, so a fixed snapshot count silently changes the
+	// amount of queryable history. Keep a hard cap as a final memory bound for sub-second
+	// heartbeat configurations.
 	m.snapshotsMu.Lock()
 	m.snapshots = append(m.snapshots, snapshot)
-	if len(m.snapshots) > 120 {
-		m.snapshots = m.snapshots[len(m.snapshots)-120:]
+	cutoff := now - telemetryHistoryRetention.Milliseconds()
+	retained := m.snapshots[:0]
+	for _, existing := range m.snapshots {
+		if existing.EndTime >= cutoff {
+			retained = append(retained, existing)
+		}
+	}
+	m.snapshots = retained
+	if len(m.snapshots) > maxTelemetryHistorySnapshots {
+		m.snapshots = m.snapshots[len(m.snapshots)-maxTelemetryHistorySnapshots:]
 	}
 	m.snapshotsMu.Unlock()
 }
@@ -1345,7 +1483,31 @@ type ConfigPayload struct {
 	Enabled           *bool    `json:"enabled,omitempty"`
 	HeartbeatInterval *int64   `json:"heartbeat_interval_ms,omitempty"`
 	SamplingRate      *float64 `json:"sampling_rate,omitempty"`
-	TTLSeconds        int64    `json:"ttl_seconds,omitempty"`
+}
+
+// ConfigApplyResult is what a push_config reply carries back, so the sender can tell a
+// config that took effect from one that was quietly dropped.
+//
+// encoding/json ignores fields it does not know, which made every payload look accepted:
+// a misspelled key, a key belonging to a newer client, or ttl_seconds -- which lives in
+// ConfigPayload and is sent by the web UI but has never been read by anything -- all
+// produced the same bare Success. Naming both halves is the only way the caller can see
+// the difference.
+type ConfigApplyResult struct {
+	// Applied lists the payload keys that changed this client's configuration.
+	Applied []string `json:"applied"`
+	// Ignored lists the payload keys this client does not act on. It is not an error:
+	// failing the whole command would stop a newer server from configuring an older
+	// client at all, so the keys are reported and the rest is still applied.
+	Ignored []string `json:"ignored,omitempty"`
+}
+
+// configPayloadKeys are the payload keys handlePushConfig acts on. Anything else in a
+// payload is reported as ignored.
+var configPayloadKeys = map[string]struct{}{
+	"enabled":               {},
+	"heartbeat_interval_ms": {},
+	"sampling_rate":         {},
 }
 
 // CollectionMetricsPayload represents the payload for collection_metrics command
@@ -1358,6 +1520,10 @@ type CollectionMetricsPayload struct {
 // handlePushConfig handles dynamic configuration updates
 func (m *ClientTelemetryManager) handlePushConfig(cmd *ClientCommand) *CommandReply {
 	var payload ConfigPayload
+	// raw is decoded alongside the typed payload purely to see which keys were sent:
+	// unmarshalling into ConfigPayload cannot distinguish "key absent" from "key unknown",
+	// and both halves are needed to answer honestly.
+	raw := map[string]json.RawMessage{}
 	if len(cmd.Payload) > 0 {
 		if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
 			return &CommandReply{
@@ -1366,25 +1532,51 @@ func (m *ClientTelemetryManager) handlePushConfig(cmd *ClientCommand) *CommandRe
 				ErrorMessage: "failed to parse config payload: " + err.Error(),
 			}
 		}
+		if err := json.Unmarshal(cmd.Payload, &raw); err != nil {
+			return &CommandReply{
+				CommandId:    cmd.CommandId,
+				Success:      false,
+				ErrorMessage: "failed to parse config payload: " + err.Error(),
+			}
+		}
 	}
+
+	ignored := make([]string, 0, len(raw))
+	for key := range raw {
+		if _, known := configPayloadKeys[key]; !known {
+			ignored = append(ignored, key)
+		}
+	}
+	sort.Strings(ignored)
+
+	// Validate before touching anything: a payload is applied whole or not at all. Writing
+	// the fields as they were read would let a rejected value leave earlier ones applied,
+	// so a command carrying both enabled and a bad interval would switch telemetry off and
+	// still report failure -- the caller would have no way to know what state it left.
+	if payload.HeartbeatInterval != nil && *payload.HeartbeatInterval <= 0 {
+		return &CommandReply{
+			CommandId:    cmd.CommandId,
+			Success:      false,
+			ErrorMessage: "heartbeat_interval_ms must be positive",
+		}
+	}
+
+	applied := make([]string, 0, len(configPayloadKeys))
 
 	// Apply configuration changes with write lock
 	m.configMu.Lock()
 	if payload.Enabled != nil {
 		m.config.Enabled = *payload.Enabled
+		applied = append(applied, "enabled")
 	}
 	if payload.HeartbeatInterval != nil {
-		if *payload.HeartbeatInterval <= 0 {
-			m.configMu.Unlock()
-			return &CommandReply{
-				CommandId:    cmd.CommandId,
-				Success:      false,
-				ErrorMessage: "heartbeat_interval_ms must be positive",
-			}
-		}
 		m.config.HeartbeatInterval = time.Duration(*payload.HeartbeatInterval) * time.Millisecond
+		applied = append(applied, "heartbeat_interval_ms")
 	}
 	if payload.SamplingRate != nil {
+		// Out-of-range rates are clamped rather than rejected, which is why this is not
+		// part of the validation above: 1.5 means "everything" and -0.5 means "nothing",
+		// and neither is ambiguous enough to refuse.
 		samplingRate := *payload.SamplingRate
 		if samplingRate < 0.0 {
 			samplingRate = 0.0
@@ -1392,13 +1584,20 @@ func (m *ClientTelemetryManager) handlePushConfig(cmd *ClientCommand) *CommandRe
 			samplingRate = 1.0
 		}
 		m.config.SamplingRate = samplingRate
+		applied = append(applied, "sampling_rate")
 	}
 	m.configMu.Unlock()
 
-	return &CommandReply{
+	reply := &CommandReply{
 		CommandId: cmd.CommandId,
 		Success:   true,
 	}
+	// A reply that cannot be encoded would be worse than one without the detail, so the
+	// command still succeeds -- the configuration was applied either way.
+	if encoded, err := json.Marshal(ConfigApplyResult{Applied: applied, Ignored: ignored}); err == nil {
+		reply.Payload = encoded
+	}
+	return reply
 }
 
 // GetConfigResponse represents the response for get_config command
@@ -1810,8 +2009,7 @@ func (m *ClientTelemetryManager) handleShowLatencyHistory(cmd *ClientCommand) *C
 	}
 }
 
-// aggregateSnapshots aggregates multiple snapshots into a single response
-// Uses weighted average for latencies (weighted by request count)
+// aggregateSnapshots aggregates multiple snapshots into a single response.
 func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot, startTime, endTime int64) *AggregatedLatencyHistoryResponse {
 	if len(snapshots) == 0 {
 		return &AggregatedLatencyHistoryResponse{
@@ -1825,13 +2023,17 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 	}
 
 	// Aggregate metrics by operation
+	type weightedLatencySample struct {
+		latencyMs float64
+		weight    float64
+	}
 	type aggregator struct {
 		requestCount   int64
 		successCount   int64
 		errorCount     int64
 		weightedAvgSum float64 // sum of (avg_latency * request_count)
-		weightedP99Sum float64 // sum of (p99_latency * request_count)
 		maxLatency     float64
+		latencySamples []weightedLatencySample
 	}
 
 	aggregators := make(map[string]*aggregator)
@@ -1852,7 +2054,25 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 			agg.successCount += opMetrics.Global.SuccessCount
 			agg.errorCount += opMetrics.Global.ErrorCount
 			agg.weightedAvgSum += opMetrics.Global.AvgLatencyMs * float64(opMetrics.Global.RequestCount)
-			agg.weightedP99Sum += opMetrics.Global.P99LatencyMs * float64(opMetrics.Global.RequestCount)
+			samples := snapshot.historyLatencySamples[opMetrics.Operation]
+			if len(samples) > 0 && opMetrics.Global.RequestCount > 0 {
+				weight := float64(opMetrics.Global.RequestCount) / float64(len(samples))
+				for _, latencyUs := range samples {
+					agg.latencySamples = append(agg.latencySamples, weightedLatencySample{
+						latencyMs: float64(latencyUs) / 1000.0,
+						weight:    weight,
+					})
+				}
+			} else if opMetrics.Global.RequestCount > 0 {
+				// Backward-compatible fallback for manually constructed or transferred
+				// snapshots that predate the internal sample sketch. Treat the window P99
+				// as a weighted point; unlike averaging percentiles, this at least retains
+				// percentile ordering and preserves the exact single-window result.
+				agg.latencySamples = append(agg.latencySamples, weightedLatencySample{
+					latencyMs: opMetrics.Global.P99LatencyMs,
+					weight:    float64(opMetrics.Global.RequestCount),
+				})
+			}
 			if opMetrics.Global.MaxLatencyMs > agg.maxLatency {
 				agg.maxLatency = opMetrics.Global.MaxLatencyMs
 			}
@@ -1866,7 +2086,21 @@ func (m *ClientTelemetryManager) aggregateSnapshots(snapshots []*MetricsSnapshot
 		p99Latency := 0.0
 		if agg.requestCount > 0 {
 			avgLatency = agg.weightedAvgSum / float64(agg.requestCount)
-			p99Latency = agg.weightedP99Sum / float64(agg.requestCount)
+			sort.Slice(agg.latencySamples, func(i, j int) bool {
+				return agg.latencySamples[i].latencyMs < agg.latencySamples[j].latencyMs
+			})
+			if len(agg.latencySamples) > 0 {
+				target := float64(agg.requestCount) * 0.99
+				cumulative := 0.0
+				p99Latency = agg.latencySamples[len(agg.latencySamples)-1].latencyMs
+				for _, sample := range agg.latencySamples {
+					cumulative += sample.weight
+					if cumulative > target {
+						p99Latency = sample.latencyMs
+						break
+					}
+				}
+			}
 		}
 
 		metrics[op] = &MetricsResponse{

--- a/client/milvusclient/telemetry_integration_test.go
+++ b/client/milvusclient/telemetry_integration_test.go
@@ -143,13 +143,13 @@ func TestTelemetryIntegration(t *testing.T) {
 			},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Check state
 		fmt.Printf("\nConfig hash: %s\n", manager.GetConfigHash())
 
 		// Get pending replies
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 		for _, r := range replies {
 			fmt.Printf("  Command %s: success=%v\n", r.CommandId, r.Success)
@@ -177,7 +177,7 @@ func TestTelemetryIntegration(t *testing.T) {
 		metrics := manager.collectMetrics()
 		fmt.Printf("Metrics count: %d\n", len(metrics))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 	})
 }

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -17,20 +17,29 @@
 package milvusclient
 
 import (
+	"context"
 	"encoding/json"
+	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 )
 
 func TestDefaultTelemetryConfig(t *testing.T) {
 	config := DefaultTelemetryConfig()
 	assert.True(t, config.Enabled)
-	assert.Equal(t, 30*time.Second, config.HeartbeatInterval)
+	assert.Equal(t, 10*time.Second, config.HeartbeatInterval, "默认心跳=窗口长度，改动会影响服务端负载与数据新鲜度")
 	assert.Equal(t, 1.0, config.SamplingRate)
 	assert.Equal(t, 100, config.ErrorMaxCount)
 }
@@ -112,7 +121,7 @@ func TestClientTelemetryManager(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, nil)
 		assert.NotNil(t, manager)
 		assert.True(t, manager.config.Enabled)
-		assert.Equal(t, 30*time.Second, manager.config.HeartbeatInterval)
+		assert.Equal(t, DefaultTelemetryConfig().HeartbeatInterval, manager.config.HeartbeatInterval)
 	})
 
 	t.Run("creation with custom config", func(t *testing.T) {
@@ -260,14 +269,14 @@ func TestClientTelemetryManager(t *testing.T) {
 			}
 		})
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Config hash should be updated for persistent commands
 		assert.NotEmpty(t, manager.GetConfigHash())
 
 		// Process the same commands again - should be idempotent
 		oldHash := manager.GetConfigHash()
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, oldHash, manager.GetConfigHash())
 	})
 
@@ -291,19 +300,63 @@ func TestClientTelemetryManager(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "test", CreateTime: 1000},
 		}
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		assert.Len(t, replies, 1)
 		assert.Equal(t, "cmd-1", replies[0].CommandId)
 
 		// Second call should return empty
-		replies = manager.getPendingReplies()
+		replies = drainPendingReplies(manager)
 		assert.Len(t, replies, 0)
 	})
 }
 
 func TestProcessProtoCommands(t *testing.T) {
+	t.Run("equal timestamp stays idempotent after repeated delivery", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		executions := 0
+		manager.RegisterCommandHandler("custom", func(cmd *ClientCommand) *CommandReply {
+			executions++
+			return &CommandReply{CommandId: cmd.CommandId, Success: true}
+		})
+		command := []*commonpb.ClientCommand{{
+			CommandId:   "same-command",
+			CommandType: "custom",
+			CreateTime:  1000,
+		}}
+
+		manager.processProtoCommands(command)
+		manager.processProtoCommands(command)
+		manager.processProtoCommands(command)
+
+		assert.Equal(t, 1, executions)
+	})
+
+	t.Run("custom handler panic becomes a failed reply and batch continues", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		executions := 0
+		manager.RegisterCommandHandler("panic", func(*ClientCommand) *CommandReply {
+			panic("boom")
+		})
+		manager.RegisterCommandHandler("success", func(cmd *ClientCommand) *CommandReply {
+			executions++
+			return &CommandReply{CommandId: cmd.CommandId, Success: true}
+		})
+
+		manager.processProtoCommands([]*commonpb.ClientCommand{
+			{CommandId: "panic-command", CommandType: "panic", CreateTime: 1000},
+			{CommandId: "next-command", CommandType: "success", CreateTime: 1000},
+		})
+
+		replies := manager.getPendingProtoRepliesSnapshot()
+		require.Len(t, replies, 2)
+		assert.False(t, replies[0].GetSuccess())
+		assert.Equal(t, "command handler panicked: boom", replies[0].GetErrorMessage())
+		assert.True(t, replies[1].GetSuccess())
+		assert.Equal(t, 1, executions)
+	})
+
 	t.Run("idempotent ack and timestamp update", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 
@@ -484,7 +537,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cfg2", CommandType: "enable_trace", Payload: []byte(`{"enabled": true}`), Persistent: true},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be updated after all commands processed
 		hash := manager.GetConfigHash()
@@ -492,7 +545,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 
 		// Hash should include both commands
 		// Verify by processing again - hash should remain the same
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 
@@ -504,7 +557,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd1", CommandType: "show_errors", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should remain empty
 		assert.Equal(t, "", manager.GetConfigHash())
@@ -520,16 +573,16 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd2", CommandType: "clear_metrics", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be calculated based on persistent commands only
 		hash := manager.GetConfigHash()
 		assert.NotEmpty(t, hash)
 
 		// Add another non-persistent command - hash shouldn't change
-		manager.processCommands([]*ClientCommand{
+		manager.processProtoCommands(toProtoCommands([]*ClientCommand{
 			{CommandId: "cmd3", CommandType: "show_metrics", Persistent: false},
-		})
+		}))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 }
@@ -555,10 +608,10 @@ func TestPartialDeliveryScenario(t *testing.T) {
 		assert.Equal(t, "", manager.GetConfigHash())
 
 		// Now process all commands properly
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should now be updated
-		expectedHash := manager.calculateConfigHash(commands)
+		expectedHash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Equal(t, expectedHash, manager.GetConfigHash())
 	})
 }
@@ -1143,6 +1196,229 @@ func TestPublicHandleMethods(t *testing.T) {
 	})
 }
 
+// A push_config reply used to say Success for any payload at all, because unknown JSON
+// fields are dropped silently by encoding/json and nothing else was reported. Pushing a
+// misspelled key, or one this client is too old to know, looked exactly like a config that
+// took effect. The reply now says which keys were applied and which were ignored, so the
+// sender can tell the difference.
+func TestPushConfigReplyReportsAppliedAndIgnoredKeys(t *testing.T) {
+	decode := func(t *testing.T, reply *CommandReply) ConfigApplyResult {
+		t.Helper()
+		var result ConfigApplyResult
+		require.NoError(t, json.Unmarshal(reply.Payload, &result))
+		return result
+	}
+
+	t.Run("applied keys are named", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"sampling_rate": 0.25, "heartbeat_interval_ms": 3000}`),
+		})
+		assert.True(t, reply.Success)
+
+		result := decode(t, reply)
+		assert.ElementsMatch(t, []string{"sampling_rate", "heartbeat_interval_ms"}, result.Applied)
+		assert.Empty(t, result.Ignored)
+	})
+
+	t.Run("unknown keys are reported rather than silently dropped", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"unsupported_probe": true, "sampling_rate": 0.5}`),
+		})
+		// Still a success: the known key was applied, and an unknown key must not fail the
+		// whole command, or a newer server could not push to an older client at all.
+		assert.True(t, reply.Success)
+
+		result := decode(t, reply)
+		assert.Equal(t, []string{"sampling_rate"}, result.Applied)
+		assert.Equal(t, []string{"unsupported_probe"}, result.Ignored)
+	})
+
+	t.Run("a payload of only unknown keys applies nothing", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		manager.configMu.RLock()
+		beforeRate, beforeInterval, beforeEnabled := manager.config.SamplingRate, manager.config.HeartbeatInterval, manager.config.Enabled
+		manager.configMu.RUnlock()
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"unsupported_probe": true}`),
+		})
+		assert.True(t, reply.Success)
+
+		result := decode(t, reply)
+		assert.Empty(t, result.Applied)
+		assert.Equal(t, []string{"unsupported_probe"}, result.Ignored)
+
+		manager.configMu.RLock()
+		defer manager.configMu.RUnlock()
+		assert.Equal(t, beforeRate, manager.config.SamplingRate)
+		assert.Equal(t, beforeInterval, manager.config.HeartbeatInterval)
+		assert.Equal(t, beforeEnabled, manager.config.Enabled)
+	})
+
+	// ttl_seconds sits in ConfigPayload and the web UI sends it, but nothing has ever read
+	// it. Naming it in the reply is how that stops being invisible.
+	t.Run("ttl_seconds is reported as ignored", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"ttl_seconds": 300}`),
+		})
+		assert.True(t, reply.Success)
+		assert.Equal(t, []string{"ttl_seconds"}, decode(t, reply).Ignored)
+	})
+
+	// A payload is applied whole or not at all. The check on heartbeat_interval_ms used to
+	// run after enabled had already been written, so a payload carrying both left telemetry
+	// switched off while the reply said the command had failed -- the one case where
+	// knowing what was applied matters most, and the one case that reported nothing.
+	t.Run("a rejected value leaves every field untouched", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		// Copied by value: m.config is a pointer, so holding it would compare the struct
+		// with itself and pass no matter what the handler did.
+		manager.configMu.RLock()
+		before := *manager.config
+		manager.configMu.RUnlock()
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"enabled": false, "sampling_rate": 0.1, "heartbeat_interval_ms": 0}`),
+		})
+		assert.False(t, reply.Success)
+		assert.Contains(t, reply.ErrorMessage, "must be positive")
+
+		manager.configMu.RLock()
+		defer manager.configMu.RUnlock()
+		assert.Equal(t, before.Enabled, manager.config.Enabled, "telemetry was switched off by a command that failed")
+		assert.Equal(t, before.SamplingRate, manager.config.SamplingRate)
+		assert.Equal(t, before.HeartbeatInterval, manager.config.HeartbeatInterval)
+	})
+
+	t.Run("a rejected value reports no applied keys", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		reply := manager.handlePushConfig(&ClientCommand{
+			CommandId: "test-1",
+			Payload:   []byte(`{"heartbeat_interval_ms": 0}`),
+		})
+		assert.False(t, reply.Success)
+		assert.Contains(t, reply.ErrorMessage, "must be positive")
+	})
+}
+
+// Sampling used to be a contiguous block: a counter modulo 10000, sampling while the
+// remainder was under rate*10000. The long-run ratio was right, but the ratio inside any
+// one heartbeat window -- the only unit the telemetry API reports -- was not: a window is
+// tens or hundreds of operations against a cycle of ten thousand, so windows came out
+// wholly sampled or wholly dropped. At 3 QPS that is minutes of full metrics followed by
+// three quarters of an hour reporting nothing while the client is plainly busy.
+func TestSamplingIsUniformWithinEveryWindow(t *testing.T) {
+	sampleN := func(m *ClientTelemetryManager, rate float64, n int) int {
+		count := 0
+		for i := 0; i < n; i++ {
+			if m.shouldSample(rate) {
+				count++
+			}
+		}
+		return count
+	}
+
+	t.Run("every window of a run holds the configured ratio", func(t *testing.T) {
+		const (
+			rate       = 0.25
+			windowSize = 100
+			windows    = 50
+		)
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		for w := 0; w < windows; w++ {
+			got := sampleN(manager, rate, windowSize)
+			// One either side: a window boundary can fall mid-interval, which shifts a
+			// single sample across it.
+			assert.InDelta(t, float64(windowSize)*rate, float64(got), 1,
+				"window %d sampled %d of %d", w, got, windowSize)
+		}
+	})
+
+	t.Run("a rate of one in four samples exactly every fourth operation", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		var pattern []bool
+		for i := 0; i < 12; i++ {
+			pattern = append(pattern, manager.shouldSample(0.25))
+		}
+		assert.Equal(t, []bool{
+			false, false, false, true,
+			false, false, false, true,
+			false, false, false, true,
+		}, pattern)
+	})
+
+	// The old threshold was rate*10000 truncated to an integer, so any rate below 1e-4
+	// became zero and the code then returned false forever: a configured rate silently
+	// meant "off".
+	t.Run("a very small rate still samples", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		got := sampleN(manager, 0.00001, 1_000_000)
+		assert.InDelta(t, 10, got, 1, "1e-5 over a million operations")
+	})
+
+	t.Run("the boundary rates are unchanged", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		assert.Equal(t, 100, sampleN(manager, 1.0, 100))
+		assert.Equal(t, 0, sampleN(manager, 0.0, 100))
+		assert.Equal(t, 100, sampleN(manager, 1.5, 100))
+		assert.Equal(t, 0, sampleN(manager, -0.5, 100))
+	})
+
+	// Lowering the rate from 1.0 used to hand out a burst of full sampling: the 1.0 path
+	// returns before touching the counter, so the counter sat at zero and the first
+	// rate*10000 operations after the change all fell inside the sampled block.
+	t.Run("lowering the rate from 1.0 does not start with a burst", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		sampleN(manager, 1.0, 5000)
+
+		got := sampleN(manager, 0.25, 100)
+		assert.InDelta(t, 25, got, 1)
+	})
+
+	t.Run("concurrent callers still see the configured ratio", func(t *testing.T) {
+		const (
+			rate       = 0.1
+			goroutines = 8
+			perG       = 1000
+		)
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		var wg sync.WaitGroup
+		var sampled atomic.Int64
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < perG; i++ {
+					if manager.shouldSample(rate) {
+						sampled.Add(1)
+					}
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Exact, not approximate: the decision is a boundary crossing of a shared
+		// accumulator, so concurrency reorders which caller samples but never how many do.
+		assert.InDelta(t, float64(goroutines*perG)*rate, float64(sampled.Load()), 1)
+	})
+}
+
 func TestHandlePushConfigEdgeCases(t *testing.T) {
 	t.Run("invalid payload", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
@@ -1656,7 +1932,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Search", "test_col", startTime, nil)
 		manager.RecordOperation("Insert", "test_col", startTime, errors.New("insert error"))
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics
@@ -1685,7 +1961,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Query", "col_a", startTime, nil)
 		manager.RecordOperation("Query", "col_b", startTime, nil) // Not enabled
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		for _, m := range metrics {
 			if m.Operation == "Query" {
 				// Only col_a should have collection metrics
@@ -1714,7 +1990,7 @@ func TestGetHeartbeatInterval(t *testing.T) {
 		})
 
 		interval := manager.getHeartbeatInterval()
-		assert.Equal(t, 30*time.Second, interval)
+		assert.Equal(t, DefaultTelemetryConfig().HeartbeatInterval, interval)
 	})
 
 	t.Run("returns default for negative interval", func(t *testing.T) {
@@ -1724,7 +2000,7 @@ func TestGetHeartbeatInterval(t *testing.T) {
 		})
 
 		interval := manager.getHeartbeatInterval()
-		assert.Equal(t, 30*time.Second, interval)
+		assert.Equal(t, DefaultTelemetryConfig().HeartbeatInterval, interval)
 	})
 }
 
@@ -1766,7 +2042,7 @@ func TestCalculateProtoConfigHash(t *testing.T) {
 func TestCalculateConfigHash(t *testing.T) {
 	t.Run("empty commands", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
-		hash := manager.calculateConfigHash(nil)
+		hash := manager.calculateProtoConfigHash(nil)
 		assert.Empty(t, hash)
 	})
 
@@ -1775,7 +2051,7 @@ func TestCalculateConfigHash(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "show_errors", Persistent: false},
 		}
-		hash := manager.calculateConfigHash(commands)
+		hash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Empty(t, hash)
 	})
 }
@@ -1980,7 +2256,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 	t.Run("no collectors", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics)
 	})
 
@@ -1992,7 +2268,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		manager.collectors["EmptyOp"] = NewOperationMetricsCollector()
 		manager.mu.Unlock()
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics) // Should skip collectors with no data
 	})
 
@@ -2007,7 +2283,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		// Record operations
 		manager.RecordOperation("Search", "any_collection", time.Now().Add(-10*time.Millisecond), nil)
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics and verify collection is included
@@ -2059,7 +2335,7 @@ func TestBuildClientInfoEdgeCases(t *testing.T) {
 }
 
 func TestSnapshotTrimming(t *testing.T) {
-	t.Run("trims to 120 snapshots", func(t *testing.T) {
+	t.Run("retains more than the old 120 snapshot limit inside one hour", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled:           true,
 			HeartbeatInterval: time.Millisecond,
@@ -2069,13 +2345,41 @@ func TestSnapshotTrimming(t *testing.T) {
 		// Record an operation first
 		manager.RecordOperation("Test", "", time.Now(), nil)
 
-		// Manually add more than 120 snapshots
+		// A count-only cap of 120 retained just two minutes at this interval.
 		for i := 0; i < 130; i++ {
 			manager.createSnapshot()
 		}
 
 		snapshots := manager.GetMetricsSnapshots()
-		assert.Equal(t, 120, len(snapshots))
+		assert.Equal(t, 130, len(snapshots))
+	})
+
+	t.Run("drops snapshots outside the one hour retention window", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		now := time.Now()
+		manager.snapshots = []*MetricsSnapshot{
+			{Timestamp: now.Add(-2 * time.Hour).UnixMilli(), EndTime: now.Add(-90 * time.Minute).UnixMilli()},
+			{Timestamp: now.Add(-time.Hour).UnixMilli(), EndTime: now.Add(-59 * time.Minute).UnixMilli()},
+		}
+
+		manager.createSnapshot()
+
+		snapshots := manager.GetMetricsSnapshots()
+		require.Len(t, snapshots, 2)
+		assert.Equal(t, now.Add(-59*time.Minute).UnixMilli(), snapshots[0].EndTime)
+	})
+
+	t.Run("keeps a hard memory bound for sub-second intervals", func(t *testing.T) {
+		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		now := time.Now().UnixMilli()
+		manager.snapshots = make([]*MetricsSnapshot, 0, maxTelemetryHistorySnapshots+1)
+		for i := 0; i < maxTelemetryHistorySnapshots; i++ {
+			manager.snapshots = append(manager.snapshots, &MetricsSnapshot{Timestamp: now, EndTime: now})
+		}
+
+		manager.createSnapshot()
+
+		assert.Len(t, manager.GetMetricsSnapshots(), maxTelemetryHistorySnapshots)
 	})
 }
 
@@ -2193,7 +2497,7 @@ func TestErrorCollectorRingBuffer(t *testing.T) {
 }
 
 func TestSendHeartbeatDisabled(t *testing.T) {
-	t.Run("disabled telemetry skips heartbeat", func(t *testing.T) {
+	t.Run("disabled telemetry with no transport is safe", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled: false,
 		})
@@ -2209,6 +2513,160 @@ func TestSendHeartbeatDisabled(t *testing.T) {
 		// This should not panic
 		manager.sendHeartbeat()
 	})
+}
+
+func TestDisabledTelemetryKeepsControlHeartbeatForAckAndReenable(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	service := &reconfigTelemetryServer{
+		secondEntered: make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	svr := grpc.NewServer()
+	milvuspb.RegisterClientTelemetryServiceServer(svr, service)
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		_ = lis.Close()
+	}()
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithBlock(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := &Client{telemetryService: milvuspb.NewClientTelemetryServiceClient(conn)}
+	optedOutConfig := DefaultTelemetryConfig()
+	optedOutConfig.Enabled = false
+	optedOutConfig.HeartbeatInterval = 5 * time.Millisecond
+	optedOut := NewClientTelemetryManager(client, optedOutConfig)
+	optedOut.Start()
+	time.Sleep(20 * time.Millisecond)
+	optedOut.Stop()
+	assert.Empty(t, service.Captures(), "an initial Enabled=false must not start the heartbeat control plane")
+
+	manager := NewClientTelemetryManager(client, DefaultTelemetryConfig())
+	manager.RecordOperation("Search", "books", time.Now().Add(-time.Millisecond), nil)
+	manager.Start()
+	require.Eventually(t, func() bool {
+		manager.configMu.RLock()
+		disabled := !manager.config.Enabled
+		manager.configMu.RUnlock()
+		return disabled && len(service.Captures()) >= 1
+	}, time.Second, time.Millisecond)
+
+	initial := service.Captures()
+	require.NotEmpty(t, initial)
+	assert.NotEmpty(t, initial[0].metrics)
+	disableHash := manager.GetConfigHash()
+	assert.NotEmpty(t, disableHash)
+	replies := manager.getPendingProtoRepliesSnapshot()
+	require.Len(t, replies, 1)
+	assert.Equal(t, "disable", replies[0].GetCommandId())
+
+	manager.snapshotsMu.RLock()
+	snapshotCount := len(manager.snapshots)
+	manager.snapshotsMu.RUnlock()
+	manager.RecordOperation("Search", "books", time.Now().Add(-time.Millisecond), nil)
+	manager.createSnapshot()
+	manager.snapshotsMu.RLock()
+	assert.Len(t, manager.snapshots, snapshotCount)
+	manager.snapshotsMu.RUnlock()
+
+	select {
+	case <-service.secondEntered:
+	case <-time.After(time.Second):
+		t.Fatal("disabled control heartbeat did not reach the server")
+	}
+	disabled := service.Captures()
+	require.GreaterOrEqual(t, len(disabled), 2)
+	assert.Empty(t, disabled[1].metrics)
+	assert.Equal(t, disableHash, disabled[1].configHash)
+	require.Equal(t, []string{"disable"}, disabled[1].replyIDs)
+	close(service.releaseSecond)
+
+	require.Eventually(t, func() bool {
+		manager.configMu.RLock()
+		enabled := manager.config.Enabled
+		manager.configMu.RUnlock()
+		return enabled && len(service.Captures()) >= 2
+	}, time.Second, time.Millisecond)
+	reenableHash := manager.GetConfigHash()
+	require.NotEmpty(t, reenableHash)
+	require.Eventually(t, func() bool {
+		return len(service.Captures()) >= 3 && len(manager.getPendingProtoRepliesSnapshot()) == 0
+	}, time.Second, time.Millisecond)
+	manager.Stop()
+	captures := service.Captures()
+	require.GreaterOrEqual(t, len(captures), 3)
+	assert.Equal(t, reenableHash, captures[2].configHash)
+	require.Equal(t, []string{"reenable"}, captures[2].replyIDs)
+	assert.Empty(t, manager.getPendingProtoRepliesSnapshot())
+}
+
+type controlHeartbeatCapture struct {
+	metrics    []*commonpb.OperationMetrics
+	replyIDs   []string
+	configHash string
+}
+
+type reconfigTelemetryServer struct {
+	milvuspb.UnimplementedClientTelemetryServiceServer
+	mu            sync.Mutex
+	captures      []controlHeartbeatCapture
+	secondEntered chan struct{}
+	releaseSecond chan struct{}
+}
+
+func (s *reconfigTelemetryServer) ClientHeartbeat(_ context.Context, request *milvuspb.ClientHeartbeatRequest) (*milvuspb.ClientHeartbeatResponse, error) {
+	s.mu.Lock()
+	replyIDs := make([]string, 0, len(request.GetCommandReplies()))
+	for _, reply := range request.GetCommandReplies() {
+		replyIDs = append(replyIDs, reply.GetCommandId())
+	}
+	s.captures = append(s.captures, controlHeartbeatCapture{
+		metrics:    request.GetMetrics(),
+		replyIDs:   replyIDs,
+		configHash: request.GetConfigHash(),
+	})
+	heartbeatNumber := len(s.captures)
+	s.mu.Unlock()
+
+	command := &commonpb.ClientCommand{
+		CommandType: "push_config",
+		Persistent:  true,
+		TargetScope: "global",
+	}
+	switch heartbeatNumber {
+	case 1:
+		command.CommandId = "disable"
+		command.Payload = []byte(`{"enabled":false,"heartbeat_interval_ms":20}`)
+		command.CreateTime = 1
+	case 2:
+		close(s.secondEntered)
+		<-s.releaseSecond
+		command.CommandId = "reenable"
+		command.Payload = []byte(`{"enabled":true}`)
+		command.CreateTime = 2
+	default:
+		return &milvuspb.ClientHeartbeatResponse{Status: &commonpb.Status{}}, nil
+	}
+	return &milvuspb.ClientHeartbeatResponse{
+		Status:   &commonpb.Status{},
+		Commands: []*commonpb.ClientCommand{command},
+	}, nil
+}
+
+func (s *reconfigTelemetryServer) Captures() []controlHeartbeatCapture {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]controlHeartbeatCapture, len(s.captures))
+	copy(result, s.captures)
+	return result
 }
 
 func TestHeartbeatLoopStop(t *testing.T) {
@@ -2468,11 +2926,21 @@ func TestHandleShowLatencyHistoryMarshalError(t *testing.T) {
 			manager.createSnapshot()
 		}
 
+		// end_time is a second past "now" on purpose. RFC3339 has second granularity, so
+		// formatting time.Now() rounds the query end *down* by up to 999ms -- and these
+		// five snapshots are all created inside a single millisecond, so their windows now
+		// start after that truncated boundary and fall outside the range.
+		//
+		// This only shows up because snapshot windows are honest now: they run from the
+		// previous window's end rather than always claiming to start one heartbeat
+		// interval ago, which used to put every snapshot 30s in the past no matter when it
+		// was taken. Real snapshots are seconds apart, so their start is never inside the
+		// truncation gap; only a back-to-back test loop can produce a zero-width window.
 		now := time.Now()
 		tenMinAgo := now.Add(-10 * time.Minute)
 		payload := LatencyHistoryPayload{
 			StartTime: tenMinAgo.Format(time.RFC3339),
-			EndTime:   now.Format(time.RFC3339),
+			EndTime:   now.Add(time.Second).Format(time.RFC3339),
 			Detail:    true, // Detail mode
 		}
 		payloadBytes, _ := json.Marshal(payload)
@@ -2532,6 +3000,35 @@ func TestAggregateSnapshotsEdgeCases(t *testing.T) {
 		// Insert should have 2 requests total (1 success + 1 error)
 		assert.Equal(t, int64(2), result.Aggregated.Metrics["Insert"].RequestCount)
 	})
+}
+
+func TestAggregateSnapshotsP99UsesCombinedLatencyDistribution(t *testing.T) {
+	manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+	fastStart := time.Now().Add(-time.Millisecond)
+	for i := 0; i < 100; i++ {
+		manager.RecordOperation("Search", "", fastStart, nil)
+	}
+	manager.createSnapshot()
+
+	slowStart := time.Now().Add(-100 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		manager.RecordOperation("Search", "", slowStart, nil)
+	}
+	manager.createSnapshot()
+
+	snapshots := manager.GetMetricsSnapshots()
+	require.Len(t, snapshots, 2)
+	require.NotEmpty(t, snapshots[0].historyLatencySamples["Search"])
+	require.NotEmpty(t, snapshots[1].historyLatencySamples["Search"])
+
+	result := manager.aggregateSnapshots(snapshots, snapshots[0].Timestamp, snapshots[1].EndTime)
+	search := result.Aggregated.Metrics["Search"]
+	require.NotNil(t, search)
+	assert.Equal(t, int64(200), search.RequestCount)
+	// Averaging the two per-window P99 values would report roughly 50ms. The P99 of
+	// the combined equal-sized distribution belongs to the slow window.
+	assert.Greater(t, search.P99LatencyMs, 90.0)
 }
 
 // TestCalculateP99FromSamplesBufferWrap tests the buffer wrap scenarios
@@ -2954,7 +3451,7 @@ func TestSendHeartbeatEdgeCases(t *testing.T) {
 		manager.sendHeartbeat()
 	})
 
-	t.Run("sendHeartbeat with telemetry disabled", func(t *testing.T) {
+	t.Run("sendHeartbeat with disabled metrics and nil client", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, &TelemetryConfig{
 			Enabled:           false,
 			HeartbeatInterval: 30 * time.Second,
@@ -2962,7 +3459,7 @@ func TestSendHeartbeatEdgeCases(t *testing.T) {
 			ErrorMaxCount:     100,
 		})
 
-		// Should return early because enabled is false
+		// The control plane remains active, but a nil client still makes this a no-op.
 		manager.sendHeartbeat()
 	})
 
@@ -3296,4 +3793,298 @@ func TestAggregateSnapshotsZeroRequestCount(t *testing.T) {
 	assert.NotNil(t, result.Aggregated.Metrics["Search"])
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].AvgLatencyMs)
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].P99LatencyMs)
+}
+
+// toProtoCommands converts local test fixtures into the proto form the production command
+// path consumes. Tests drive processProtoCommands/calculateProtoConfigHash through this so
+// they exercise the same code that runs against a real server, rather than a parallel
+// local-type implementation that can silently drift from it.
+func toProtoCommands(commands []*ClientCommand) []*commonpb.ClientCommand {
+	if commands == nil {
+		return nil
+	}
+	result := make([]*commonpb.ClientCommand, 0, len(commands))
+	for _, cmd := range commands {
+		result = append(result, &commonpb.ClientCommand{
+			CommandId:   cmd.CommandId,
+			CommandType: cmd.CommandType,
+			Payload:     cmd.Payload,
+			CreateTime:  cmd.CreateTime,
+			Persistent:  cmd.Persistent,
+			TargetScope: cmd.TargetScope,
+		})
+	}
+	return result
+}
+
+// drainPendingReplies returns the queued command replies and clears them, mirroring what a
+// successful heartbeat does, so assertions can be written against local types.
+func drainPendingReplies(m *ClientTelemetryManager) []*CommandReply {
+	protoReplies := m.getPendingProtoRepliesSnapshot()
+	m.clearPendingProtoReplies(len(protoReplies))
+
+	var result []*CommandReply
+	for _, r := range protoReplies {
+		result = append(result, &CommandReply{
+			CommandId:    r.GetCommandId(),
+			Success:      r.GetSuccess(),
+			ErrorMessage: r.GetErrorMessage(),
+			Payload:      r.GetPayload(),
+		})
+	}
+	return result
+}
+
+func TestTelemetryClientID(t *testing.T) {
+	t.Run("defaults to generated uuid", func(t *testing.T) {
+		m1 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		m2 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		assert.NotEmpty(t, m1.clientID)
+		assert.NotEqual(t, m1.clientID, m2.clientID)
+	})
+
+	t.Run("honors configured stable id", func(t *testing.T) {
+		cfg := DefaultTelemetryConfig()
+		cfg.ClientID = "milvus-worker-0"
+
+		m := NewClientTelemetryManager(nil, cfg)
+		assert.Equal(t, "milvus-worker-0", m.clientID)
+
+		// The heartbeat must carry it, that is what the server keys scoping on.
+		assert.Equal(t, "milvus-worker-0", m.buildClientInfo().GetReserved()["client_id"])
+	})
+}
+
+func TestMaxLatencyIsReported(t *testing.T) {
+	m := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+	m.handleCollectionMetrics(&ClientCommand{
+		CommandId:   "enable-all",
+		CommandType: "collection_metrics",
+		Payload:     []byte(`{"enabled": true, "collections": ["*"]}`),
+	})
+
+	start := time.Now().Add(-50 * time.Millisecond)
+	m.RecordOperation("Search", "coll-1", start, nil)
+
+	protoMetrics := m.toProtoOperationMetrics(m.collectMetrics())
+	assert.Len(t, protoMetrics, 1)
+
+	global := protoMetrics[0].GetGlobal()
+	assert.Greater(t, global.GetMaxLatencyMs(), float64(0), "max_latency_ms must reach the wire")
+	assert.GreaterOrEqual(t, global.GetMaxLatencyMs(), global.GetAvgLatencyMs())
+
+	collMetrics := protoMetrics[0].GetCollectionMetrics()["coll-1"]
+	assert.NotNil(t, collMetrics)
+	assert.Greater(t, collMetrics.GetMaxLatencyMs(), float64(0))
+}
+
+// TestHeartbeatAgainstUnimplementedServer covers a client talking to a Milvus that predates
+// ClientTelemetryService: the heartbeat can never succeed, so it must latch off instead of
+// firing forever on every interval.
+func TestHeartbeatAgainstUnimplementedServer(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	// Deliberately register no services: every RPC answers codes.Unimplemented.
+	svr := grpc.NewServer()
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		lis.Close()
+	}()
+
+	c, err := New(context.Background(), &ClientConfig{
+		Address:         "bufnet",
+		DisableConn:     true,
+		TelemetryConfig: &TelemetryConfig{Enabled: false},
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		},
+	})
+	require.NoError(t, err)
+	defer c.Close(context.Background())
+
+	m := NewClientTelemetryManager(c, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: 30 * time.Second,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	require.True(t, m.IsSupported())
+	require.NoError(t, m.LastHeartbeatError())
+
+	m.sendHeartbeat()
+
+	assert.False(t, m.IsSupported(), "Unimplemented must be visible")
+	assert.Error(t, m.LastHeartbeatError(), "the failure must be observable, not silently swallowed")
+
+	// Each further rejection backs off further, but never to the point of giving up.
+	before := m.nextHeartbeatDelay()
+	assert.Greater(t, before, 30*time.Second, "a rejection must widen the interval")
+	m.sendHeartbeat()
+	assert.Greater(t, m.nextHeartbeatDelay(), before, "repeated rejections must back off further")
+}
+
+// TestUnsupportedBacksOffAndRecovers is the rolling-upgrade case: a client is
+// load-balanced across proxies, so one heartbeat may reach an old proxy while the rest of
+// the cluster already serves the API. Treating that single answer as final would leave
+// telemetry off for the life of the client, long after the upgrade finished.
+func TestUnsupportedBacksOffAndRecovers(t *testing.T) {
+	m := NewClientTelemetryManager(nil, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: 30 * time.Second,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+
+	assert.Equal(t, 30*time.Second, m.nextHeartbeatDelay())
+
+	t.Run("backs off while rejected", func(t *testing.T) {
+		m.unsupportedStreak.Store(1)
+		assert.Equal(t, time.Minute, m.nextHeartbeatDelay())
+
+		m.unsupportedStreak.Store(3)
+		assert.Equal(t, 4*time.Minute, m.nextHeartbeatDelay())
+
+		assert.False(t, m.IsSupported())
+	})
+
+	t.Run("backoff is capped", func(t *testing.T) {
+		m.unsupportedStreak.Store(1000)
+		assert.Equal(t, maxUnsupportedBackoff, m.nextHeartbeatDelay(),
+			"an old cluster must cost almost nothing, but still be probed")
+	})
+
+	t.Run("a success restores the normal interval", func(t *testing.T) {
+		m.unsupportedStreak.Store(0)
+
+		assert.Equal(t, 30*time.Second, m.nextHeartbeatDelay())
+		assert.True(t, m.IsSupported(), "the client must recover once the cluster is upgraded")
+	})
+}
+
+// TestHeartbeatLoopKeepsProbingWhenUnsupported pins the behavior the previous latch got
+// wrong: the loop must stay alive so it can pick the service back up.
+func TestHeartbeatLoopKeepsProbingWhenUnsupported(t *testing.T) {
+	m := NewClientTelemetryManager(nil, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: 50 * time.Millisecond,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	m.unsupportedStreak.Store(2)
+	m.Start()
+
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("heartbeat loop exited instead of backing off; an upgraded cluster would never be noticed")
+	case <-time.After(300 * time.Millisecond):
+		// Still running, as it must be.
+	}
+
+	m.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("heartbeat loop did not stop on Stop()")
+	}
+}
+
+// TestUnsupportedStreakResetsOnAnyReply pins that the backoff clears as soon as the server
+// answers at all. Reaching a business status proves the method is implemented, so an
+// unhealthy-but-reachable server must not leave the client stuck at an interval inflated
+// by an earlier Unimplemented.
+func TestUnsupportedStreakResetsOnAnyReply(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	svr := grpc.NewServer()
+	milvuspb.RegisterClientTelemetryServiceServer(svr, &unhealthyTelemetryServer{})
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		lis.Close()
+	}()
+
+	c, err := New(context.Background(), &ClientConfig{
+		Address:         "bufnet",
+		DisableConn:     true,
+		TelemetryConfig: &TelemetryConfig{Enabled: false},
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		},
+	})
+	require.NoError(t, err)
+	defer c.Close(context.Background())
+
+	m := NewClientTelemetryManager(c, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: 30 * time.Second,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+
+	// Left over from an earlier heartbeat that landed on a stale proxy.
+	m.unsupportedStreak.Store(3)
+	require.Greater(t, m.nextHeartbeatDelay(), 30*time.Second)
+
+	m.sendHeartbeat()
+
+	assert.Equal(t, 30*time.Second, m.nextHeartbeatDelay(),
+		"a reachable server must clear the backoff even when it reports an error")
+	assert.True(t, m.IsSupported())
+	assert.Error(t, m.LastHeartbeatError(), "the unhealthy status is still reported")
+}
+
+// unhealthyTelemetryServer implements the service but reports a failure status, the way a
+// coordinator that is still starting up does.
+type unhealthyTelemetryServer struct {
+	milvuspb.UnimplementedClientTelemetryServiceServer
+}
+
+func (s *unhealthyTelemetryServer) ClientHeartbeat(context.Context, *milvuspb.ClientHeartbeatRequest) (*milvuspb.ClientHeartbeatResponse, error) {
+	return &milvuspb.ClientHeartbeatResponse{
+		Status: &commonpb.Status{Code: 1, Reason: "telemetry manager not initialized"},
+	}, nil
+}
+
+// TestSnapshotWindowTracksActualElapsedTime covers the window a snapshot claims to cover.
+//
+// Counters accumulate until they are collected, so the window has to be the time actually
+// covered. Deriving it as now - HeartbeatInterval assumes the loop ran on schedule, which
+// the Unimplemented backoff breaks: it can stretch a gap to 30 minutes while the configured
+// interval still says 30 seconds. Half an hour of traffic then gets labeled a 30 second
+// window, and every rate derived from it, plus any history query filtering on the range, is
+// wrong by that factor.
+func TestSnapshotWindowTracksActualElapsedTime(t *testing.T) {
+	cfg := DefaultTelemetryConfig()
+	cfg.HeartbeatInterval = time.Hour // deliberately nothing like the real gap below
+	m := NewClientTelemetryManager(nil, cfg)
+
+	m.createSnapshot()
+	time.Sleep(20 * time.Millisecond)
+	m.createSnapshot()
+
+	m.snapshotsMu.RLock()
+	snapshots := append([]*MetricsSnapshot(nil), m.snapshots...)
+	m.snapshotsMu.RUnlock()
+
+	require.Len(t, snapshots, 2)
+	first, second := snapshots[0], snapshots[1]
+
+	assert.Equal(t, first.EndTime, second.Timestamp,
+		"a window must start where the previous one ended, not one configured interval ago")
+	assert.LessOrEqual(t, second.EndTime-second.Timestamp, int64(5000),
+		"a 20ms gap must not be reported as an hour-long window")
+
+	// The first snapshot has no predecessor, so falling back to the configured interval is
+	// the only estimate available.
+	assert.Equal(t, cfg.HeartbeatInterval.Milliseconds(), first.EndTime-first.Timestamp)
 }

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -2,10 +2,17 @@
 
 - **Created:** 2026-01-31
 - **Author(s):** @xiaofanluan
-- **Status:** Draft
+- **Status:** Implemented
 - **Component:** SDK | Proxy | Coordinator
-- **Related Issues:** #46934
-- **Released:** [TBD]
+- **Related Issues:** #46934, #47281
+- **Implemented by:** #47523, #47542
+
+> This document was refreshed to match the implementation. Where the original draft
+> described interfaces that were never built (`set_sampling_rate`, `enable_collections`,
+> `update_config`, `NewConfigHash`), those sections have been
+> replaced with what the code actually does. Source of truth is
+> `internal/rootcoord/telemetry/`, `internal/proxy/telemetry_*.go` and
+> `client/milvusclient/telemetry.go`.
 
 ## Summary
 
@@ -32,10 +39,11 @@ This feature addresses these gaps by implementing a comprehensive client telemet
 ```go
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
-    Enabled           bool          // Enable/disable telemetry collection
-    HeartbeatInterval time.Duration // Heartbeat frequency (default: 30s)
+    Enabled           bool          // Enable/disable telemetry collection (default: true)
+    HeartbeatInterval time.Duration // Heartbeat frequency (default: 10s)
     SamplingRate      float64       // Sampling rate 0.0-1.0 (default: 1.0)
     ErrorMaxCount     int           // Max errors to track (default: 100)
+    ClientID          string        // Optional stable identity across process restarts
 }
 
 // ClientConfig gains a new field
@@ -45,19 +53,56 @@ type ClientConfig struct {
 }
 ```
 
+**Telemetry is on by default and must be turned off explicitly.** `New()` always constructs
+and starts the manager; a nil `TelemetryConfig` is replaced by `DefaultTelemetryConfig()`,
+which returns `Enabled: true` with a 10s heartbeat and 100% sampling. A caller who never
+mentions `TelemetryConfig` therefore still reports heartbeats and metrics to the server. To
+disable it:
+
+```go
+client.New(ctx, &client.ClientConfig{
+    Address:         "localhost:19530",
+    TelemetryConfig: &milvusclient.TelemetryConfig{Enabled: false},
+})
+```
+
+An initial `Enabled: false` is an explicit opt-out and starts no heartbeat worker. If an
+already-running client is disabled later by a server `push_config`, operation collection and
+metric payloads stop, but the lightweight command heartbeat remains active so the disable
+reply is acknowledged and a later re-enable can be received.
+
 ### HTTP REST APIs (Proxy)
 
+Served on the internal HTTP port (`9091` by default), not on the gRPC port.
+
 ```
-GET  /api/v1/telemetry/clients          - List connected clients with optional filtering
-POST /api/v1/telemetry/commands         - Push commands to clients
-DELETE /api/v1/telemetry/commands/{id}  - Delete a command
+GET    /api/v1/_telemetry/clients                    - List connected clients
+GET    /api/v1/_telemetry/clients/{clientId}         - Metrics for one client
+GET    /api/v1/_telemetry/clients/{clientId}/config  - Ask a client for its config
+GET    /api/v1/_telemetry/clients/{clientId}/history - Ask a client for latency history
+POST   /api/v1/_telemetry/commands                   - Push a command to clients
+GET    /api/v1/_telemetry/commands/{commandId}/reply - Fetch a client's reply to a command
+DELETE /api/v1/_telemetry/commands/{commandId}       - Delete a command
+GET    /webui/telemetry.html                         - WebUI dashboard
 ```
 
-### gRPC APIs (RootCoord)
+The path constants in `internal/http/router.go` are relative: `RegisterRestRouter` is
+mounted on the `/api/v1` group in `internal/distributed/proxy/service.go`, so the served
+paths carry that prefix. Verified against a running standalone.
+
+`internal/http/router.go` also declares `TelemetryUIPath = "/telemetry"` and registers a
+handler for it, but that route returns 404 on a running server; the dashboard is reachable
+only as `/webui/telemetry.html`.
+
+### gRPC APIs
+
+The RPCs live in their own service, `ClientTelemetryService`, registered on the Proxy's
+**external** gRPC server. Proxy forwards to MixCoord, which forwards to RootCoord, where
+`TelemetryManager` holds the state.
 
 ```protobuf
-service RootCoord {
-    // Client heartbeat with metrics
+service ClientTelemetryService {
+    // Client heartbeat with metrics; response carries pending commands
     rpc ClientHeartbeat(ClientHeartbeatRequest) returns (ClientHeartbeatResponse);
 
     // Query connected clients
@@ -71,6 +116,11 @@ service RootCoord {
 }
 ```
 
+`ClientHeartbeat` carries no `privilege_ext_obj` annotation, so the privilege interceptor
+short-circuits for it and only normal authentication applies. The REST endpoints are
+guarded by `TelemetryAuthMiddleware`, which is Basic Auth only -- there is no RBAC
+privilege check on this surface.
+
 ## Design Details
 
 ### Architecture Overview
@@ -83,13 +133,13 @@ service RootCoord {
 │  │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐       │  │
 │  │  │ Operation       │  │ Error           │  │ Command         │       │  │
 │  │  │ Metrics         │  │ Collector       │  │ Handler         │       │  │
-│  │  │ Collector       │  │ (Ring Buffer)   │  │ Router          │       │  │
+│  │  │ Collector       │  │ (Ring Buffer)   │  │ Registry        │       │  │
 │  │  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘       │  │
 │  │           │                    │                    │                 │  │
 │  │           └────────────────────┼────────────────────┘                 │  │
 │  │                                ▼                                       │  │
 │  │                    ┌───────────────────────┐                          │  │
-│  │                    │   Heartbeat Loop      │───────── 30s interval    │  │
+│  │                    │   Heartbeat Loop      │───────── 10s default     │  │
 │  │                    │   (Background)        │                          │  │
 │  │                    └───────────┬───────────┘                          │  │
 │  └────────────────────────────────┼──────────────────────────────────────┘  │
@@ -104,12 +154,15 @@ service RootCoord {
 │  │     Proxy      │◄────────►│              RootCoord                     │  │
 │  │                │          │  ┌─────────────────────────────────────┐  │  │
 │  │  HTTP API      │          │  │      Telemetry Manager              │  │  │
-│  │  /telemetry/*  │          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
+│  │ /api/v1/_tel..│          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
 │  │                │          │  │  │ Client    │  │ Command       │   │  │  │
-│  │  WebUI         │          │  │  │ Store     │  │ Store         │   │  │  │
-│  │  telemetry.html│          │  │  └───────────┘  └───────────────┘   │  │  │
-│  └────────────────┘          │  └─────────────────────────────────────┘  │  │
-│                              └───────────────────────────────────────────┘  │
+│  │  WebUI         │          │  │  │ Cache     │  │ Store         │   │  │  │
+│  │  telemetry.html│          │  │  └───────────┘  └──────┬────────┘   │  │  │
+│  └────────────────┘          │  └────────────────────────┼────────────┘  │  │
+│                              └───────────────────────────┼───────────────┘  │
+│                                                          ▼                   │
+│                                            etcd: /client-telemetry/configs/  │
+│                                            (persistent configs only)         │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -121,24 +174,36 @@ The central component managing telemetry collection and heartbeat communication.
 
 ```go
 type ClientTelemetryManager struct {
-    config         *TelemetryConfig
-    client         *Client
-    clientID       string                              // Stable UUID
-    collectors     map[string]*OperationMetricsCollector
-    errorCollector *ErrorCollectorImpl
+    config          *TelemetryConfig
+    client          *Client
+    clientID        string                              // UUID, see below
+    collectors      map[string]*OperationMetricsCollector
+    errorCollector  *ErrorCollectorImpl
     commandHandlers map[string]CommandHandler
 
+    // Deduplication and change detection
+    configHash           string
+    lastCommandTimestamp atomic.Int64
+    executedCommands     map[string]int64
+
     // Heartbeat management
-    stopCh         chan struct{}
-    wg             sync.WaitGroup
+    stopCh chan struct{}
+    wg     sync.WaitGroup
 }
 ```
 
 **Key behaviors:**
-- Generates stable client UUID on creation
+- Generates a client UUID on creation unless `TelemetryConfig.ClientID` pins a stable value.
+  The resolved ID is stable for the lifetime of the `Client` and across gRPC reconnects. It
+  survives a process restart only when the caller supplies `ClientID`.
 - Starts background heartbeat loop on `Start()`
 - Sends first heartbeat immediately, then every `HeartbeatInterval`
+- Uses `time.After` per iteration rather than a `time.Ticker`, so a server-pushed interval
+  change takes effect on the next cycle
 - Collects and resets metrics atomically during snapshot creation
+
+**Instrumented operations (7):** `Search`, `Query`, `HybridSearch`, `RunAnalyzer`,
+`Insert`, `Delete`, `Upsert`. DDL, index and partition operations are not instrumented.
 
 #### 2. OperationMetricsCollector
 
@@ -162,12 +227,15 @@ type OperationMetricsCollector struct {
 }
 ```
 
-**Metrics tracked:**
-- Request count
-- Success/error counts
-- Average latency (ms)
-- P99 latency (ms) - calculated from 1000 sample buffer
-- Max latency (ms)
+**Metrics tracked:** request count, success/error counts, average latency (ms), P99 latency
+(ms, from the 1000-sample buffer), max latency (ms).
+
+P99 is computed inside the locked snapshot, *before* the sample buffer is reset, so a
+concurrent heartbeat cannot read a cleared buffer. `totalSamples` is tracked separately
+from the buffer index so a genuine 0µs latency is distinguishable from an unwritten slot.
+
+Per-collection metrics are **off by default** and enabled by the `collection_metrics`
+command.
 
 #### 3. ErrorCollectorImpl
 
@@ -181,11 +249,11 @@ type ErrorCollectorImpl struct {
 }
 
 type ErrorInfo struct {
-    Timestamp  int64
-    Operation  string
-    ErrorMsg   string
-    Collection string
-    RequestID  string
+    Timestamp  int64  `json:"timestamp"`             // Unix ms
+    Operation  string `json:"operation"`
+    ErrorMsg   string `json:"error_msg"`
+    Collection string `json:"collection,omitempty"`
+    RequestID  string `json:"request_id,omitempty"`
 }
 ```
 
@@ -194,52 +262,180 @@ type ErrorInfo struct {
 Supports server-pushed commands with extensible handler registration.
 
 ```go
-type CommandHandler func(cmd *ClientCommand) string  // Returns error message or ""
-
-// Built-in commands:
-const (
-    CmdSetSamplingRate   = "set_sampling_rate"        // Adjust sampling rate
-    CmdEnableCollections = "enable_collections"       // Enable specific collections
-    CmdUpdateConfig      = "update_config"            // Update telemetry config
-)
+type CommandHandler func(cmd *ClientCommand) *CommandReply
 ```
+
+**Command types.** These five strings are the complete set. `command_type` is a free-form
+string on the wire and the server does not validate it on push, so an unknown type reaches
+the client and is answered with `"unknown command type: <type>"`.
+
+| Type | Purpose | May be persistent |
+|------|---------|-------------------|
+| `push_config` | Change client telemetry settings | **Yes (the only one)** |
+| `collection_metrics` | Enable/disable per-collection metrics | No |
+| `show_errors` | Return the last N client-side errors | No |
+| `show_latency_history` | Return client metric snapshots for a time window | No |
+| `get_config` | Return the client's current effective config | No |
+
+`command_store.go` rejects `persistent=true` for anything other than `push_config`.
+Custom handlers execute on the heartbeat goroutine. A handler panic is recovered and turned
+into a failed command reply so it cannot terminate the process or stop later heartbeats.
+
+**Payload schemas.** `ClientCommand.payload` is raw JSON (not protobuf).
+
+```go
+// push_config
+type PushConfigPayload struct {
+    Enabled             *bool    `json:"enabled,omitempty"`
+    HeartbeatIntervalMs *int64   `json:"heartbeat_interval_ms,omitempty"`
+    SamplingRate        *float64 `json:"sampling_rate,omitempty"`   // 0.0-1.0
+    TTLSeconds          int64    `json:"ttl_seconds,omitempty"`
+}
+
+// collection_metrics -- "*" in Collections is the all-collections wildcard
+type CollectionMetricsPayload struct {
+    Collections  []string `json:"collections"`
+    Enabled      bool     `json:"enabled"`
+    MetricsTypes []string `json:"metrics_types,omitempty"`
+}
+
+// show_errors
+type ErrorMessagesPayload struct {
+    MaxCount int `json:"max_count,omitempty"`   // default 100
+}
+
+// show_latency_history -- RFC3339 timestamps, window must be <= 1 hour
+type LatencyHistoryPayload struct {
+    StartTime string `json:"start_time"`
+    EndTime   string `json:"end_time"`
+    Detail    bool   `json:"detail"`
+}
+
+// get_config -- no payload
+```
+
+Reply payloads are capped at 1 MB client-side; `show_errors` halves the returned count
+until it fits. `get_config` deliberately omits `Password` and `APIKey`.
+
+Latency snapshots are retained by timestamp for one hour, independent of the dynamically
+configured heartbeat interval. A 4096-snapshot hard cap is the final memory bound for
+sub-second intervals. The previous fixed 120-snapshot cap represented one hour only at the
+obsolete 30-second default and retained just 20 minutes at the current 10-second default.
+Each operation/window also retains an internal 128-point, evenly spaced quantile sketch
+from the collector's recent sample ring. Aggregated history merges those weighted samples
+and computes P99 from the combined distribution; averaging the P99 values of individual
+windows is mathematically invalid. The sketch is internal and is not added to heartbeat or
+detail-mode response payloads.
 
 ### Server-Side Components
 
 #### 1. Telemetry Manager (RootCoord)
 
-Central server-side storage for client telemetry data.
+Central server-side storage for client telemetry data. Client state is held in a
+`sync.Map` keyed by client ID.
 
 ```go
-type TelemetryManager struct {
-    clients      map[string]*ClientTelemetry  // clientID -> telemetry
-    commandStore *CommandStore
-}
-
-type ClientTelemetry struct {
+type ClientMetricsCache struct {
     ClientInfo        *commonpb.ClientInfo
     LastHeartbeatTime int64
-    Status            string  // "active" or "inactive"
-    Databases         []string
-    Metrics           []*commonpb.OperationMetrics
+    Status            string       // "active" or "inactive"
+    AccessedDatabases sync.Map     // accumulative, never pruned
+    LatestMetrics     []*commonpb.OperationMetrics
+    CommandReplies    []*StoredCommandReply   // last 50
+    LastCommandTS     int64
 }
 ```
+
+**Client identity.** The manager reads `ClientInfo.Reserved["client_id"]`. When absent it
+falls back to `legacy:<host>:<hash(sdkType|sdkVersion|host|user)>`, in which case two
+processes on the same host with the same SDK and user **collide into one entry** and
+`client:` scoping becomes unusable. Database association comes from
+`Reserved["db_name"]` (or `Reserved["database"]`).
+
+**Hardcoded limits.** There are no `milvus.yaml` or paramtable keys for this feature;
+`DefaultTelemetryConfig()` in `manager.go` is never overridden in production:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `ClientStatusThreshold` | 1 min | No heartbeat for this long → `Status: "inactive"` |
+| `InactiveClientThreshold` | 10 min | No heartbeat for this long → evicted from memory |
+| `CleanupInterval` | 1 min | Sweep cadence for expired commands and dead clients |
+| `MaxClientsInMemory` | 100000 | Then LRU eviction by last heartbeat |
+| `MaxMetricsPerClient` | 1 MB | Larger payloads are truncated (see below) |
+| `MaxOperationTypesPerClient` | 100 | Operation list truncated to this many |
+
+**Metrics ingest guards.** On each heartbeat the server drops every `CollectionMetrics`
+entry whose `RequestCount == 0`, truncates the operation list to 100, and if the message
+still exceeds 1 MB, first nulls all `CollectionMetrics`, then truncates further.
 
 #### 2. Command Store
 
-Manages pending commands for clients with support for persistent and one-time commands.
+Manages pending commands, with different storage for the two kinds:
 
-```go
-type CommandStore struct {
-    commands     []*commonpb.ClientCommand  // One-time commands
-    persistent   []*commonpb.ClientCommand  // Persistent commands
-}
-```
+- **Persistent (`push_config` only)** → written to etcd under `/client-telemetry/configs/`.
+  Survives RootCoord restart. Deduplicated by `(ConfigType, TargetScope)`: pushing a second
+  config for the same scope **JSON-merges** the new payload over the old one and deletes the
+  superseded entry, so partial updates accumulate rather than replace.
+- **One-time** → in-memory on the RootCoord that received the push. Lost on restart and
+  **not shared across coordinator replicas**.
 
-**Command targeting:**
-- `TargetScope = "*"` - All clients
-- `TargetScope = "client_id:xxx"` - Specific client
-- `TargetScope = "db:database_name"` - Clients using specific database
+**Command targeting** (`TargetScope`, built server-side from the push request):
+
+- `global` — all clients
+- `client:<clientID>` — one client, exact match
+- `database:<dbName>` — clients that have accessed that database
+
+**Persistent configs and client scope.** A persistent config is keyed by target scope, so
+a `client:` config keeps applying only for as long as the target keeps its ID. By default
+the SDK generates a fresh UUID per process, so such a config would silently stop applying
+after a restart while remaining in etcd. It is therefore rejected unless the target client
+is currently connected *and* reports `Reserved["client_id_stable"] = "true"`, which the Go
+SDK sets when the caller pinned `TelemetryConfig.ClientID`.
+
+The decision is made on the identity the client declares, not on the scope: a pinned ID
+does survive restarts, and a config aimed at one is legitimate. For the same reason,
+existing client-scoped configs are loaded normally at startup and never deleted
+automatically — retire them with `DeleteClientCommand`.
+
+**TTL.** `ttl_seconds` is a field of `PushClientCommandRequest`, not of `ClientCommand`, so
+clients never see it.
+
+| `ttl_seconds` | Meaning at the RPC / store |
+|---------------|---------------------------|
+| absent | Same as `0` — no expiry. The store applies no default. |
+| `0` | Never expires (every expiry check treats `<= 0` as immortal) |
+| `> 0` | Expires that many seconds after the push |
+| `< 0` | Never expires |
+
+**The one-hour default is applied by the HTTP layer, not the store**, and marking the field
+`optional` does not change that. Presence only helps senders that know about it: proto3
+implicit presence means a client built against the older definition emits *nothing* for an
+explicit `0`, so the server receives it as absent and cannot tell that deliberate "never
+expire" apart from "unspecified". Defaulting on absence would silently give every such
+client a one-hour expiry with no way to ask for the old behavior back.
+
+`POST /_telemetry/commands` decodes `ttl_seconds` into a pointer, so it genuinely can see
+the difference: omit the field and you get 3600, send `0` and you get no expiry. It then
+sends an explicit value onward, so the store never has to guess.
+
+That default is a **bound on how long an unanswered command occupies memory, not a delivery
+window**. It deliberately does not encode "N heartbeat cycles": `HeartbeatInterval` is
+client-side config with no upper bound, the server is never told what it is, and clients
+matched by one scope may use different values. A default expressed in cycles would expire
+before a client on a long interval ever got a chance to read the command.
+
+Without any default, a command that no client ever collects stays in RootCoord memory for
+the life of the process.
+
+Persistent configs ignore TTL entirely.
+
+**Do not combine a broadcast scope with `ttl_seconds: 0`.** A `global` or `database:` command
+is removed only by its TTL, and until then it is still handed to clients that connect later.
+With no expiry it never goes away and every new client keeps executing it.
+
+A reply reclaims a command only when the command named a single client — see
+[Replies](#replies). A broadcast command is answered by many clients, so for it the TTL is
+the only thing that ever removes it.
 
 #### 3. HTTP Handlers (Proxy)
 
@@ -247,13 +443,100 @@ REST API endpoints for WebUI and external integrations.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/telemetry/clients` | GET | List connected clients |
-| `/api/v1/telemetry/clients?database=X` | GET | Filter by database |
-| `/api/v1/telemetry/clients?include_metrics=true` | GET | Include operation metrics |
-| `/api/v1/telemetry/commands` | POST | Push command to clients |
-| `/api/v1/telemetry/commands/{id}` | DELETE | Remove a command |
+| `/api/v1/_telemetry/clients` | GET | List clients; `?database=`, `?client_id=`, `?include_metrics=` |
+| `/api/v1/_telemetry/clients/{clientId}` | GET | Metrics for one client |
+| `/api/v1/_telemetry/clients/{clientId}/config` | GET | Push `get_config`; returns a command ID |
+| `/api/v1/_telemetry/clients/{clientId}/history` | GET | Push `show_latency_history`; `?start_time=`, `?end_time=`, `?detail=` |
+| `/api/v1/_telemetry/commands` | POST | Push an arbitrary command |
+| `/api/v1/_telemetry/commands/{commandId}/reply` | GET | Fetch a client's reply; `?client_id=` |
+| `/api/v1/_telemetry/commands/{commandId}` | DELETE | Remove a command |
 
-**Authentication:** Uses existing Milvus Basic Auth when authorization is enabled.
+**Authentication:** Basic Auth via `TelemetryAuthMiddleware`, active only when
+`common.security.authorizationEnabled` is set. No RBAC.
+
+**Asynchrony.** Commands are answered on the client's next heartbeat, so any endpoint that
+pulls data from a client is inherently asynchronous. `/config`, `/history` and the
+command-reply endpoint share one response shape:
+
+```json
+{
+  "command_id": "...",
+  "status": "pending" | "done",
+  "responded": 2,
+  "observed_clients": 3,
+  "replies": [ {"client_id": "...", "reply": { ... }} ],
+  "client_id": "...",
+  "reply": { ... }
+}
+```
+
+Callers branch on `status` and read `replies` when it is `done`. `pending` is returned with
+HTTP 200, not an error: a reply that has not arrived is indistinguishable from one that
+never will, since replies are also evicted once a client accumulates more than 50.
+
+**One command can have many answers.** A command with neither `target_client_id` nor
+`target_database` is stored with scope `global` and delivered to *every* connected client,
+each of which answers under the same command ID. So `replies` is always an array, one entry
+per answering client, and each entry carries the `client_id` it came from — otherwise an
+operator reads one arbitrary client's data as the cluster's. Entries are ordered by client
+ID so a repeated request is stable; the underlying iteration is over a `sync.Map`, whose
+order is unspecified.
+
+A broadcast command is **not** deleted when the first client answers. It is delivered to
+every matching client, each replying on its own heartbeat, so retiring it on the first reply
+would let whichever client heartbeats soonest cancel delivery to the rest — with clients on
+a 30s and a 5min interval, the slow one would never see the command at all. Only
+`client:`-scoped commands, which have exactly one recipient, are removed on reply; `global`
+and `database:` ones live until their TTL. Clients skip commands older than their
+`last_command_timestamp` watermark, so retention does not cause re-execution — but a client
+that connects during the TTL window does execute the command, which is what you want for a
+fleet-wide state change and merely noisy for a one-off query.
+
+`responded` and `observed_clients` are **observations, not a progress bar**.
+`observed_clients` counts what the lookup scanned, not what the command targeted: the scan
+covers every cached client regardless of the command's scope, includes clients that have
+gone inactive or connected after the push, and its membership changes between polls. The
+server does not record who a broadcast command was delivered to, so neither number
+establishes completeness. Re-querying later returns everything accumulated so far.
+
+`reply` and `client_id` repeat the first entry. They are the whole answer for a
+client-scoped command — which `/config` and `/history` always are — and anything reading a
+broadcast command must use `replies`.
+
+**Collecting a result is always deferred.** Push the command, keep the returned
+`command_id`, and read it later from `/api/v1/_telemetry/commands/{commandId}/reply`.
+Passing `?client_id=` makes that a lookup of one client instead of a scan of every cached
+one, and is strongly preferred.
+
+There is deliberately **no server-side blocking mode**. An earlier revision of this work
+offered `?wait=`, which polled RootCoord on the caller's behalf; it was removed because the
+cost multiplies in a way the caller cannot see:
+
+- Every lookup carries each matching client's **entire** stored reply history — up to 50
+  replies — because `command_replies` is encoded into `ClientInfo.Reserved` regardless of
+  `IncludeMetrics`, and the proxy filters by command ID only after decoding.
+- Reply payloads are bounded at 1MiB only for the **built-in** handlers. A reply from a
+  handler registered through `RegisterCommandHandler` has no size limit at all.
+- Without `client_id` the scan covers the whole fleet, so the per-lookup cost scales with
+  the number of connected clients.
+- `common.security.authorizationEnabled` defaults to **false**, and
+  `TelemetryAuthMiddleware` passes every request straight through when it is off — so the
+  endpoint is unauthenticated by default.
+
+A blocking mode turns one unauthenticated HTTP request into dozens of full-history
+transfers inside the cluster. A caller that wants to wait polls the endpoint on its own
+schedule instead, which keeps one request to one internal query and puts the cost where it
+is visible.
+
+`GetClientTelemetryRequest.command_id`
+([milvus-io/milvus-proto#647](https://github.com/milvus-io/milvus-proto/pull/647)) would let
+the server return just the requested reply and remove the per-lookup amplification
+entirely. This repo pins a milvus-proto that predates it; using it is a follow-up gated on a
+proto bump, and a blocking mode should only be reconsidered once it is in place.
+
+Replies are also visible in the `command_replies` array of `GET /api/v1/_telemetry/clients`,
+which is how the WebUI polls; on the wire they are JSON-encoded into
+`ClientInfo.Reserved["command_replies"]` rather than carried in a dedicated proto field.
 
 ### Heartbeat Protocol
 
@@ -264,40 +547,109 @@ Client                                      Server
    │     - ClientInfo (ID, SDK version, host)  │
    │     - Metrics (per-operation, per-coll)   │
    │     - CommandReplies                      │
-   │     - ConfigHash (for change detection)   │
+   │     - ConfigHash                          │
+   │     - LastCommandTimestamp                │
    │                                           │
    │◄─── ClientHeartbeatResponse ─────────────│
+   │     - ServerTimestamp                     │
    │     - Commands (pending for this client)  │
-   │     - NewConfigHash (if config changed)   │
    │                                           │
 ```
 
-**Heartbeat interval:** 30 seconds (configurable, server can override)
+**Heartbeat interval:** 10 seconds (client default; the server can change it via
+`push_config`).
 
-**Config hash:** SHA-256 of client configuration, used to detect when server pushes new config.
+**`report_timestamp`** is accepted but ignored — the server uses its own clock for
+`LastHeartbeat` and `server_timestamp`.
+
+#### Config hash
+
+Used to avoid re-sending persistent configs on every heartbeat. Both sides must compute it
+identically or configs are re-pushed forever.
+
+```
+if no configs:            hash = ""
+else:                     sort configs by ID ascending
+                          h = sha256()
+                          for each: h.write(ID); h.write(Type); h.write(Payload)
+                          hash = hex(h.sum())[:16]      // first 16 hex chars
+```
+
+The server computes it over the configs **already filtered to this client's scope**, and
+sends persistent configs only when `request.ConfigHash != serverHash`. The response has no
+"new hash" field — the client recomputes it locally after processing commands.
+
+#### Command delivery and deduplication
+
+One-time commands are returned only when `command.CreateTime > request.LastCommandTimestamp`
+(strict). The client advances `LastCommandTimestamp` to the maximum `CreateTime` it has
+seen, **after** processing the whole batch, so a mid-batch crash re-fetches.
+
+Consequence: a one-time command is delivered **once**. It is not redelivered if the client
+fails to execute it, because the client has already advanced its watermark past it.
+
+> **Known defect: a millisecond-granularity watermark loses commands.**
+>
+> The cursor is a millisecond timestamp and the comparison is strict, so a command created
+> in the *same millisecond* as one the client has already processed is filtered out of every
+> subsequent heartbeat and is never delivered. It survives only until its TTL and then
+> disappears, with no error to the pusher and no record on the client.
+>
+> Relaxing the comparison to `>=` does not fix it: the client prunes its executed-ID set at
+> the watermark, so commands at exactly that timestamp would eventually be re-executed
+> instead. A correct fix needs a cursor that is unique per command — a strictly monotonic
+> sequence number, or a `(timestamp, command_id)` pair compared lexicographically — which is
+> a protocol change on both sides.
+>
+> This is pre-existing, not introduced by the client-telemetry audit, and is tracked in
+> [#51963](https://github.com/milvus-io/milvus/issues/51963). It is recorded here because an
+> earlier revision of this document described the watermark as already correct; it is not.
+
+#### Replies
+
+A reply with a non-empty `command_id` — **whether or not `success` is true** — reclaims the
+corresponding non-persistent command server-side, but **only when that command was scoped to
+a single client** (`client:<id>`). There the reply is the whole answer, so the command is
+finished.
+
+A `global` or `database:` command is delivered to every matching client and answered by each
+on its own heartbeat. Deleting it on the first reply would let whichever client heartbeats
+soonest cancel delivery to all the others — with clients on a 30s and a 5min interval, the
+slow one would never receive it at all. Those commands are removed only by their TTL.
+
+So: replies are the fast path for reclaiming a **client-scoped** command; the TTL is the
+backstop for client-scoped commands nobody answers, and the *only* mechanism for broadcast
+ones.
+
+The client queues replies and clears them **only after a successful heartbeat**, so replies
+survive a failed heartbeat and are retried on the next one. Commands already executed still
+receive an idempotent success ACK.
+
+Persistent configs are never deleted by a reply; they are removed only via
+`DeleteClientCommand`, and are suppressed on the wire whenever `config_hash` matches.
 
 ### Data Flow
 
 1. **Metrics Collection:**
-   - Each SDK operation (Search, Insert, Query, etc.) records metrics
-   - Sampling rate determines if operation is tracked (default: 100%)
-   - Metrics stored in per-operation collectors
+   - Each instrumented SDK operation records into a per-operation collector
+   - Sampling rate determines whether an operation is tracked (default 100%)
 
 2. **Heartbeat Cycle:**
-   - Background goroutine wakes every 30 seconds
-   - Creates atomic snapshot of all metrics (resets counters)
-   - Sends snapshot to RootCoord via ClientHeartbeat RPC
+   - Background goroutine sends immediately on start, then every `HeartbeatInterval`
+   - Creates an atomic snapshot of all metrics (resetting counters, computing P99)
+   - Sends the snapshot, pending replies, config hash and watermark
    - Receives and processes any pending commands
 
 3. **Command Processing:**
-   - Server pushes commands via heartbeat response
-   - Client executes command handler
-   - Reply sent in next heartbeat request
-   - Persistent commands re-sent until explicitly deleted
+   - Server returns commands in the heartbeat response
+   - Client dispatches to the registered handler for that type
+   - A custom-handler panic becomes a failed reply; later commands and heartbeats continue
+   - Reply is queued and sent with the next heartbeat
+   - Persistent configs are re-sent only when the client's `config_hash` disagrees
 
 ### WebUI Dashboard
 
-A new telemetry dashboard (`/webui/telemetry.html`) provides:
+A telemetry dashboard served at `/webui/telemetry.html` provides:
 
 - **Client List:** Active/inactive clients with connection details
 - **Metrics View:** Per-client operation metrics with latency charts
@@ -306,20 +658,51 @@ A new telemetry dashboard (`/webui/telemetry.html`) provides:
 
 ## Compatibility, Deprecation, and Migration Plan
 
-- **Backward Compatible:** Telemetry is opt-in and disabled by default can be enabled
-- **No Breaking Changes:** Existing SDK usage remains unchanged
-- **Server Compatibility:** Old clients work with new servers (no heartbeats sent)
-- **Client Compatibility:** New clients work with old servers (heartbeats fail silently)
+- **Backward Compatible:** No wire or API breaking changes, and no proto change at all —
+  this work runs entirely on the existing RPC surface.
+- **No Breaking Changes:** Existing SDK usage remains unchanged.
+- **Server Compatibility:** Old clients simply never heartbeat; they appear only through
+  their `Connect` call, not in telemetry.
+- **Client Compatibility:** Against a server without `ClientTelemetryService`, the heartbeat
+  fails with `codes.Unimplemented`. The client does **not** switch telemetry off. It backs
+  off exponentially — doubling the heartbeat interval per consecutive rejection, capped at
+  30 minutes, never shortening below the configured interval — and keeps probing. The
+  streak resets on the first reply, so the client recovers on its own once the cluster is
+  upgraded.
+
+  Latching off would be wrong here: a client load-balances across proxies, so during a
+  rolling upgrade one heartbeat can land on an old proxy while the rest of the cluster
+  already supports the service, and a client that gave up would stay dark until restarted.
+  Backing off makes talking to a genuinely old cluster cost roughly nothing while keeping
+  recovery automatic.
+
+  Because telemetry is best-effort and the `client/` module carries no logger, the failure
+  is not raised through the normal API. `ClientTelemetryManager.IsSupported()` reports
+  whether the server is currently known *not* to implement the service — it is optimistic,
+  returning true before the first heartbeat, so pair it with `LastHeartbeatError()` to tell
+  "no evidence of an old server" from "confirmed working".
+
+## Implementation Status
+
+Client-side telemetry is implemented in the **Go SDK only**. pymilvus, the Java, Node.js and
+Rust SDKs do not implement the client half; the generated protobuf stubs exist for some of
+them but are unused. Any operator-facing claim about client coverage should be read as
+"Go SDK clients only".
+
+Server-side components are complete. Two pieces of the original design are present but not
+wired into the live path: `CommandRouter` validates payload shapes but is never invoked from
+`HandleHeartbeat`, and `PushCommand` does not validate `command_type` against it.
 
 ## Test Plan
 
 ### Unit Tests
-- `telemetry_test.go`: Metrics collection, P99 calculation, ring buffer
-- `telemetry_http_handler_test.go`: HTTP API handlers
-- `command_router_test.go`: Command routing and handling
+- `client/milvusclient/telemetry_test.go`: metrics collection, P99, ring buffer,
+  command dispatch, config hash
+- `internal/proxy/telemetry_http_handler_test.go`: HTTP API handlers
+- `internal/rootcoord/telemetry/*_test.go`: manager, command store, scope matching
 
 ### Integration Tests
-- `telemetry_integration_test.go`: End-to-end heartbeat flow
+- `client/milvusclient/telemetry_integration_test.go`: end-to-end heartbeat flow
 - Multi-client scenarios with different configurations
 - Command push and execution verification
 
@@ -344,6 +727,8 @@ Server polls clients for metrics.
 
 ## References
 
-- Milvus existing telemetry: `internal/proxy/impl.go`
+- Server implementation: `internal/rootcoord/telemetry/`
+- Proxy HTTP layer: `internal/proxy/telemetry_http_handler.go`, `telemetry_models.go`
+- Go SDK client: `client/milvusclient/telemetry.go`
 - gRPC health checking: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 - OpenTelemetry SDK patterns: https://opentelemetry.io/docs/instrumentation/go/


### PR DESCRIPTION
Backport the remaining Go SDK client changes from master to the 3.0 branch in preparation for the client v3.0.0 release. The 3.0 server already supports every feature these changes rely on; only the client module is touched (plus the client-side telemetry design doc).

What changed:

- Add FunctionScore support to SearchOption and HybridSearchOption via WithFunctionScore, carrying both scoring functions and score-option params (boost_mode / function_mode) that were previously inexpressible.
- Add the index types the Go client was missing (HNSW SQ/PQ/PRQ, AISAQ, NGRAM) and preserve the described generic index type so Params() and IndexType() cannot disagree.
- Harden client telemetry: trustworthy windows/quantiles, fractional sampling that never rounds a positive rate to off, idempotent command cursor, panic-safe command handlers, bounded history, config reply detail, and opt-in client_request_id correlation.
- Bump the SDK version to 3.0.0.

Backports (master PRs): #52095/#52098 index types, #52153 generic index type, #53359 FunctionScore, #51967/#52597/#52804 telemetry.