### PR TITLE
fix: align XGBoost corrupted model assertion with segcore diagnostics

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_function_chain.py
+++ b/tests/python_client/milvus_client/test_milvus_client_function_chain.py
@@ -1646,13 +1646,12 @@ class TestMilvusClientFunctionChainXGBoost(TestMilvusClientV2Base):
             )
             self._assert_scores_match(recovered, fixture["expected_scores"])
             assert error_is_explicit, error_text
-            # The original segcore code (2042 = ModelInvalid) now travels the
-            # wire directly instead of being collapsed to the generic 2000 with
-            # a "segcoreCode=" decoration in the message.
+            # The original segcore code (2042 = InvalidParameter) travels the
+            # wire directly, and merr retains it in the diagnostic message.
             assert error_code == 2042, f"unexpected wire error code {error_code}: {error_text}"
             assert error_is_input is True, f"corrupted user model was not classified as input error: {error_text}"
             assert error_retriable is False, f"corrupted user model was unexpectedly retriable: {error_text}"
-            assert "segcoreCode=" not in error_text, f"legacy segcoreCode decoration reappeared: {error_text}"
+            assert "segcoreCode=2042" in error_text, f"precise segcore code was not preserved: {error_text}"
         finally:
             self._cleanup_file_resource(
                 client,


### PR DESCRIPTION
issue: #53398

## Summary

The corrupted-XGBoost-UBJ e2e test asserted that `segcoreCode=` never appears in the error message. That contradicts the current error contract: `merr` keeps the original segcore code in the diagnostic, and the code travels the wire directly. Update the assertion to require `segcoreCode=2042` instead of rejecting the decoration.

The test still verifies the explicit parse failure, wire code 2042, input-error classification, non-retriable behavior, and successful reranking with the valid model.

## Test Plan

- `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_function_chain.py`
- `ruff check --config tests/ruff.toml tests/python_client/milvus_client/test_milvus_client_function_chain.py`
- CI on this PR: `ci-v2/e2e-default`, `ci-v2/go-sdk`, and `Ruff (changed files only)` pass.

Fixes #53398
