### PR TITLE
fix: [3.0] correct buffer ownership and allocation cleanup

### DIFF
--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -164,7 +164,7 @@ class Array {
         }
     }
 
-    Array(const Array& array) noexcept
+    Array(const Array& array)
         : length_{array.length_},
           size_{array.size_},
           element_type_{array.element_type_} {

--- a/internal/core/src/common/ArrayTest.cpp
+++ b/internal/core/src/common/ArrayTest.cpp
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include "common/Array.h"
 #include "common/Types.h"
@@ -270,4 +271,24 @@ TEST(Array, TestLiteralElementTypeMismatch) {
     bool_literal.set_same_type(true);
     bool_literal.mutable_array()->Add()->set_bool_val(false);
     expect_mismatch(string_array, bool_literal);
+}
+
+TEST(Array, CopyAndMoveExceptionContracts) {
+    using milvus::Array;
+    EXPECT_FALSE(std::is_nothrow_copy_constructible_v<Array>);
+    EXPECT_TRUE(std::is_nothrow_move_constructible_v<Array>);
+    EXPECT_TRUE(std::is_nothrow_move_assignable_v<Array>);
+
+    milvus::proto::schema::ScalarField field;
+    field.mutable_string_data()->add_data("first");
+    field.mutable_string_data()->add_data("second");
+    Array source(field);
+    Array copy(source);
+    Array assigned;
+    assigned = source;
+    EXPECT_NE(copy.data(), source.data());
+    EXPECT_NE(copy.get_offsets_data(), source.get_offsets_data());
+    EXPECT_NE(assigned.data(), source.data());
+    EXPECT_EQ(copy.get_data<std::string_view>(1), "second");
+    EXPECT_EQ(assigned.get_data<std::string_view>(0), "first");
 }

--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -30,6 +30,17 @@ MmapChunkTarget::~MmapChunkTarget() {
     }
 }
 
