### PR TITLE
fix: [3.0] keep installed C++ debug info self-contained

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -84,19 +84,6 @@ endif ()
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( Utils )
 
-# ---- Split DWARF (Linux only) ----
-# Moves debug info into .dwo files, dramatically reducing .o file sizes
-# and link time. Requires GCC 4.8+ or Clang 3.7+.
-if (LINUX AND NOT USE_ASAN STREQUAL "ON")
-    check_cxx_compiler_flag("-gsplit-dwarf" HAS_SPLIT_DWARF)
-    if (HAS_SPLIT_DWARF)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gsplit-dwarf")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gsplit-dwarf")
-        message(STATUS "Using -gsplit-dwarf for faster linking")
-    endif ()
-endif ()
-
-
 # **************************** Build time, type and code version ****************************
 get_current_time( BUILD_TIME )
 message( STATUS "Build time = ${BUILD_TIME}" )
@@ -201,6 +188,18 @@ find_package(Azure REQUIRED)
 include( CTest )
 include( BuildUtils )
 include( DefineOptions )
+
+# ---- Split DWARF (Linux only) ----
+# Keep this opt-in: .dwo files stay in the build tree and are not included in
+# installed artifacts or the published debug image by default.
+if (LINUX AND MILVUS_USE_SPLIT_DWARF AND NOT USE_ASAN STREQUAL "ON")
+    check_cxx_compiler_flag("-gsplit-dwarf" HAS_SPLIT_DWARF)
+    if (HAS_SPLIT_DWARF)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gsplit-dwarf")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gsplit-dwarf")
+        message(STATUS "Using -gsplit-dwarf for faster linking")
+    endif ()
+endif ()
 
 include( ExternalProject )
 include( GNUInstallDirs )

--- a/internal/core/cmake/DefineOptions.cmake
+++ b/internal/core/cmake/DefineOptions.cmake
@@ -63,6 +63,9 @@ define_option(MILVUS_USE_PCH "Use precompiled headers to speed up compilation" O
 
 define_option(MILVUS_UNITY_BUILD "Use CMake unity (jumbo) build to speed up compilation" OFF)
 
+define_option(MILVUS_USE_SPLIT_DWARF
+        "Split DWARF debug info into external .dwo files for build trees that preserve them" OFF)
+
 define_option(MILVUS_VERBOSE_THIRDPARTY_BUILD
         "Show output from ExternalProjects rather than just logging to files" ON)
 

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -110,6 +110,7 @@ fi
 # Build acceleration options (override via env vars)
 : "${USE_PCH:="ON"}"
 : "${USE_UNITY_BUILD:="OFF"}"
+: "${USE_SPLIT_DWARF:="OFF"}"
 
 while getopts "p:t:s:n:a:y:x:f:S:ulcgbZh" arg; do
   case $arg in
@@ -255,7 +256,8 @@ ${CMAKE_EXTRA_ARGS} \
 -DENABLE_GCP_NATIVE=${ENABLE_GCP_NATIVE} \
 -DENABLE_AZURE_FS=${ENABLE_AZURE_FS} \
 -DMILVUS_USE_PCH=${USE_PCH} \
--DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} "
+-DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} \
+-DMILVUS_USE_SPLIT_DWARF=${USE_SPLIT_DWARF} "
 # Azure build variables removed as we now use Arrow with Azure support directly
 CMAKE_CMD=${CMAKE_CMD}"${CPP_SRC_DIR}"
 

--- a/scripts/milvus-debug.sh
+++ b/scripts/milvus-debug.sh
@@ -5,7 +5,7 @@
 #
 # Starting from v2.6.15, each Milvus release publishes two image variants:
 #   milvusdb/milvus:<tag>         - stripped, production (default, ~1/3 size)
-#   milvusdb/milvus:<tag>-debug   - unstripped, full debug symbols (for GDB)
+#   milvusdb/milvus:<tag>-debug   - unstripped, self-contained debug info (for GDB)
 #
 # The stripped and debug images share byte-identical code sections, so GDB
 # can use the debug image's symbols to resolve addresses in a coredump


### PR DESCRIPTION
## What this fixes

Backport #53214 to the `3.0` branch.

Linux 3.0 builds enable split DWARF by default, while installed artifacts and published debug images do not preserve the generated `.dwo` files. This leaves dangling DWO references in the shipped ELF files.

## Changes

- make split DWARF an explicit CMake opt-in that defaults to OFF
- expose `USE_SPLIT_DWARF=ON` for build-tree workflows that preserve `.dwo` files
- keep release image tagging, multi-arch manifests, and production stripping unchanged

## Validation

- `bash -n scripts/core_build.sh scripts/milvus-debug.sh`
- parsed `DefineOptions.cmake` with the default and explicit `MILVUS_USE_SPLIT_DWARF=ON`
- `git diff --check`

Related issue: #53182
pr: #53214 
