### PR TITLE
fix: limit boolean expression nesting depth to prevent proxy crash

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -414,6 +414,13 @@ proxy:
   roleNameValidation:
     allowedChars: $ # Additional characters allowed in role names beyond underscores, letters and numbers. Add '-' to allow hyphens in role names.
   maxTaskNum: 1024 # The maximum number of tasks in the task queue of the proxy.
+  # Maximum structural nesting depth a boolean expression may use. Parsing walks the expression
+  # recursively (ANTLR recursive descent, then the plan visitor), so an unbounded depth lets a single
+  # request exhaust the goroutine stack and crash the process; requests past the bound are rejected as
+  # invalid before parsing starts. When the limit is applied, values above 10000 are clamped to 10000
+  # (far shallower nesting already exceeds any legitimate filter) and values below 1 fall back to the
+  # default.
+  maxExpressionDepth: 1000
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection

--- a/internal/parser/planparserv2/plan_parser_depth_limit_test.go
+++ b/internal/parser/planparserv2/plan_parser_depth_limit_test.go
@@ -1,0 +1,51 @@
+package planparserv2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestExpr_NestingDepthLimit(t *testing.T) {
+	paramtable.Init()
+
+	schema := newTestSchema(false)
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	assert.NoError(t, err)
+
+	t.Run("expressions within the default limit still parse", func(t *testing.T) {
+		nested := strings.Repeat("(", 100) + "FieldID > 0" + strings.Repeat(")", 100)
+		_, err := CreateRetrievePlan(helper, nested, nil)
+		assert.NoError(t, err)
+
+		unary := strings.Repeat("not ", 100) + "(FieldID > 0)"
+		_, err = CreateRetrievePlan(helper, unary, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("depth beyond the configured limit is rejected", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.MaxExpressionDepth.Key, "50")
+		defer paramtable.Get().Remove(paramtable.Get().ProxyCfg.MaxExpressionDepth.Key)
+
+		nested := strings.Repeat("(", 51) + "FieldID > 0" + strings.Repeat(")", 51)
+		_, err := CreateRetrievePlan(helper, nested, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nesting depth")
+
+		// a deeply nested unary chain is rejected as well
+		unary := strings.Repeat("not ", 51) + "(FieldID > 0)"
+		_, err = CreateRetrievePlan(helper, unary, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("an over-limit value is clamped before use", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().ProxyCfg.MaxExpressionDepth.Key, "1000000")
+		defer paramtable.Get().Remove(paramtable.Get().ProxyCfg.MaxExpressionDepth.Key)
+
+		assert.Equal(t, maxExprNestingDepthLimit, exprNestingLimit())
+	})
+}

--- a/internal/parser/planparserv2/plan_parser_v2.go
+++ b/internal/parser/planparserv2/plan_parser_v2.go
@@ -163,6 +163,9 @@ func handleExprInternal(schema *typeutil.SchemaHelper, exprStr string, visitorAr
 	if isEmptyExpression(exprStr) {
 		return trueLiteral
 	}
+	if err := checkExprNestingDepth(exprStr); err != nil {
+		return err
+	}
 	ast, err := handleInternal(exprStr)
 	if err != nil {
 		return err
@@ -174,6 +177,106 @@ func handleExprInternal(schema *typeutil.SchemaHelper, exprStr string, visitorAr
 
 func handleExpr(schema *typeutil.SchemaHelper, exprStr string) (result interface{}) {
 	return handleExprInternal(schema, exprStr, &ParserVisitorArgs{})
+}
+
+const (
+	// defaultExprNestingDepth mirrors the proxy.maxExpressionDepth default.
+	defaultExprNestingDepth = 1000
+	// maxExprNestingDepthLimit is the hard upper bound accepted for
+	// proxy.maxExpressionDepth: a limit beyond it would defeat the purpose
+	// of the guard, since far shallower nesting already exhausts the
+	// goroutine stack.
+	maxExprNestingDepthLimit = 10000
+)
+
+// exprNestingLimit returns the effective expression nesting limit.
+func exprNestingLimit() int {
+	limit := paramtable.Get().ProxyCfg.MaxExpressionDepth.GetAsInt()
+	if limit <= 0 {
+		limit = defaultExprNestingDepth
+	}
+	return min(limit, maxExprNestingDepthLimit)
+}
+
+// exprNestingDepth measures the structural nesting of an expression. The
+// recursion points of the expression grammar (Plan.g4) are grouping
+// parentheses and brackets, exists/not/unary +/-/~ prefixes, and
+// parenthesized sub-expressions, so bounding them bounds both the ANTLR
+// parser and the plan visitor recursion.
+func exprNestingDepth(expr string) int {
+	depth, maxDepth := 0, 0
+	// Unary operators stack: "not not (" recurses two levels before the
+	// group, so pending prefixes are folded into the depth when the next
+	// non-unary token arrives.
+	pendingUnary := 0
+	applyPending := func() {
+		depth += pendingUnary
+		if depth > maxDepth {
+			maxDepth = depth
+		}
+		pendingUnary = 0
+	}
+	for i := 0; i < len(expr); {
+		if end, ok := unaryKeywordAt(expr, i); ok {
+			pendingUnary++
+			i = end
+			continue
+		}
+		switch expr[i] {
+		case '(', '[':
+			applyPending()
+			depth++
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		case ')', ']':
+			applyPending()
+			if depth > 0 {
+				depth--
+			}
+		case '!', '~', '+', '-':
+			applyPending()
+			pendingUnary++
+		default:
+			applyPending()
+		}
+		i++
+	}
+	applyPending()
+	return maxDepth
+}
+
+// unaryKeywordAt reports whether a not/exists keyword starts at index i and
+// returns the index just past it. Identifier boundaries are enforced so
+// names like "notes" do not count as unary prefixes.
+func unaryKeywordAt(expr string, i int) (int, bool) {
+	rest := expr[i:]
+	for _, kw := range []string{"not", "exists"} {
+		if len(rest) < len(kw) || !strings.EqualFold(rest[:len(kw)], kw) {
+			continue
+		}
+		end := i + len(kw)
+		if (i == 0 || !isWordChar(expr[i-1])) && (end == len(expr) || !isWordChar(expr[end])) {
+			return end, true
+		}
+	}
+	return i, false
+}
+
+func isWordChar(c byte) bool {
+	return c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// checkExprNestingDepth rejects expressions whose structural nesting exceeds
+// proxy.maxExpressionDepth before the ANTLR parser runs: parsing recurses
+// once per nesting level on the goroutine stack, and a stack overflow is a
+// fatal runtime error that recover() cannot intercept.
+func checkExprNestingDepth(expr string) error {
+	limit := exprNestingLimit()
+	if depth := exprNestingDepth(expr); depth > limit {
+		return merr.WrapErrParameterInvalidMsg("expression nesting depth %d exceeds the maximum allowed %d (proxy.maxExpressionDepth)", depth, limit)
+	}
+	return nil
 }
 
 func parseExprTemplateInner(schema *typeutil.SchemaHelper, exprStr string, visitorArgs *ParserVisitorArgs) (*planpb.Expr, error) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2516,6 +2516,7 @@ type proxyConfig struct {
 	NameValidationAllowedChars        ParamItem `refreshable:"true"`
 	RoleNameValidationAllowedChars    ParamItem `refreshable:"true"`
 	MaxTaskNum                        ParamItem `refreshable:"false"`
+	MaxExpressionDepth                ParamItem `refreshable:"true"`
 	DDLConcurrency                    ParamItem `refreshable:"true"`
 	DCLConcurrency                    ParamItem `refreshable:"true"`
 	ShardLeaderCacheInterval          ParamItem `refreshable:"false"`
@@ -2788,6 +2789,21 @@ For migration, enable streaming.splitChunkSN first, then disable proxy.splitChun
 		Export:       true,
 	}
 	p.MaxTaskNum.Init(base.mgr)
+
+	p.MaxExpressionDepth = ParamItem{
+		Key:          "proxy.maxExpressionDepth",
+		Version:      "3.0.3",
+		DefaultValue: "1000",
+		Formatter:    positiveProxyLimitFormatter("1000"),
+		Doc: `Maximum structural nesting depth a boolean expression may use. Parsing walks the expression
+recursively (ANTLR recursive descent, then the plan visitor), so an unbounded depth lets a single
+request exhaust the goroutine stack and crash the process; requests past the bound are rejected as
+invalid before parsing starts. When the limit is applied, values above 10000 are clamped to 10000
+(far shallower nesting already exceeds any legitimate filter) and values below 1 fall back to the
+default.`,
+		Export: true,
+	}
+	p.MaxExpressionDepth.Init(base.mgr)
 
 	p.DDLConcurrency = ParamItem{
 		Key:          "proxy.ddlConcurrency",


### PR DESCRIPTION
## What this PR does / why we need it

A single Search/Query/Delete request can crash the whole proxy with an unrecoverable `fatal error: stack overflow`.

The boolean expression of a request is parsed by planparserv2 through recursive descent (ANTLR `parser.Expr()`), and the recursion depth of an expression is unbounded. Grammar rules like `'(' expr ')'`, `NOT expr`, `EXISTS expr` and the unary `+/-/~` prefixes recurse once per nesting level on the goroutine stack. A filter such as `"((((...))))"` about 1M levels deep (a ~2MB string, well under the gRPC max receive size) exhausts the default 1GB stack; the fatal error is thrown by the runtime, so the `recover()` in `handleExprInternal` cannot catch it and the process dies. Repeating the request keeps the cluster down. Expressions that stay under the stack limit still allocate one parser context per level, which the expression cache (1024 entries) then holds for 10 minutes.

Reproduced on a standalone deployment with `authorizationEnabled=true`: one query request with a deeply nested filter terminates the process (`runtime: goroutine stack exceeds 1000000000-byte limit`).

## Changes

- `internal/parser/planparserv2/plan_parser_v2.go`: check the structural nesting of an expression before parsing, at the single entry point every parse path goes through (`handleExprInternal`). The scan counts grouping parens/brackets and runs of `not`/`exists`/unary `+/-/~` prefixes — the recursion points of the grammar — so bounding them bounds both the parser and the visitor recursion.
- `pkg/util/paramtable/component_param.go`: new refreshable param `proxy.maxExpressionDepth` (default 1000). Values above 10000 are clamped when the limit is applied, since far shallower nesting already exceeds any legitimate filter; values below 1 fall back to the default.
- `internal/parser/planparserv2/plan_parser_depth_limit_test.go`: expressions within the limit still parse; over-limit parens and unary chains are rejected; an over-limit configured value is clamped.

Expressions within the limit are untouched: the scan is a pre-parse pass, and a rejected request never reaches the parser or the expression cache.

## Tests

- `go test ./internal/parser/...` passes (planparserv2 + rewriter).
- New `TestExpr_NestingDepthLimit` covers the three cases above.
- Before: `CreateRetrievePlan` with a 1M-deep expression dies with `fatal error: stack overflow`. After: the same request returns an invalid-parameter error.

issue: #53404