+MemChunkTarget::~MemChunkTarget() {
+    if (data_ != nullptr) {
+        munmap(data_, cap_);
+    }
+}
+
+void
+MemChunkTarget::TransferOwnership() noexcept {
+    data_ = nullptr;
+}
+
 void
 MemChunkTarget::write(const void* data, size_t size) {
     AssertInfo(size + size_ <= cap_, "can not exceed target capacity");

--- a/internal/core/src/common/ChunkTarget.h
+++ b/internal/core/src/common/ChunkTarget.h
@@ -40,7 +40,9 @@ class ChunkTarget {
     write(const void* data, size_t size) = 0;
 
     /**
-     * @brief release the data pointer to the caller
+     * @brief finish writing and return the data pointer to the caller
+     * @note owning targets retain fallback cleanup until TransferOwnership()
+     *       is called after the caller has installed its own owner
      * @note no write() should be called after release()
      * @return the data pointer
      */
@@ -115,9 +117,15 @@ class MemChunkTarget : public ChunkTarget {
         AssertInfo(m != MAP_FAILED,
                    "failed to map: {}, map_size={}",
                    strerror(errno),
-                   size_);
+                   cap_);
         data_ = reinterpret_cast<char*>(m);
     }
+
+    ~MemChunkTarget() override;
+
+    MemChunkTarget(const MemChunkTarget&) = delete;
+    MemChunkTarget&
+    operator=(const MemChunkTarget&) = delete;
 
     void
     write(const void* data, size_t size) override;
@@ -125,11 +133,15 @@ class MemChunkTarget : public ChunkTarget {
     char*
     release() override;
 
+    // Disarm fallback cleanup only after ChunkMmapGuard owns the mapping.
+    void
+    TransferOwnership() noexcept;
+
     size_t
     tell() override;
 
  private:
-    char* data_;  // no need to delete in destructor, will be deleted by Chunk
+    char* data_{nullptr};
     size_t cap_;
     size_t size_ = 0;
 };

--- a/internal/core/src/common/ChunkTargetTest.cpp
+++ b/internal/core/src/common/ChunkTargetTest.cpp
@@ -30,12 +30,8 @@ namespace {
 
 int
 MappingStatus(char* data, size_t size) {
-#ifdef __APPLE__
-    char residency;
-#else
-    unsigned char residency;
-#endif
-    return mincore(data, size, &residency);
+    // msync reports ENOMEM for unmapped pages on both Linux and macOS.
+    return msync(data, size, MS_ASYNC);
 }
 
 TEST(MemChunkTarget, DiscardedTargetUnmapsItsBuffer) {

--- a/internal/core/src/common/ChunkTargetTest.cpp
+++ b/internal/core/src/common/ChunkTargetTest.cpp
@@ -1,0 +1,81 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "common/Chunk.h"
+#include "common/ChunkTarget.h"
+#include "gtest/gtest.h"
+
+namespace milvus {
+namespace {
+
+int
+MappingStatus(char* data, size_t size) {
+#ifdef __APPLE__
+    char residency;
+#else
+    unsigned char residency;
+#endif
+    return mincore(data, size, &residency);
+}
+
+TEST(MemChunkTarget, DiscardedTargetUnmapsItsBuffer) {
+    const auto page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    char* data = nullptr;
+    {
+        MemChunkTarget target(page_size, false);
+        data = target.release();
+        ASSERT_EQ(MappingStatus(data, page_size), 0);
+    }
+    errno = 0;
+    const auto result = MappingStatus(data, page_size);
+    const auto error = errno;
+    EXPECT_EQ(result, -1);
+    EXPECT_EQ(error, ENOMEM);
+    EXPECT_FALSE(std::is_copy_constructible_v<MemChunkTarget>);
+}
+
+TEST(MemChunkTarget, GuardKeepsTransferredBufferAlive) {
+    const auto page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const char value[] = "chunk payload";
+    char* data = nullptr;
+    std::shared_ptr<ChunkMmapGuard> guard;
+    {
+        MemChunkTarget target(page_size, false);
+        target.write(value, sizeof(value));
+        data = target.release();
+        guard = std::make_shared<ChunkMmapGuard>(data, page_size, "");
+        target.TransferOwnership();
+    }
+    ASSERT_EQ(MappingStatus(data, page_size), 0);
+    EXPECT_EQ(std::memcmp(data, value, sizeof(value)), 0);
+
+    guard.reset();
+    errno = 0;
+    const auto result = MappingStatus(data, page_size);
+    const auto error = errno;
+    EXPECT_EQ(result, -1);
+    EXPECT_EQ(error, ENOMEM);
+}
+
+}  // namespace
+}  // namespace milvus

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -779,9 +779,12 @@ create_chunk_buffer(const FieldMeta& field_meta,
     size_t aligned_size = (size + ChunkTarget::ALIGNED_SIZE - 1) &
                           ~(ChunkTarget::ALIGNED_SIZE - 1);
     std::shared_ptr<ChunkTarget> target;
+    std::shared_ptr<MemChunkTarget> mem_target;
     std::shared_ptr<MmapChunkTarget> mmap_target;
     if (file_path.empty()) {
-        target = std::make_shared<MemChunkTarget>(aligned_size, mmap_populate);
+        mem_target =
+            std::make_shared<MemChunkTarget>(aligned_size, mmap_populate);
+        target = mem_target;
     } else {
         auto io_prio = storage::io::GetPriorityFromLoadPriority(load_priority);
         mmap_target = std::make_shared<MmapChunkTarget>(
@@ -800,6 +803,7 @@ create_chunk_buffer(const FieldMeta& field_meta,
         mmap_target->TransferOwnership();
     } else {
         chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(data, size, "");
+        mem_target->TransferOwnership();
     }
     ChunkBuffer buffer;
     buffer.data = data;
@@ -875,10 +879,12 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
         }
     }
     std::shared_ptr<ChunkTarget> target;
+    std::shared_ptr<MemChunkTarget> mem_target;
     std::shared_ptr<MmapChunkTarget> mmap_target;
     if (file_path.empty()) {
-        target =
+        mem_target =
             std::make_shared<MemChunkTarget>(total_aligned_size, mmap_populate);
+        target = mem_target;
     } else {
         mmap_target = std::make_shared<MmapChunkTarget>(
             file_path,
@@ -927,6 +933,7 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
     } else {
         chunk_mmap_guard =
             std::make_shared<ChunkMmapGuard>(data, total_aligned_size, "");
+        mem_target->TransferOwnership();
     }
 
     std::unordered_map<FieldId, std::shared_ptr<Chunk>> chunks;

--- a/internal/core/src/common/RangeSearchHelper.cpp
+++ b/internal/core/src/common/RangeSearchHelper.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <memory>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -63,10 +64,10 @@ ReGenRangeSearchResult(DatasetPtr data_set,
     auto dist = GetDatasetDistance(data_set);
 
     // use p_id and p_dist to GenResultDataset after sorted
-    auto p_id = new int64_t[topk * nq];
-    auto p_dist = new float[topk * nq];
-    std::fill_n(p_id, topk * nq, -1);
-    std::fill_n(p_dist, topk * nq, std::numeric_limits<float>::max());
+    std::unique_ptr<int64_t[]> p_id(new int64_t[topk * nq]);
+    std::unique_ptr<float[]> p_dist(new float[topk * nq]);
+    std::fill_n(p_id.get(), topk * nq, -1);
+    std::fill_n(p_dist.get(), topk * nq, std::numeric_limits<float>::max());
 
     /*
      *   get result for one nq
@@ -111,7 +112,7 @@ ReGenRangeSearchResult(DatasetPtr data_set,
             pq.pop();
         }
     }
-    return GenResultDataset(nq, topk, p_id, p_dist);
+    return GenResultDataset(nq, topk, std::move(p_id), std::move(p_dist));
 }
 
 void

--- a/internal/core/src/common/RangeSearchHelperTest.cpp
+++ b/internal/core/src/common/RangeSearchHelperTest.cpp
@@ -188,3 +188,25 @@ TEST_P(RangeSearchSortTest, CheckRangeSearchSort) {
     delete[] p_id;
     delete[] p_dist;
 }
+
+TEST(RangeSearchResultOwnershipTest, TransfersBothOutputArrays) {
+    auto ids = std::make_unique<int64_t[]>(2);
+    auto distances = std::make_unique<float[]>(2);
+    ids[0] = 10;
+    ids[1] = 20;
+    distances[0] = 0.25F;
+    distances[1] = 0.5F;
+    auto* original_ids = ids.get();
+    auto* original_distances = distances.get();
+
+    auto result =
+        milvus::GenResultDataset(1, 2, std::move(ids), std::move(distances));
+    EXPECT_EQ(ids, nullptr);
+    EXPECT_EQ(distances, nullptr);
+    EXPECT_EQ(result->GetRows(), 1);
+    EXPECT_EQ(result->GetDim(), 2);
+    EXPECT_EQ(result->GetIds(), original_ids);
+    EXPECT_EQ(result->GetDistance(), original_distances);
+    EXPECT_EQ(result->GetIds()[1], 20);
+    EXPECT_FLOAT_EQ(result->GetDistance()[1], 0.5F);
+}

--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -105,14 +105,19 @@ GenIdsDataset(const int64_t count, const int64_t* ids) {
 inline DatasetPtr
 GenResultDataset(const int64_t nq,
                  const int64_t topk,
-                 const int64_t* ids,
-                 const float* distance) {
+                 std::unique_ptr<int64_t[]> ids,
+                 std::unique_ptr<float[]> distance) {
     auto ret_ds = std::make_shared<Dataset>();
+    // Dataset setters can allocate. Keep the arrays owned by the guards until
+    // every setter succeeds, including when only one pointer was installed.
+    ret_ds->SetIsOwner(false);
     ret_ds->SetRows(nq);
     ret_ds->SetDim(topk);
-    ret_ds->SetIds(ids);
-    ret_ds->SetDistance(distance);
+    ret_ds->SetIds(ids.get());
+    ret_ds->SetDistance(distance.get());
     ret_ds->SetIsOwner(true);
+    ids.release();
+    distance.release();
     return ret_ds;
 }
 

--- a/internal/core/src/common/VectorArray.h
+++ b/internal/core/src/common/VectorArray.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstring>
+#include <limits>
 #include <memory>
 
 #include "common/FastMem.h"
@@ -55,61 +56,48 @@ class VectorArray : public milvus::VectorTrait {
     // One row of VectorFieldProto
     explicit VectorArray(const VectorFieldProto& vector_field) {
         dim_ = vector_field.dim();
+        AssertInfo(dim_ > 0 && dim_ <= std::numeric_limits<int>::max(),
+                   "invalid vector array dimension {}",
+                   dim_);
+
+        const void* data = nullptr;
+        size_t size = 0;
+        size_t bytes_per_vector = 0;
         switch (vector_field.data_case()) {
             case VectorFieldProto::kFloatVector: {
                 element_type_ = DataType::VECTOR_FLOAT;
-                // data size should be array length * dim
-                length_ = vector_field.float_vector().data().size() / dim_;
-                auto data = new float[length_ * dim_];
-                size_ =
-                    vector_field.float_vector().data().size() * sizeof(float);
-                milvus::fastmem::FastMemcpy(
-                    data,
-                    vector_field.float_vector().data().data(),
-                    vector_field.float_vector().data().size() * sizeof(float));
-                data_ = std::unique_ptr<char[]>(reinterpret_cast<char*>(data));
+                const auto& values = vector_field.float_vector().data();
+                data = values.data();
+                size = static_cast<size_t>(values.size()) * sizeof(float);
+                bytes_per_vector = dim_ * sizeof(float);
                 break;
             }
             case VectorFieldProto::kBinaryVector: {
                 element_type_ = DataType::VECTOR_BINARY;
-                int bytes_per_vector = (dim_ + 7) / 8;
-                length_ =
-                    vector_field.binary_vector().size() / bytes_per_vector;
-                size_ = vector_field.binary_vector().size();
-                data_ = std::make_unique<char[]>(size_);
-                milvus::fastmem::FastMemcpy(
-                    data_.get(), vector_field.binary_vector().data(), size_);
+                data = vector_field.binary_vector().data();
+                size = vector_field.binary_vector().size();
+                bytes_per_vector = (dim_ + 7) / 8;
                 break;
             }
             case VectorFieldProto::kFloat16Vector: {
                 element_type_ = DataType::VECTOR_FLOAT16;
-                int bytes_per_element = 2;  // 2 bytes per float16
-                length_ = vector_field.float16_vector().size() /
-                          (dim_ * bytes_per_element);
-                size_ = vector_field.float16_vector().size();
-                data_ = std::make_unique<char[]>(size_);
-                milvus::fastmem::FastMemcpy(
-                    data_.get(), vector_field.float16_vector().data(), size_);
+                data = vector_field.float16_vector().data();
+                size = vector_field.float16_vector().size();
+                bytes_per_vector = dim_ * sizeof(float16);
                 break;
             }
             case VectorFieldProto::kBfloat16Vector: {
                 element_type_ = DataType::VECTOR_BFLOAT16;
-                int bytes_per_element = 2;  // 2 bytes per bfloat16
-                length_ = vector_field.bfloat16_vector().size() /
-                          (dim_ * bytes_per_element);
-                size_ = vector_field.bfloat16_vector().size();
-                data_ = std::make_unique<char[]>(size_);
-                milvus::fastmem::FastMemcpy(
-                    data_.get(), vector_field.bfloat16_vector().data(), size_);
+                data = vector_field.bfloat16_vector().data();
+                size = vector_field.bfloat16_vector().size();
+                bytes_per_vector = dim_ * sizeof(bfloat16);
                 break;
             }
             case VectorFieldProto::kInt8Vector: {
                 element_type_ = DataType::VECTOR_INT8;
-                length_ = vector_field.int8_vector().size() / dim_;
-                size_ = vector_field.int8_vector().size();
-                data_ = std::make_unique<char[]>(size_);
-                milvus::fastmem::FastMemcpy(
-                    data_.get(), vector_field.int8_vector().data(), size_);
+                data = vector_field.int8_vector().data();
+                size = vector_field.int8_vector().size();
+                bytes_per_vector = dim_;
                 break;
             }
             default: {
@@ -117,6 +105,23 @@ class VectorArray : public milvus::VectorTrait {
                           "Not implemented vector type: {}",
                           static_cast<int>(vector_field.data_case()));
             }
+        }
+        AssertInfo(size % bytes_per_vector == 0,
+                   "vector array data size {} is not a multiple of vector "
+                   "size {} for dimension {}",
+                   size,
+                   bytes_per_vector,
+                   dim_);
+        AssertInfo(size <= std::numeric_limits<int>::max(),
+                   "vector array data size {} exceeds the supported size",
+                   size);
+        length_ = size / bytes_per_vector;
+        size_ = size;
+        // Allocate and delete through the same byte-array type for every
+        // vector encoding, using exactly the size that will be copied.
+        if (size_ != 0) {
+            data_ = std::unique_ptr<char[]>(new char[size_]);
+            milvus::fastmem::FastMemcpy(data_.get(), data, size_);
         }
     }
 

--- a/internal/core/src/common/VectorArrayTest.cpp
+++ b/internal/core/src/common/VectorArrayTest.cpp
@@ -217,7 +217,7 @@ TEST(VectorArray, RejectsInvalidDimensions) {
         proto::schema::VectorField field;
         field.set_dim(dim);
         field.mutable_float_vector()->add_data(1.0f);
-        EXPECT_ANY_THROW({ VectorArray array(field); });
+        EXPECT_ANY_THROW({ milvus::VectorArray array(field); });
     }
 }
 
@@ -238,7 +238,7 @@ TEST(VectorArray, RejectsPartialVectors) {
 
     for (const auto& field : fields) {
         SCOPED_TRACE(static_cast<int>(field.data_case()));
-        EXPECT_ANY_THROW({ VectorArray array(field); });
+        EXPECT_ANY_THROW({ milvus::VectorArray array(field); });
     }
 }
 
@@ -257,11 +257,11 @@ TEST(VectorArray, OwnedBytesRoundTripForEveryEncoding) {
 
     for (const auto& field : fields) {
         SCOPED_TRACE(static_cast<int>(field.data_case()));
-        VectorArray array(field);
+        milvus::VectorArray array(field);
         EXPECT_EQ(array.length(), 2);
         EXPECT_EQ(array.output_data().SerializeAsString(),
                   field.SerializeAsString());
-        VectorArray copy(array);
+        milvus::VectorArray copy(array);
         EXPECT_NE(copy.data(), array.data());
         EXPECT_EQ(copy.output_data().SerializeAsString(),
                   field.SerializeAsString());
@@ -277,7 +277,7 @@ TEST(VectorArray, EmptyRowsPreserveEncoding) {
     fields[4].mutable_int8_vector();
     for (auto& field : fields) {
         field.set_dim(16);
-        VectorArray array(field);
+        milvus::VectorArray array(field);
         EXPECT_EQ(array.length(), 0);
         EXPECT_EQ(array.byte_size(), 0);
         EXPECT_EQ(array.output_data().SerializeAsString(),

--- a/internal/core/src/common/VectorArrayTest.cpp
+++ b/internal/core/src/common/VectorArrayTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <random>
 #include <string>
@@ -207,5 +208,79 @@ TEST(VectorArray, TestConstructorWithData) {
             small_data.data(), 5, small_dim, DataType::VECTOR_FLOAT);
         ASSERT_EQ(va_small.length(), 5);
         ASSERT_EQ(va_small.dim(), small_dim);
+    }
+}
+
+TEST(VectorArray, RejectsInvalidDimensions) {
+    for (const int64_t dim :
+         {int64_t{0}, int64_t{-1}, std::numeric_limits<int64_t>::max()}) {
+        proto::schema::VectorField field;
+        field.set_dim(dim);
+        field.mutable_float_vector()->add_data(1.0f);
+        EXPECT_ANY_THROW({ VectorArray array(field); });
+    }
+}
+
+TEST(VectorArray, RejectsPartialVectors) {
+    std::vector<proto::schema::VectorField> fields(5);
+    fields[0].set_dim(3);
+    for (int i = 0; i < 4; ++i) {
+        fields[0].mutable_float_vector()->add_data(static_cast<float>(i));
+    }
+    fields[1].set_dim(16);
+    fields[1].set_binary_vector(std::string(3, 'x'));
+    fields[2].set_dim(2);
+    fields[2].set_float16_vector(std::string(5, 'x'));
+    fields[3].set_dim(2);
+    fields[3].set_bfloat16_vector(std::string(5, 'x'));
+    fields[4].set_dim(3);
+    fields[4].set_int8_vector(std::string(4, 'x'));
+
+    for (const auto& field : fields) {
+        SCOPED_TRACE(static_cast<int>(field.data_case()));
+        EXPECT_ANY_THROW({ VectorArray array(field); });
+    }
+}
+
+TEST(VectorArray, OwnedBytesRoundTripForEveryEncoding) {
+    std::vector<proto::schema::VectorField> fields(5);
+    for (auto& field : fields) {
+        field.set_dim(16);
+    }
+    for (int i = 0; i < 32; ++i) {
+        fields[0].mutable_float_vector()->add_data(static_cast<float>(i));
+    }
+    fields[1].set_binary_vector(std::string(4, 'a'));
+    fields[2].set_float16_vector(std::string(64, 'b'));
+    fields[3].set_bfloat16_vector(std::string(64, 'c'));
+    fields[4].set_int8_vector(std::string(32, 'd'));
+
+    for (const auto& field : fields) {
+        SCOPED_TRACE(static_cast<int>(field.data_case()));
+        VectorArray array(field);
+        EXPECT_EQ(array.length(), 2);
+        EXPECT_EQ(array.output_data().SerializeAsString(),
+                  field.SerializeAsString());
+        VectorArray copy(array);
+        EXPECT_NE(copy.data(), array.data());
+        EXPECT_EQ(copy.output_data().SerializeAsString(),
+                  field.SerializeAsString());
+    }
+}
+
+TEST(VectorArray, EmptyRowsPreserveEncoding) {
+    std::vector<proto::schema::VectorField> fields(5);
+    fields[0].mutable_float_vector();
+    fields[1].mutable_binary_vector();
+    fields[2].mutable_float16_vector();
+    fields[3].mutable_bfloat16_vector();
+    fields[4].mutable_int8_vector();
+    for (auto& field : fields) {
+        field.set_dim(16);
+        VectorArray array(field);
+        EXPECT_EQ(array.length(), 0);
+        EXPECT_EQ(array.byte_size(), 0);
+        EXPECT_EQ(array.output_data().SerializeAsString(),
+                  field.SerializeAsString());
     }
 }

--- a/internal/core/src/exec/expression/CacheCompressor.cpp
+++ b/internal/core/src/exec/expression/CacheCompressor.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <vector>
 
 #include <roaring/roaring.h>
@@ -61,8 +62,10 @@ CacheCompressor::CompressRoaring(const TargetBitmap& bset) {
     constexpr size_t WORDS_PER_CONTAINER = 1024;
     constexpr int32_t ARRAY_THRESHOLD = 4096;
 
-    roaring_bitmap_t* r = roaring_bitmap_create_with_capacity(
-        static_cast<uint32_t>(num_containers));
+    std::unique_ptr<roaring_bitmap_t, decltype(&roaring_bitmap_free)> r(
+        roaring_bitmap_create_with_capacity(
+            static_cast<uint32_t>(num_containers)),
+        roaring_bitmap_free);
 
     for (size_t c = 0; c < num_containers; ++c) {
         uint16_t key = static_cast<uint16_t>(c);
@@ -112,12 +115,11 @@ CacheCompressor::CompressRoaring(const TargetBitmap& bset) {
     }
 
     // runOptimize: convert bitmap/array → run containers where smaller
-    roaring_bitmap_run_optimize(r);
+    roaring_bitmap_run_optimize(r.get());
 
-    size_t ser_size = roaring_bitmap_size_in_bytes(r);
+    size_t ser_size = roaring_bitmap_size_in_bytes(r.get());
     std::vector<char> buf(ser_size);
-    roaring_bitmap_serialize(r, buf.data());
-    roaring_bitmap_free(r);
+    roaring_bitmap_serialize(r.get(), buf.data());
     return buf;
 }
 
@@ -128,18 +130,19 @@ CacheCompressor::DecompressRoaring(const char* data,
                                    uint32_t data_len,
                                    uint32_t num_bits,
                                    TargetBitmap& out) {
-    roaring_bitmap_t* r = roaring_bitmap_deserialize_safe(data, data_len);
+    std::unique_ptr<roaring_bitmap_t, decltype(&roaring_bitmap_free)> r(
+        roaring_bitmap_deserialize_safe(data, data_len), roaring_bitmap_free);
     if (!r) {
         LOG_WARN("CacheCompressor::DecompressRoaring: deserialize failed");
         return false;
     }
 
     TargetBitmap result(num_bits, false);
-    uint64_t card = roaring_bitmap_get_cardinality(r);
+    uint64_t card = roaring_bitmap_get_cardinality(r.get());
     if (card > 0) {
         // Extract all set-bit positions and set them in dense bitset
         std::vector<uint32_t> positions(card);
-        roaring_bitmap_to_uint32_array(r, positions.data());
+        roaring_bitmap_to_uint32_array(r.get(), positions.data());
 
         uint64_t* words = reinterpret_cast<uint64_t*>(result.data());
         for (uint32_t pos : positions) {
@@ -148,7 +151,6 @@ CacheCompressor::DecompressRoaring(const char* data,
             }
         }
     }
-    roaring_bitmap_free(r);
     out = std::move(result);
     return true;
 }

--- a/internal/core/src/exec/operator/query-agg/Aggregate.h
+++ b/internal/core/src/exec/operator/query-agg/Aggregate.h
@@ -83,6 +83,13 @@ class Aggregate {
     virtual void
     extractValues(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 
+    // Release resources owned by one accumulator before its row is freed.
+    // Rows start zero-initialized: cleanup must also accept state whose
+    // initialization or output extraction did not finish, and be idempotent.
+    virtual void
+    destroy(char* /*group*/) noexcept {
+    }
+
     template <typename T>
     T*
     value(char* group) const {

--- a/internal/core/src/exec/operator/query-agg/GroupingSet.cpp
+++ b/internal/core/src/exec/operator/query-agg/GroupingSet.cpp
@@ -32,12 +32,18 @@
 namespace milvus {
 namespace exec {
 GroupingSet::~GroupingSet() {
-    if (isGlobal_ && lookup_) {
-        AssertInfo(lookup_->hits_.size() == 1,
-                   "GlobalAggregation should have exactly one output line");
-        // globalAggregationBuffer_ is automatically cleaned up by unique_ptr
-        // No need to manually delete[] or set to nullptr
-        lookup_->hits_[0] = nullptr;
+    if (isGlobal_) {
+        if (globalAggregationBuffer_) {
+            for (auto& aggregate : aggregates_) {
+                aggregate.function_->destroy(globalAggregationBuffer_.get());
+            }
+        }
+    } else if (hash_table_) {
+        for (auto* row : hash_table_->rows()->allRows()) {
+            for (auto& aggregate : aggregates_) {
+                aggregate.function_->destroy(row);
+            }
+        }
     }
 }
 

--- a/internal/core/src/exec/operator/query-agg/GroupingSetTest.cpp
+++ b/internal/core/src/exec/operator/query-agg/GroupingSetTest.cpp
@@ -1,0 +1,267 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "common/Vector.h"
+#include "exec/VectorHasher.h"
+#include "exec/operator/query-agg/GroupingSet.h"
+#include "exec/operator/query-agg/MaxAggregateBase.h"
+#include "exec/operator/query-agg/MinAggregateBase.h"
+
+namespace milvus::exec {
+namespace {
+
+struct CleanupCounts {
+    size_t rows = 0;
+    size_t strings = 0;
+};
+
+// Observe the real string aggregate's cleanup while exercising GroupingSet's
+// ownership boundary; the delegate still allocates and destroys its own state.
+class ObservedStringAggregate : public Aggregate {
+ public:
+    ObservedStringAggregate(bool minimum, CleanupCounts& counts)
+        : Aggregate(DataType::VARCHAR), counts_(counts) {
+        if (minimum) {
+            delegate_ = std::make_unique<MinStringAggregate>(DataType::VARCHAR);
+        } else {
+            delegate_ = std::make_unique<MaxStringAggregate>(DataType::VARCHAR);
+        }
+    }
+
+    int32_t
+    accumulatorFixedWidthSize() const override {
+        return delegate_->accumulatorFixedWidthSize();
+    }
+
+    void
+    addSingleGroupRawInput(char* group,
+                           int64_t numRows,
+                           const std::vector<VectorPtr>& input) override {
+        delegate_->addSingleGroupRawInput(group, numRows, input);
+    }
+
+    void
+    addRawInput(char** groups,
+                int numGroups,
+                const std::vector<VectorPtr>& input) override {
+        delegate_->addRawInput(groups, numGroups, input);
+    }
+
+    void
+    extractValues(char** groups,
+                  int32_t numGroups,
+                  VectorPtr* result) override {
+        delegate_->extractValues(groups, numGroups, result);
+    }
+
+    void
+    destroy(char* group) noexcept override {
+        ++counts_.rows;
+        counts_.strings += *delegate_->value<std::string*>(group) != nullptr;
+        delegate_->destroy(group);
+        EXPECT_EQ(*delegate_->value<std::string*>(group), nullptr);
+    }
+
+ protected:
+    void
+    setOffsetsInternal(int32_t offset,
+                       int32_t nullByte,
+                       uint8_t nullMask,
+                       int32_t rowSizeOffset) override {
+        Aggregate::setOffsetsInternal(
+            offset, nullByte, nullMask, rowSizeOffset);
+        delegate_->setOffsets(offset, nullByte, nullMask, rowSizeOffset);
+    }
+
+    void
+    initializeNewGroupsInternal(
+        char** groups, folly::Range<const vector_size_t*> indices) override {
+        delegate_->initializeNewGroups(groups, indices);
+    }
+
+ private:
+    CleanupCounts& counts_;
+    std::unique_ptr<Aggregate> delegate_;
+};
+
+// minimum / grouped
+class StringAggregateCleanupTest
+    : public testing::TestWithParam<std::tuple<bool, bool>> {
+ protected:
+    bool
+    minimum() const {
+        return std::get<0>(GetParam());
+    }
+
+    bool
+    grouped() const {
+        return std::get<1>(GetParam());
+    }
+
+    size_t
+    groupCount() const {
+        return grouped() ? 2 : 1;
+    }
+
+    std::unique_ptr<GroupingSet>
+    makeGroupingSet(CleanupCounts& counts, bool two_aggregates = false) {
+        std::vector<std::unique_ptr<VectorHasher>> hashers;
+        if (grouped()) {
+            hashers.emplace_back(VectorHasher::create(DataType::INT64, 0));
+        }
+        std::vector<AggregateInfo> aggregates;
+        for (int i = 0; i < (two_aggregates ? 2 : 1); ++i) {
+            aggregates.push_back(
+                {std::make_unique<ObservedStringAggregate>(minimum(), counts),
+                 {1},
+                 (grouped() ? 1 : 0) + i});
+        }
+        auto input_type = std::make_shared<RowType>(
+            std::vector<std::string>{"key", "value"},
+            std::vector<DataType>{DataType::INT64, DataType::VARCHAR});
+        return std::make_unique<GroupingSet>(
+            input_type, std::move(hashers), std::move(aggregates));
+    }
+
+    RowVectorPtr
+    makeInput() {
+        auto keys = std::make_shared<ColumnVector>(DataType::INT64, 3);
+        auto values = std::make_shared<ColumnVector>(DataType::VARCHAR, 3);
+        for (int i = 0; i < 3; ++i) {
+            keys->SetValueAt<int64_t>(i, i == 1 ? 2 : 1);
+            values->SetValueAt<std::string>(
+                i, std::string(256, i == 0 ? 'z' : (i == 1 ? 'm' : 'a')));
+        }
+        return std::make_shared<RowVector>(
+            std::vector<VectorPtr>{keys, values});
+    }
+
+    RowVectorPtr
+    makeOutput() {
+        std::vector<DataType> types;
+        if (grouped()) {
+            types.push_back(DataType::INT64);
+        }
+        types.push_back(DataType::VARCHAR);
+        return std::make_shared<RowVector>(types, groupCount());
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(MinMaxGroupedAndGlobal,
+                         StringAggregateCleanupTest,
+                         testing::Combine(testing::Bool(), testing::Bool()));
+
+TEST_P(StringAggregateCleanupTest, DestroysStateWithoutOutput) {
+    CleanupCounts counts;
+    auto groups = makeGroupingSet(counts);
+    groups->addInput(makeInput());
+    groups.reset();
+    EXPECT_EQ(counts.rows, groupCount());
+    EXPECT_EQ(counts.strings, groupCount());
+}
+
+TEST_P(StringAggregateCleanupTest, SuccessfulOutputDoesNotDoubleFree) {
+    CleanupCounts counts;
+    auto groups = makeGroupingSet(counts);
+    groups->addInput(makeInput());
+    auto output = makeOutput();
+    ASSERT_TRUE(groups->getOutput(output));
+    groups.reset();
+    EXPECT_EQ(counts.rows, groupCount());
+    EXPECT_EQ(counts.strings, 0);
+
+    auto values = std::dynamic_pointer_cast<ColumnVector>(
+        output->child(grouped() ? 1 : 0));
+    for (size_t i = 0; i < groupCount(); ++i) {
+        char expected = minimum() ? 'a' : 'z';
+        if (grouped()) {
+            auto keys =
+                std::dynamic_pointer_cast<ColumnVector>(output->child(0));
+            if (keys->ValueAt<int64_t>(i) == 2) {
+                expected = 'm';
+            }
+        }
+        EXPECT_EQ(values->ValueAt<std::string>(i), std::string(256, expected));
+    }
+}
+
+TEST_P(StringAggregateCleanupTest, FailedOutputStillDestroysState) {
+    CleanupCounts counts;
+    auto groups = makeGroupingSet(counts, true);
+    groups->addInput(makeInput());
+    // The first aggregate extracts and frees its state. The second output
+    // vector triggers the existing assertion, leaving its state for teardown.
+    std::vector<VectorPtr> columns;
+    if (grouped()) {
+        columns.push_back(
+            std::make_shared<ColumnVector>(DataType::INT64, groupCount()));
+    }
+    columns.push_back(
+        std::make_shared<ColumnVector>(DataType::VARCHAR, groupCount()));
+    columns.push_back(std::make_shared<RowVector>(std::vector<VectorPtr>{}));
+    auto output = std::make_shared<RowVector>(std::move(columns));
+    EXPECT_THROW(groups->getOutput(output), SegcoreError);
+    groups.reset();
+    EXPECT_EQ(counts.rows, groupCount() * 2);
+    EXPECT_EQ(counts.strings, groupCount());
+}
+
+TEST_P(StringAggregateCleanupTest, NullGroupsNeedNoStringCleanup) {
+    CleanupCounts counts;
+    auto groups = makeGroupingSet(counts);
+    auto input = makeInput();
+    auto values = std::dynamic_pointer_cast<ColumnVector>(input->child(1));
+    for (size_t i = 0; i < values->size(); ++i) {
+        values->nullAt(i);
+    }
+    groups->addInput(input);
+    groups.reset();
+    EXPECT_EQ(counts.rows, groupCount());
+    EXPECT_EQ(counts.strings, 0);
+}
+
+TEST_P(StringAggregateCleanupTest, DestroysZeroInitializedState) {
+    CleanupCounts counts;
+    auto groups = makeGroupingSet(counts);
+    if (grouped()) {
+        groups->createHashTable();
+    } else {
+        groups->initializeGlobalAggregation();
+    }
+    groups.reset();
+    EXPECT_EQ(counts.rows, grouped() ? 0 : 1);
+    EXPECT_EQ(counts.strings, 0);
+
+    ObservedStringAggregate aggregate(minimum(), counts);
+    aggregate.setOffsets(8, 0, 1, 0);
+    alignas(std::string*) char row[32]{};
+    // A freshly allocated row can be visited by teardown before its
+    // initializeNewGroups call, or after an earlier cleanup.
+    aggregate.destroy(row);
+    aggregate.destroy(row);
+    EXPECT_EQ(counts.strings, 0);
+}
+
+}  // namespace
+}  // namespace milvus::exec

--- a/internal/core/src/exec/operator/query-agg/GroupingSetTest.cpp
+++ b/internal/core/src/exec/operator/query-agg/GroupingSetTest.cpp
@@ -135,7 +135,7 @@ class StringAggregateCleanupTest
             aggregates.push_back(
                 {std::make_unique<ObservedStringAggregate>(minimum(), counts),
                  {1},
-                 (grouped() ? 1 : 0) + i});
+                 static_cast<column_index_t>((grouped() ? 1 : 0) + i)});
         }
         auto input_type = std::make_shared<RowType>(
             std::vector<std::string>{"key", "value"},

--- a/internal/core/src/exec/operator/query-agg/MaxAggregateBase.h
+++ b/internal/core/src/exec/operator/query-agg/MaxAggregateBase.h
@@ -118,6 +118,13 @@ class MaxStringAggregate final : public Aggregate {
     }
 
     void
+    destroy(char* group) noexcept override {
+        auto& ptr = *value<std::string*>(group);
+        delete ptr;
+        ptr = nullptr;
+    }
+
+    void
     extractValues(char** groups,
                   int32_t numGroups,
                   VectorPtr* result) override {

--- a/internal/core/src/exec/operator/query-agg/MinAggregateBase.h
+++ b/internal/core/src/exec/operator/query-agg/MinAggregateBase.h
@@ -118,6 +118,13 @@ class MinStringAggregate final : public Aggregate {
     }
 
     void
+    destroy(char* group) noexcept override {
+        auto& ptr = *value<std::string*>(group);
+        delete ptr;
+        ptr = nullptr;
+    }
+
+    void
     extractValues(char** groups,
                   int32_t numGroups,
                   VectorPtr* result) override {

--- a/internal/core/src/exec/operator/query-agg/RowContainer.cpp
+++ b/internal/core/src/exec/operator/query-agg/RowContainer.cpp
@@ -18,6 +18,7 @@
 
 #include <string.h>
 #include <cstdint>
+#include <memory>
 
 #include "common/BitUtil.h"
 #include "common/Vector.h"
@@ -87,10 +88,11 @@ RowContainer::initializeRow(char* row) {
 
 char*
 RowContainer::newRow() {
-    char* row = new char[fixedRowSize_];
-    rows_.emplace_back(row);
+    std::unique_ptr<char[]> row(new char[fixedRowSize_]);
+    initializeRow(row.get());
+    rows_.emplace_back(row.get());
     ++numRows_;
-    return initializeRow(row);
+    return row.release();
 }
 
 void

--- a/internal/core/src/segcore/PackedReaderWriterTest.cpp
+++ b/internal/core/src/segcore/PackedReaderWriterTest.cpp
@@ -108,7 +108,28 @@ TEST(CPackedTest, PackedWriterAndReader) {
     EXPECT_EQ(c_status.error_code, 0);
     EXPECT_NE(c_packed_reader, nullptr);
 
+    struct ArrowArray read_array {};
+    struct ArrowSchema read_schema {};
+    c_status = ReadNext(c_packed_reader, &read_array, &read_schema);
+    ASSERT_EQ(c_status.error_code, 0);
+    ASSERT_NE(read_array.release, nullptr);
+    ASSERT_NE(read_schema.release, nullptr);
+    auto imported = arrow::ImportRecordBatch(&read_array, &read_schema);
+    ASSERT_TRUE(imported.ok());
+    auto read_batch = imported.ValueOrDie();
+    EXPECT_TRUE(batch->Equals(*read_batch));
+    EXPECT_EQ(read_array.release, nullptr);
+    EXPECT_EQ(read_schema.release, nullptr);
+
+    // The same caller-owned structs can be reused after import; EOF leaves
+    // both outputs released without affecting the previously imported batch.
+    c_status = ReadNext(c_packed_reader, &read_array, &read_schema);
+    EXPECT_EQ(c_status.error_code, 0);
+    EXPECT_EQ(read_array.release, nullptr);
+    EXPECT_EQ(read_schema.release, nullptr);
+
     c_status = CloseReader(c_packed_reader);
     EXPECT_EQ(c_status.error_code, 0);
+    EXPECT_TRUE(batch->Equals(*read_batch));
     FreeCColumnSplits(cgs);
 }

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <map>
@@ -2904,6 +2905,29 @@ TEST_F(FlushGrowingSegmentTest, FreeFlushResultNull) {
     result.num_rows = 0;
 
     // should not crash
+    FreeFlushResult(&result);
+}
+
+TEST_F(FlushGrowingSegmentTest, FreePartiallyFilledBM25Stats) {
+    CFlushResult result{};
+    // The output arrays can be allocated before any row is serialized.
+    result.bm25_field_ids = static_cast<int64_t*>(malloc(3 * sizeof(int64_t)));
+    result.bm25_stats_sizes = static_cast<size_t*>(malloc(3 * sizeof(size_t)));
+    result.bm25_stats = static_cast<uint8_t**>(calloc(3, sizeof(uint8_t*)));
+    ASSERT_NE(result.bm25_field_ids, nullptr);
+    ASSERT_NE(result.bm25_stats_sizes, nullptr);
+    ASSERT_NE(result.bm25_stats, nullptr);
+    result.bm25_stats[0] = static_cast<uint8_t*>(malloc(8));
+    ASSERT_NE(result.bm25_stats[0], nullptr);
+    result.bm25_field_ids[0] = 100;
+    result.bm25_stats_sizes[0] = 8;
+    result.num_bm25_stats = 1;
+
+    FreeFlushResult(&result);
+    EXPECT_EQ(result.bm25_stats, nullptr);
+    EXPECT_EQ(result.bm25_field_ids, nullptr);
+    EXPECT_EQ(result.bm25_stats_sizes, nullptr);
+    EXPECT_EQ(result.num_bm25_stats, 0);
     FreeFlushResult(&result);
 }
 

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -208,9 +208,12 @@ NewPackedReader(char** paths,
 
 CStatus
 ReadNext(CPackedReader c_packed_reader,
-         CArrowArray* out_array,
-         CArrowSchema* out_schema) {
+         struct ArrowArray* out_array,
+         struct ArrowSchema* out_schema) {
     SCOPE_CGO_CALL_METRIC();
+
+    *out_array = {};
+    *out_schema = {};
 
     try {
         auto packed_reader =
@@ -225,19 +228,12 @@ ReadNext(CPackedReader c_packed_reader,
         if (record_batch == nullptr) {
             // end of file
             return milvus::SuccessCStatus();
-        } else {
-            std::unique_ptr<ArrowArray> arr = std::make_unique<ArrowArray>();
-            std::unique_ptr<ArrowSchema> schema =
-                std::make_unique<ArrowSchema>();
-            auto status = arrow::ExportRecordBatch(
-                *record_batch, arr.get(), schema.get());
-            if (!status.ok()) {
-                return milvus::FailureCStatus(milvus::ErrorCode::FileReadFailed,
-                                              status.ToString());
-            }
-            *out_array = arr.release();
-            *out_schema = schema.release();
-            return milvus::SuccessCStatus();
+        }
+        auto export_status =
+            arrow::ExportRecordBatch(*record_batch, out_array, out_schema);
+        if (!export_status.ok()) {
+            return milvus::FailureCStatus(milvus::ErrorCode::FileReadFailed,
+                                          export_status.ToString());
         }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/segcore/packed_reader_c.h
+++ b/internal/core/src/segcore/packed_reader_c.h
@@ -29,8 +29,6 @@ struct ArrowSchema;
 struct ArrowArray;
 
 typedef void* CPackedReader;
-typedef void* CArrowArray;
-typedef void* CArrowSchema;
 
 CStatus
 NewPackedReaderWithStorageConfig(char** paths,
@@ -72,13 +70,15 @@ NewPackedReader(char** paths,
  *        By default, the maximum return batch is 1024 rows.
  *
  * @param c_packed_reader The packed reader to read.
- * @param out_array The output pointer of the arrow array.
- * @param out_schema The output pointer of the arrow schema.
+ * @param out_array Caller-owned array, with release == nullptr on entry.
+ *                  A null release callback on success indicates end of stream.
+ * @param out_schema Caller-owned schema, with release == nullptr on entry.
+ *                   The caller releases both outputs, including on failure.
  */
 CStatus
 ReadNext(CPackedReader c_packed_reader,
-         CArrowArray* out_array,
-         CArrowSchema* out_schema);
+         struct ArrowArray* out_array,
+         struct ArrowSchema* out_schema);
 
 /**
  * @brief Close the packed reader and release the resources.

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -553,18 +553,13 @@ CRetrieveResult*
 CreateLeakedCRetrieveResultFromProto(
     std::unique_ptr<milvus::proto::segcore::RetrieveResults> retrieve_result) {
     auto size = retrieve_result->ByteSizeLong();
-    auto buffer = new uint8_t[size];
-    try {
-        retrieve_result->SerializePartialToArray(buffer, size);
-    } catch (std::exception& e) {
-        delete[] buffer;
-        throw;
-    }
+    std::unique_ptr<uint8_t[]> buffer(new uint8_t[size]);
+    retrieve_result->SerializePartialToArray(buffer.get(), size);
 
-    auto result = new CRetrieveResult();
-    result->proto_blob = buffer;
+    auto result = std::make_unique<CRetrieveResult>();
+    result->proto_blob = buffer.release();
     result->proto_size = size;
-    return result;
+    return result.release();
 }
 
 CFuture*  // Future<CRetrieveResult>
@@ -2622,27 +2617,46 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         auto manifest_path = milvus_storage::get_manifest_filepath(
             writer_config.segment_path, committed_version);
         result->manifest_path = strdup(manifest_path.c_str());
+        if (!result->manifest_path) {
+            return milvus::FailureCStatus(milvus::MemAllocateFailed,
+                                          "failed to allocate manifest path");
+        }
         result->committed_version = committed_version;
         result->num_rows = output.rows_written;
         if (!bm25_stats.empty()) {
-            result->num_bm25_stats = bm25_stats.size();
-            result->bm25_field_ids = static_cast<int64_t*>(
-                malloc(sizeof(int64_t) * result->num_bm25_stats));
-            result->bm25_stats = static_cast<uint8_t**>(
-                malloc(sizeof(uint8_t*) * result->num_bm25_stats));
-            result->bm25_stats_sizes = static_cast<size_t*>(
-                malloc(sizeof(size_t) * result->num_bm25_stats));
-            size_t idx = 0;
+            const auto num_stats = bm25_stats.size();
+            result->bm25_field_ids =
+                static_cast<int64_t*>(malloc(sizeof(int64_t) * num_stats));
+            result->bm25_stats =
+                static_cast<uint8_t**>(calloc(num_stats, sizeof(uint8_t*)));
+            result->bm25_stats_sizes =
+                static_cast<size_t*>(malloc(sizeof(size_t) * num_stats));
+            if (!result->bm25_field_ids || !result->bm25_stats ||
+                !result->bm25_stats_sizes) {
+                return milvus::FailureCStatus(
+                    milvus::MemAllocateFailed,
+                    "failed to allocate growing flush BM25 stats arrays");
+            }
             for (const auto& [field_id, stats] : bm25_stats) {
                 auto serialized = SerializeBM25Stats(stats);
+                const auto idx = result->num_bm25_stats;
                 result->bm25_field_ids[idx] = field_id;
                 result->bm25_stats_sizes[idx] = serialized.size();
                 result->bm25_stats[idx] =
                     static_cast<uint8_t*>(malloc(serialized.size()));
-                std::memcpy(result->bm25_stats[idx],
-                            serialized.data(),
-                            serialized.size());
-                idx++;
+                if (!serialized.empty()) {
+                    if (!result->bm25_stats[idx]) {
+                        return milvus::FailureCStatus(
+                            milvus::MemAllocateFailed,
+                            "failed to allocate growing flush BM25 stats");
+                    }
+                    std::memcpy(result->bm25_stats[idx],
+                                serialized.data(),
+                                serialized.size());
+                }
+                // FreeFlushResult must only visit entries whose ownership
+                // has been transferred, including on serialization failure.
+                ++result->num_bm25_stats;
             }
         }
         return milvus::SuccessCStatus();

--- a/internal/core/src/storage/MmapChunkManager.cpp
+++ b/internal/core/src/storage/MmapChunkManager.cpp
@@ -256,14 +256,16 @@ MmapChunkManager::~MmapChunkManager() {
 
 MmapChunkDescriptorPtr
 MmapChunkManager::Register() {
-    std::unique_lock<std::shared_mutex> lck(mtx_);
+    // Construct the owner before taking mtx_: shared_ptr allocation failure
+    // invokes its deleter, which takes this same lock in UnRegister().
     auto new_descriptor = std::shared_ptr<MmapChunkDescriptor>(
-        new MmapChunkDescriptor(descriptor_counter_.load()),
+        new MmapChunkDescriptor(descriptor_counter_.fetch_add(1)),
         [this](MmapChunkDescriptor* ptr) {
             UnRegister(ptr->GetId());
             delete ptr;
         });
-    descriptor_counter_.fetch_add(1);
+    // If emplace throws, lck must be destroyed before new_descriptor.
+    std::unique_lock<std::shared_mutex> lck(mtx_);
     blocks_table_.emplace(new_descriptor->GetId(), std::vector<MmapBlockPtr>());
     return new_descriptor;
 }

--- a/internal/core/src/storage/MmapChunkManagerTest.cpp
+++ b/internal/core/src/storage/MmapChunkManagerTest.cpp
@@ -13,8 +13,10 @@
 #include <cstdint>
 
 #include <gtest/gtest.h>
+#include <future>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "storage/MmapChunkManager.h"
@@ -46,4 +48,35 @@ TEST(MmapChunkManager, AllocateKeepsTypedBuffersAligned) {
         0);
 
     ASSERT_NO_THROW(mcm->UnRegister(segment_descriptor));
+}
+
+TEST(MmapChunkManager, ConcurrentRegistrationsRemainIndependent) {
+    auto mcm =
+        milvus::storage::MmapManager::GetInstance().GetMmapChunkManager();
+    using Descriptor = milvus::storage::MmapChunkDescriptorPtr;
+    std::vector<std::future<std::vector<Descriptor>>> futures;
+    for (int worker = 0; worker < 8; ++worker) {
+        futures.push_back(std::async(std::launch::async, [mcm] {
+            std::vector<Descriptor> descriptors;
+            for (int i = 0; i < 16; ++i) {
+                descriptors.push_back(mcm->Register());
+            }
+            return descriptors;
+        }));
+    }
+    std::vector<Descriptor> descriptors;
+    for (auto& future : futures) {
+        auto registered = future.get();
+        descriptors.insert(
+            descriptors.end(), registered.begin(), registered.end());
+    }
+
+    for (size_t i = 0; i < descriptors.size(); ++i) {
+        ASSERT_TRUE(mcm->HasRegister(descriptors[i]));
+        mcm->UnRegister(descriptors[i]);
+        ASSERT_FALSE(mcm->HasRegister(descriptors[i]));
+        for (size_t j = i + 1; j < descriptors.size(); ++j) {
+            ASSERT_TRUE(mcm->HasRegister(descriptors[j]));
+        }
+    }
 }

--- a/internal/core/thirdparty/tantivy/rust-array.h
+++ b/internal/core/thirdparty/tantivy/rust-array.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <iostream>
-#include <memory>
+#include <optional>
 #include <sstream>
+#include <utility>
 
 #include "tantivy-binding.h"
 #include "rust-binding.h"
@@ -135,19 +136,18 @@ struct RustResultWrapper {
     NO_COPY_OR_ASSIGN(RustResultWrapper);
 
     RustResultWrapper() = default;
-    explicit RustResultWrapper(RustResult result)
-        : result_(std::make_unique<RustResult>(result)) {
+    explicit RustResultWrapper(RustResult result) noexcept : result_(result) {
     }
 
-    RustResultWrapper(RustResultWrapper&& other) noexcept {
-        result_ = std::move(other.result_);
+    RustResultWrapper(RustResultWrapper&& other) noexcept
+        : result_(std::exchange(other.result_, std::nullopt)) {
     }
 
     RustResultWrapper&
     operator=(RustResultWrapper&& other) noexcept {
         if (this != &other) {
             free();
-            result_ = std::move(other.result_);
+            result_ = std::exchange(other.result_, std::nullopt);
         }
 
         return *this;
@@ -157,7 +157,7 @@ struct RustResultWrapper {
         free();
     }
 
-    std::unique_ptr<RustResult> result_;
+    std::optional<RustResult> result_;
 
  private:
     void

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -94,7 +94,8 @@ struct TantivyIndexWrapper {
                         uintptr_t num_threads = DEFAULT_NUM_THREADS,
                         uintptr_t overall_memory_budget_in_bytes =
                             DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES,
-                        bool enable_background_merge = false) {
+                        bool enable_background_merge = false)
+        : path_(path) {
         RustResultWrapper res;
         if (inverted_single_semgnent) {
             AssertInfo(tantivy_index_version == 5,
@@ -117,14 +118,13 @@ struct TantivyIndexWrapper {
                    "failed to create index: {}",
                    res.result_->error);
         writer_ = res.result_->value.ptr._0;
-        path_ = std::string(path);
     }
 
     // load index. create index reader.
     explicit TantivyIndexWrapper(const char* path,
                                  bool load_in_mmap,
                                  SetBitsetFn set_bitset)
-        : load_in_mmap_(load_in_mmap) {
+        : path_(path), load_in_mmap_(load_in_mmap) {
         assert(tantivy_index_exist(path));
         auto res = RustResultWrapper(
             tantivy_load_index(path, load_in_mmap_, set_bitset));
@@ -132,7 +132,6 @@ struct TantivyIndexWrapper {
                    "failed to load index: {}",
                    res.result_->error);
         reader_ = res.result_->value.ptr._0;
-        path_ = std::string(path);
     }
 
     // create index writer for text type with tokenizer.
@@ -150,7 +149,8 @@ struct TantivyIndexWrapper {
                         uintptr_t num_threads = DEFAULT_NUM_THREADS,
                         uintptr_t overall_memory_budget_in_bytes =
                             DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES,
-                        bool enable_background_merge = false) {
+                        bool enable_background_merge = false)
+        : path_(path) {
         auto res = RustResultWrapper(
             tantivy_create_text_writer(field_name,
                                        path,
@@ -166,7 +166,6 @@ struct TantivyIndexWrapper {
                    "failed to create text writer: {}",
                    res.result_->error);
         writer_ = res.result_->value.ptr._0;
-        path_ = std::string(path);
     }
 
     // create index writer for json key stats
@@ -176,7 +175,8 @@ struct TantivyIndexWrapper {
                         bool in_ram = false,
                         uintptr_t num_threads = DEFAULT_NUM_THREADS,
                         uintptr_t overall_memory_budget_in_bytes =
-                            DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES) {
+                            DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES)
+        : path_(path) {
         auto res = RustResultWrapper(
             tantivy_create_json_key_stats_writer(field_name,
                                                  path,
@@ -188,7 +188,6 @@ struct TantivyIndexWrapper {
                    "failed to create text writer: {}",
                    res.result_->error);
         writer_ = res.result_->value.ptr._0;
-        path_ = std::string(path);
     }
 
     // create index writer for ngram
@@ -198,7 +197,8 @@ struct TantivyIndexWrapper {
                         uintptr_t max_gram,
                         uintptr_t num_threads = DEFAULT_NUM_THREADS,
                         uintptr_t overall_memory_budget_in_bytes =
-                            DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES) {
+                            DEFAULT_OVERALL_MEMORY_BUDGET_IN_BYTES)
+        : path_(path) {
         auto res = RustResultWrapper(
             tantivy_create_ngram_writer(field_name,
                                         path,
@@ -211,7 +211,6 @@ struct TantivyIndexWrapper {
                    "failed to create ngram writer: {}",
                    res.result_->error);
         writer_ = res.result_->value.ptr._0;
-        path_ = std::string(path);
     }
 
     // create reader.

--- a/internal/core/unittest/test_rust_result.cpp
+++ b/internal/core/unittest/test_rust_result.cpp
@@ -12,9 +12,12 @@
 #include <stddef.h>
 #include <cstdint>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 #include "gtest/gtest.h"
 #include "tantivy-binding.h"
+#include "rust-array.h"
 
 TEST(RustResultTest, TestResult) {
     auto arr = test_enum_with_array();
@@ -28,4 +31,49 @@ TEST(RustResultTest, TestResult) {
     EXPECT_EQ(1, *static_cast<uint32_t*>(ptr.value.ptr._0));
     free_rust_result(ptr);
     free_test_ptr(ptr.value.ptr._0);
+}
+
+using milvus::tantivy::RustArrayWrapper;
+using milvus::tantivy::RustResultWrapper;
+
+static_assert(std::is_nothrow_constructible_v<RustResultWrapper, RustResult>);
+static_assert(std::is_nothrow_move_constructible_v<RustResultWrapper>);
+static_assert(std::is_nothrow_move_assignable_v<RustResultWrapper>);
+
+TEST(RustResultTest, WrapperMovesTransferOwnership) {
+    RustResultWrapper source(test_enum_with_array());
+    auto* original_array = source.result_->value.rust_array._0.array;
+
+    RustResultWrapper moved(std::move(source));
+    EXPECT_FALSE(source.result_);
+    ASSERT_TRUE(moved.result_);
+    EXPECT_EQ(moved.result_->value.rust_array._0.array, original_array);
+
+    // Replacing an existing result must release it before adopting the source.
+    RustResultWrapper destination(test_enum_with_array());
+    destination = std::move(moved);
+    EXPECT_FALSE(moved.result_);
+    ASSERT_TRUE(destination.result_);
+    EXPECT_EQ(destination.result_->value.rust_array._0.array, original_array);
+    EXPECT_EQ(destination.result_->value.rust_array._0.len, 3);
+    EXPECT_EQ(destination.result_->value.rust_array._0.array[2], 3);
+
+    RustResultWrapper empty;
+    destination = std::move(empty);
+    EXPECT_FALSE(destination.result_);
+    EXPECT_FALSE(empty.result_);
+}
+
+TEST(RustResultTest, WrapperCanTransferArrayOwnership) {
+    RustResultWrapper result(test_enum_with_array());
+    auto* original_array = result.result_->value.rust_array._0.array;
+    RustArrayWrapper array(std::move(result.result_->value.rust_array._0));
+    EXPECT_EQ(result.result_->value.rust_array._0.array, nullptr);
+    EXPECT_EQ(array.array_.array, original_array);
+
+    // Releasing the moved-from result must leave the transferred array valid.
+    result = RustResultWrapper();
+    EXPECT_EQ(array.array_.len, 3);
+    EXPECT_EQ(array.array_.array[0], 1);
+    EXPECT_EQ(array.array_.array[2], 3);
 }

--- a/internal/distributed/proxy/httpserver/wrap_request.go
+++ b/internal/distributed/proxy/httpserver/wrap_request.go
@@ -331,7 +331,7 @@ func (f *FieldData) AsSchemapb() (*schemapb.FieldData, error) {
 		if len(wrappedData) < 1 {
 			return nil, merr.WrapErrParameterInvalidMsg("at least one row for insert")
 		}
-		data := make([][]byte, len(wrappedData))
+		data := make([][]byte, 0, len(wrappedData))
 		dim := int64(0)
 		for _, row := range wrappedData {
 			rowData, err := typeutil.CreateSparseFloatRowFromMap(row)

--- a/internal/distributed/proxy/httpserver/wrap_request_test.go
+++ b/internal/distributed/proxy/httpserver/wrap_request_test.go
@@ -302,8 +302,19 @@ func TestFieldData_AsSchemapb(t *testing.T) {
 		}
 		raw, _ := json.Marshal(fieldData)
 		json.Unmarshal(raw, &fieldData)
-		_, err := fieldData.AsSchemapb()
-		assert.NoError(t, err)
+		converted, err := fieldData.AsSchemapb()
+		require.NoError(t, err)
+		sparse := converted.GetVectors().GetSparseFloatVector()
+		require.Len(t, sparse.GetContents(), 3)
+		assert.Equal(t, int64(7), sparse.GetDim())
+		for i, indices := range [][]uint32{{1, 2}, {3, 5}, {4, 6}} {
+			expected, err := typeutil.CreateSparseFloatRowFromMap(map[string]interface{}{
+				"indices": []interface{}{float64(indices[0]), float64(indices[1])},
+				"values":  []interface{}{0.1, 0.2},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, expected, sparse.GetContents()[i])
+		}
 	})
 
 	t.Run("sparsefloatvector_ok_2", func(t *testing.T) {
@@ -317,8 +328,19 @@ func TestFieldData_AsSchemapb(t *testing.T) {
 		}
 		raw, _ := json.Marshal(fieldData)
 		json.Unmarshal(raw, &fieldData)
-		_, err := fieldData.AsSchemapb()
-		assert.NoError(t, err)
+		converted, err := fieldData.AsSchemapb()
+		require.NoError(t, err)
+		sparse := converted.GetVectors().GetSparseFloatVector()
+		require.Len(t, sparse.GetContents(), 3)
+		assert.Equal(t, int64(7), sparse.GetDim())
+		for i, indices := range [][]uint32{{1, 2}, {3, 5}, {4, 6}} {
+			expected, err := typeutil.CreateSparseFloatRowFromMap(map[string]interface{}{
+				"indices": []interface{}{float64(indices[0]), float64(indices[1])},
+				"values":  []interface{}{0.1, 0.2},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, expected, sparse.GetContents()[i])
+		}
 	})
 
 	t.Run("sparsefloatvector_ok_3", func(t *testing.T) {
@@ -332,8 +354,19 @@ func TestFieldData_AsSchemapb(t *testing.T) {
 		}
 		raw, _ := json.Marshal(fieldData)
 		json.Unmarshal(raw, &fieldData)
-		_, err := fieldData.AsSchemapb()
-		assert.NoError(t, err)
+		converted, err := fieldData.AsSchemapb()
+		require.NoError(t, err)
+		sparse := converted.GetVectors().GetSparseFloatVector()
+		require.Len(t, sparse.GetContents(), 3)
+		assert.Equal(t, int64(7), sparse.GetDim())
+		for i, indices := range [][]uint32{{1, 2}, {3, 5}, {4, 6}} {
+			expected, err := typeutil.CreateSparseFloatRowFromMap(map[string]interface{}{
+				"indices": []interface{}{float64(indices[0]), float64(indices[1])},
+				"values":  []interface{}{0.1, 0.2},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, expected, sparse.GetContents()[i])
+		}
 	})
 
 	t.Run("sparsefloatvector_empty_err", func(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/wrap_request_test.go
+++ b/internal/distributed/proxy/httpserver/wrap_request_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestFieldData_AsSchemapb(t *testing.T) {

--- a/internal/proxy/fieldvalidator/validate_util.go
+++ b/internal/proxy/fieldvalidator/validate_util.go
@@ -1203,6 +1203,15 @@ func (v *ValidateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fi
 		return merr.WrapErrParameterInvalid("valid length array", "array length exceeds max capacity", msg)
 	}
 
+	// Each row's dimension is serialized into the insert message and used by
+	// segcore to allocate its VectorArray, so it must agree with the schema.
+	for i, vector := range data.GetData() {
+		if vector.GetDim() != dim {
+			return merr.WrapErrParameterInvalidMsg("array of vector field %s row %d has dim %d, expected %d",
+				field.GetFieldName(), i, vector.GetDim(), dim)
+		}
+	}
+
 	validateVectorCount := func(payloadLength int, elementsPerVector int) (int, error) {
 		if elementsPerVector <= 0 {
 			return 0, merr.WrapErrParameterInvalidMsg("invalid dim %d for array of vector field %s", dim, field.GetFieldName())

--- a/internal/proxy/fieldvalidator/validate_util_test.go
+++ b/internal/proxy/fieldvalidator/validate_util_test.go
@@ -7985,6 +7985,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 						VectorArray: &schemapb.VectorArray{
 							Data: []*schemapb.VectorField{
 								{
+									Dim: 3,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{1.0, 2.0, float32(math.NaN())},
@@ -8016,6 +8017,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 						VectorArray: &schemapb.VectorArray{
 							Data: []*schemapb.VectorField{
 								{
+									Dim: 1,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{float32(math.NaN())},
@@ -8046,6 +8048,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 						VectorArray: &schemapb.VectorArray{
 							Data: []*schemapb.VectorField{
 								{
+									Dim: 2,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{1.0, 2.0},
@@ -8053,6 +8056,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 									},
 								},
 								{
+									Dim: 2,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{3.0, 4.0},
@@ -8084,6 +8088,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 						VectorArray: &schemapb.VectorArray{
 							Data: []*schemapb.VectorField{
 								{
+									Dim: 2,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{1.0, 2.0, 3.0, 4.0},
@@ -8119,6 +8124,7 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 						VectorArray: &schemapb.VectorArray{
 							Data: []*schemapb.VectorField{
 								{
+									Dim: 2,
 									Data: &schemapb.VectorField_FloatVector{
 										FloatVector: &schemapb.FloatArray{
 											Data: []float32{1.0, 2.0, 3.0},
@@ -8141,6 +8147,58 @@ func Test_ValidateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "divisible")
 	})
+}
+
+func Test_ValidateUtil_ArrayOfVectorRowDimensions(t *testing.T) {
+	cases := []struct {
+		elementType schemapb.DataType
+		row         *schemapb.VectorField
+	}{
+		{schemapb.DataType_FloatVector, &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}}}}},
+		{schemapb.DataType_BinaryVector, &schemapb.VectorField{Dim: 16, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2}}}},
+		{schemapb.DataType_Float16Vector, &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_Float16Vector{Float16Vector: make([]byte, 8)}}},
+		{schemapb.DataType_BFloat16Vector, &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: make([]byte, 8)}}},
+		{schemapb.DataType_Int8Vector, &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.elementType.String(), func(t *testing.T) {
+			dim := tc.row.GetDim()
+			schema := &schemapb.FieldSchema{
+				FieldID: 100, Name: "vectors", DataType: schemapb.DataType_ArrayOfVector,
+				ElementType: tc.elementType, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: fmt.Sprint(dim)}},
+			}
+			helper, err := typeutil.CreateSchemaHelper(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{schema}})
+			require.NoError(t, err)
+			newField := func() *schemapb.FieldData {
+				return &schemapb.FieldData{
+					FieldId: 100, FieldName: "vectors", Type: schemapb.DataType_ArrayOfVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim: dim, ValidData: []bool{true, false},
+						Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+							Dim: dim, ElementType: tc.elementType, Data: []*schemapb.VectorField{tc.row},
+						}},
+					}},
+				}
+			}
+			v := NewValidateUtil()
+			for _, invalidDim := range []int64{0, -1, dim - 1, dim + 1} {
+				t.Run(fmt.Sprint(invalidDim), func(t *testing.T) {
+					tc.row.Dim = invalidDim
+					err := v.Validate([]*schemapb.FieldData{newField()}, helper, 2)
+					require.ErrorIs(t, err, merr.ErrParameterInvalid)
+					assert.Contains(t, err.Error(), "row 0 has dim")
+				})
+			}
+			tc.row.Dim = dim
+			field := newField()
+			require.NoError(t, v.Validate([]*schemapb.FieldData{field}, helper, 2))
+			rows := field.GetVectors().GetVectorArray().GetData()
+			require.Len(t, rows, 2)
+			assert.Equal(t, dim, rows[0].GetDim())
+			assert.Equal(t, dim, rows[1].GetDim())
+		})
+	}
 }
 
 func Test_ValidateUtil_checkAligned_ArrayOfVector(t *testing.T) {

--- a/internal/proxy/fieldvalidator/validate_util_test.go
+++ b/internal/proxy/fieldvalidator/validate_util_test.go
@@ -8173,8 +8173,9 @@ func Test_ValidateUtil_ArrayOfVectorRowDimensions(t *testing.T) {
 			newField := func() *schemapb.FieldData {
 				return &schemapb.FieldData{
 					FieldId: 100, FieldName: "vectors", Type: schemapb.DataType_ArrayOfVector,
+					ValidData: []bool{true, false},
 					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
-						Dim: dim, ValidData: []bool{true, false},
+						Dim: dim,
 						Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
 							Dim: dim, ElementType: tc.elementType, Data: []*schemapb.VectorField{tc.row},
 						}},

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -246,8 +246,8 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 	}
 
 	partitionIDs := make([]int64, len(colMeta.Partitions))
-	for _, p := range colMeta.Partitions {
-		partitionIDs = append(partitionIDs, p.PartitionID)
+	for i, p := range colMeta.Partitions {
+		partitionIDs[i] = p.PartitionID
 	}
 	dcReq := &datapb.AlterCollectionRequest{
 		CollectionID:   collectionID,

--- a/internal/rootcoord/broker_test.go
+++ b/internal/rootcoord/broker_test.go
@@ -226,7 +226,13 @@ func TestServerBroker_BroadcastAlteredCollection(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		c := newTestCore(withValidMixCoord())
+		mixCoord := mocks.NewMixCoord(t)
+		mixCoord.On("BroadcastAlteredCollection", mock.Anything,
+			mock.MatchedBy(func(req *datapb.AlterCollectionRequest) bool {
+				return assert.Equal(t, int64(1), req.GetCollectionID()) &&
+					assert.Equal(t, []int64{2}, req.GetPartitionIDs())
+			})).Return(merr.Success(), nil).Once()
+		c := newTestCore(withMixCoord(mixCoord))
 		meta := mockrootcoord.NewIMetaTable(t)
 		meta.On("GetCollectionByID",
 			mock.Anything,

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -182,24 +182,24 @@ func (pr *PackedReader) ReadNext() (arrow.Record, error) {
 		pr.currentBatch.Release()
 		pr.currentBatch = nil
 	}
-	var cArr C.CArrowArray
-	var cSchema C.CArrowSchema
+	// The caller owns the Arrow structs; importing transfers their buffers only.
+	var cArr C.struct_ArrowArray
+	var cSchema C.struct_ArrowSchema
+	goCArr := (*cdata.CArrowArray)(unsafe.Pointer(&cArr))
+	goCSchema := (*cdata.CArrowSchema)(unsafe.Pointer(&cSchema))
+	defer func() {
+		cdata.ReleaseCArrowArray(goCArr)
+		cdata.ReleaseCArrowSchema(goCSchema)
+	}()
 	status := C.ReadNext(pr.cPackedReader, &cArr, &cSchema)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, err
 	}
 
-	if cArr == nil {
+	if cArr.release == nil {
 		return nil, io.EOF // end of stream, no more records to read
 	}
 
-	// Convert ArrowArray to Go RecordBatch using cdata
-	goCArr := (*cdata.CArrowArray)(unsafe.Pointer(cArr))
-	goCSchema := (*cdata.CArrowSchema)(unsafe.Pointer(cSchema))
-	defer func() {
-		cdata.ReleaseCArrowArray(goCArr)
-		cdata.ReleaseCArrowSchema(goCSchema)
-	}()
 	recordBatch, err := cdata.ImportCRecordBatch(goCArr, goCSchema)
 	if err != nil {
 		return nil, merr.WrapErrStorage(err, "failed to convert ArrowArray to Record")


### PR DESCRIPTION
Native buffers can lose their owner between allocation and result construction, while partial flush and aggregate states need cleanup when execution exits early. Two Go conversions also append to slices whose lengths are already populated, producing extra sparse-vector rows or partition IDs.

Backport the ownership, validation and slice fixes from master PR #53345 to `3.0`.

pr: #53345
issue: #53344

### Changes

- Validate vector-array row dimensions and payload widths; use matching allocation/deletion types and keep allocating Array copies throwable.
- Preserve ownership through mmap registration/chunk transfer, range/retrieve result construction, partial BM25 flush output, aggregation rows/string MIN/MAX states, and temporary Roaring bitmaps.
- Export packed-reader batches into caller-owned Arrow structs, store Rust results inline, and initialize Tantivy paths before acquiring native handles.
- Produce exactly one sparse-vector row and partition ID per input entry, with content assertions.

### 3.0 adaptations

- Cherry-pick `a4e929ce02` and the test-portability follow-up `903aacec24`, with source commit trailers and DCO sign-offs.
- Omit the one-line update to `ArrayValueTest.cpp`: the recursive-array test suite and its call site do not exist on `3.0`.
- Use `FieldData.ValidData` in the nullable vector-array regression test, matching the existing 3.0 protobuf. No protobuf dependency upgrade is needed.
- Preserve 3.0's existing error translation and Tantivy FFI layout. The packed-reader C signature and its Go caller are updated together.

### Validation

- Passed the complete `internal/proxy/fieldvalidator` and `pkg/util/merr` packages using `-tags dynamic,test -gcflags='all=-N -l' -count=1`.
- Passed the exact 3.0 sparse conversion method and the three regression cases in an isolated source-level Go package. Restoring the original allocation makes all three cases fail with six rows instead of three.
- Passed an ASan/UBSan standalone check against the 3.0 RustResultWrapper and FFI headers, including adoption while C++ allocation is disabled, move/replacement, and array transfer.
- Passed an ASan/UBSan standalone check containing the exact 3.0 retrieve helper: success, standard/nonstandard serialization exceptions, payload allocation failure, and result-wrapper allocation failure all leave no live payload allocations.
- Audited the changed ownership transfer call sites and the 3.0 flush cleanup path; passed clang-format 15 for all changed C++ files, Go formatting, and `git diff --check`.

Full native GTests and integration validation remain pending CI. CMake configuration is blocked locally by missing `glogConfig.cmake`; HTTP/RootCoord/packed Go package tests cannot build without the `milvus_core`, `milvus-storage`, and RocksDB pkg-config dependencies. The isolated checks above do not substitute for native integration or demonstrate complete OOM recovery.

Master PR #53345 is still open and should merge before this backport.
