### PR TITLE
fix: make import cancellation effective and release index on cancel

### DIFF
--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -143,7 +143,12 @@ func (t *ImportTask) GetSegmentsInfo() []*datapb.ImportSegmentInfo {
 }
 
 func (t *ImportTask) Clone() Task {
-	ctx, cancel := context.WithCancel(t.ctx)
+	// Use context.Background() as the parent, not t.ctx: Cancel() on the
+	// clone's ctx propagates child→parent is false, so RemoveTask canceling
+	// the leaf clone can never cancel the root ctx captured by the running
+	// goroutines. Deriving from Background() gives the manager a direct
+	// cancel handle for the task's actual execution lifetime.
+	ctx, cancel := context.WithCancel(context.Background())
 	infos := make(map[int64]*datapb.ImportSegmentInfo)
 	for id, info := range t.segmentsInfo {
 		infos[id] = typeutil.Clone(info)

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -389,6 +389,16 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 		return err
 	}
 
+	// Ensure the native index is freed if cancellation between stages
+	// prevents PostExecute from running gcIndex. Delete is idempotent,
+	// so the normal PostExecute path is unaffected.
+	defer func() {
+		if it.index != nil {
+			it.index.Delete()
+			it.index = nil
+		}
+	}()
+
 	buildIndexLatency := it.tr.RecordSpan()
 	metrics.DataNodeKnowhereBuildIndexLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(buildIndexLatency.Seconds())
 


### PR DESCRIPTION
Fixes #53316
Fixes #53317

## Bug 1: Import cancellation no-op

`ImportTask.Clone()` derived the clone's context from the running task's context (`t.ctx`). The task manager replaces the map entry with the clone, and `RemoveTask` cancels only the clone's cancel func. Since cancellation propagates parent→child but never the reverse, canceling the clone could never cancel the root context captured by the executing goroutines — the import kept reading files and writing binlogs into segments DataCoord had already marked Dropped.

**Fix**: Clone derives from `context.Background()` so the manager's cancel is direct and effective.

## Bug 2: Native index leak on cancel

`indexBuildTask.Execute` allocates a native (Knowhere) index via a blocking cgo call that ignores ctx. The stage check in the scheduler (`wrap`) only detects cancellation **between** stages. If cancellation arrives during the build, `PostExecute` is skipped — and `gcIndex` (the sole `it.index.Delete()` call) never runs. `t.Reset()` only nils the Go pointer.

**Fix**: Added a defer in `Execute` after `CreateIndex` succeeds that ensures the native index is freed even when PostExecute is skipped.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>