### PR TITLE
fix: read sparse float vector dict indices as decimal

### DIFF
--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -4314,9 +4314,13 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 	} else if !ok1 && !ok2 {
 		// try format2
 		for k, v := range input {
-			idx, err := strconv.ParseUint(k, 0, 32)
+			// Base 10 is mandatory: the accepted format documents the key as a
+			// decimal index. With base 0 strconv infers the base from the
+			// prefix, so "010" silently became index 8 and "0x10" index 16,
+			// while "08"/"09" were rejected as invalid octal.
+			idx, err := strconv.ParseUint(k, 10, 32)
 			if err != nil {
-				return nil, err
+				return nil, merr.WrapErrParameterInvalidMsg("invalid index in JSON: %s must be a decimal index in [0, 2^32-1)", k)
 			}
 
 			val, err := getValue(v)

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3177,6 +3177,72 @@ func TestParseJsonSparseFloatRow(t *testing.T) {
 	})
 }
 
+func TestParseJsonSparseFloatRowDictIndexBase(t *testing.T) {
+	// The dict format documents its keys as decimal indices
+	// ({"1": 0.1, "2": 0.2}). Keys must therefore be read in base 10 only:
+	// inferring the base from the prefix silently maps "010" to index 8 and
+	// accepts non-decimal spellings such as "0x10" or "0b11".
+	type testCase struct {
+		name        string
+		row         map[string]interface{}
+		expectedErr bool
+		expected    []byte
+	}
+	cases := []testCase{
+		{
+			name:     "plain decimal key",
+			row:      map[string]interface{}{"10": 0.5},
+			expected: CreateSparseFloatRow([]uint32{10}, []float32{0.5}),
+		},
+		{
+			name:     "zero padded decimal key",
+			row:      map[string]interface{}{"010": 0.5},
+			expected: CreateSparseFloatRow([]uint32{10}, []float32{0.5}),
+		},
+		{
+			name:     "multiple zero padded decimal keys",
+			row:      map[string]interface{}{"01": 1.0, "0003": 2.0},
+			expected: CreateSparseFloatRow([]uint32{1, 3}, []float32{1.0, 2.0}),
+		},
+		{
+			name:        "hexadecimal key rejected",
+			row:         map[string]interface{}{"0x10": 0.5},
+			expectedErr: true,
+		},
+		{
+			name:        "binary key rejected",
+			row:         map[string]interface{}{"0b11": 0.5},
+			expectedErr: true,
+		},
+		{
+			name:        "octal key rejected",
+			row:         map[string]interface{}{"0o11": 0.5},
+			expectedErr: true,
+		},
+		{
+			name:        "underscore separated key rejected",
+			row:         map[string]interface{}{"1_0": 0.5},
+			expectedErr: true,
+		},
+		{
+			name:        "non numeric key rejected",
+			row:         map[string]interface{}{"a": 0.5},
+			expectedErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := CreateSparseFloatRowFromMap(tc.row)
+			if tc.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
 func TestParseJsonSparseFloatRowBytes(t *testing.T) {
 	t.Run("valid row 1", func(t *testing.T) {
 		row := []byte(`{"indices":[1,3,5],"values":[1.0,2.0,3.0]}`)


### PR DESCRIPTION
/kind bug

issue: #53399

### What

Parse the sparse float vector dict-format keys in base 10 instead of with an
inferred base, and report a parameter-invalid error naming the offending key.

### Why

`CreateSparseFloatRowFromMap` used `strconv.ParseUint(k, 0, 32)`. The key comes
from a user JSON object, so it is an arbitrary string rather than a JSON number,
and base 0 lets strconv infer the base from the prefix:

| input           | index today | expected |
|-----------------|-------------|----------|
| `{"010": 0.5}`  | 8           | 10       |
| `{"0x10": 0.5}` | 16          | reject   |
| `{"0b11": 0.5}` | 3           | reject   |
| `{"1_0": 0.5}`  | 10          | reject   |
| `{"08": 0.5}`   | error       | 8        |

The first four are silent: the row is written to the wrong sparse dimension and
later searches score against the wrong term. `"08"` being rejected while `"010"`
is accepted also makes the current behaviour internally inconsistent. The
function's own doc comment documents the format as decimal indices
(`{"1": 0.1, "2": 0.2, "3": 0.3}`).

The error factory is an Input one per `docs/dev/error_handling_guide.md`: the
request content itself forces the branch. The branch previously returned the
bare `strconv` error, which is not an merr code.

Paths reached: `internal/distributed/proxy/httpserver/wrap_request.go:393` and
`utils.go:1061,3469`; `internal/util/importutilv2/{json,csv}/row_parser.go`;
`internal/util/importutilv2/parquet/field_reader.go`.

The sibling `getIndex` helper keeps base 0 for its `json.Number` case: there the
value came out of a JSON decoder, and the JSON grammar cannot express `010`,
`0x10`, `0b11` or `1_0`, so base 0 and base 10 agree on every reachable input.

### How tested

`TestParseJsonSparseFloatRowDictIndexBase`, table-driven, fails on master and
passes with this change. `gofmt -l` and `go vet` clean on the touched files.

<details>
<summary>Before (new test against unpatched schema.go)</summary>

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)