### PR TITLE
fix: enforce RBAC authorization on the low-level REST API

### DIFF
--- a/internal/distributed/proxy/httpserver/handler.go
+++ b/internal/distributed/proxy/httpserver/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // Handlers handles http requests
@@ -112,6 +113,31 @@ func (h *Handlers) handleGetHealth(c *gin.Context) (interface{}, error) {
 	return gin.H{"status": "ok"}, nil
 }
 
+// checkAuthorization enforces the same RBAC rules on the low-level REST API
+// that the gRPC chain applies through PrivilegeInterceptor: the handlers below
+// invoke the proxy implementation directly, which performs no privilege check
+// of its own. The check is a no-op while authorization is disabled, matching
+// the gRPC path, and skips the liveness and debug endpoints that carry no
+// privilege annotation in the proto definition.
+func (h *Handlers) checkAuthorization(c *gin.Context, req interface{}) error {
+	if !paramtable.Get().CommonCfg.AuthorizationEnabled.GetAsBool() {
+		return nil
+	}
+	username, ok := c.Get(ContextUsername)
+	if !ok || username.(string) == "" {
+		return merr.Mark(merr.ErrNeedAuthenticate, errUnauthorized)
+	}
+	// The database a request targets is taken from the request body by the
+	// privilege interceptor itself, so no db metadata is injected here.
+	ctx := proxy.NewContextWithMetadata(c.Request.Context(), username.(string), "")
+	ctx, authErr := proxy.PrivilegeInterceptorWithMetaCache(h.metaCache)(ctx, req)
+	if authErr != nil {
+		return merr.Mark(authErr, errForbidden)
+	}
+	c.Request = c.Request.WithContext(ctx)
+	return nil
+}
+
 func (h *Handlers) handleDummy(c *gin.Context) (interface{}, error) {
 	req := milvuspb.DummyRequest{}
 	// use ShouldBind to supports binding JSON, XML, YAML, and protobuf.
@@ -141,6 +167,9 @@ func (h *Handlers) handleCreateCollection(c *gin.Context) (interface{}, error) {
 		ConsistencyLevel: wrappedReq.ConsistencyLevel,
 		Properties:       wrappedReq.Properties,
 	}
+	if err := h.checkAuthorization(c, req); err != nil {
+		return nil, err
+	}
 	return h.proxy.CreateCollection(c, req)
 }
 
@@ -149,6 +178,9 @@ func (h *Handlers) handleDropCollection(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.DropCollection(c, &req)
 }
@@ -159,6 +191,9 @@ func (h *Handlers) handleHasCollection(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.HasCollection(c, &req)
 }
 
@@ -167,6 +202,9 @@ func (h *Handlers) handleDescribeCollection(c *gin.Context) (interface{}, error)
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.DescribeCollection(c, &req)
 }
@@ -177,6 +215,9 @@ func (h *Handlers) handleLoadCollection(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.LoadCollection(c, &req)
 }
 
@@ -185,6 +226,9 @@ func (h *Handlers) handleReleaseCollection(c *gin.Context) (interface{}, error) 
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.ReleaseCollection(c, &req)
 }
@@ -195,6 +239,9 @@ func (h *Handlers) handleGetCollectionStatistics(c *gin.Context) (interface{}, e
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetCollectionStatistics(c, &req)
 }
 
@@ -203,6 +250,9 @@ func (h *Handlers) handleShowCollections(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.ShowCollections(c, &req)
 }
@@ -213,6 +263,9 @@ func (h *Handlers) handleCreatePartition(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.CreatePartition(c, &req)
 }
 
@@ -221,6 +274,9 @@ func (h *Handlers) handleDropPartition(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.DropPartition(c, &req)
 }
@@ -231,6 +287,9 @@ func (h *Handlers) handleHasPartition(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.HasPartition(c, &req)
 }
 
@@ -239,6 +298,9 @@ func (h *Handlers) handleLoadPartitions(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.LoadPartitions(c, &req)
 }
@@ -249,6 +311,9 @@ func (h *Handlers) handleReleasePartitions(c *gin.Context) (interface{}, error) 
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.ReleasePartitions(c, &req)
 }
 
@@ -257,6 +322,9 @@ func (h *Handlers) handleGetPartitionStatistics(c *gin.Context) (interface{}, er
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetPartitionStatistics(c, &req)
 }
@@ -267,6 +335,9 @@ func (h *Handlers) handleShowPartitions(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.ShowPartitions(c, &req)
 }
 
@@ -275,6 +346,9 @@ func (h *Handlers) handleCreateAlias(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.CreateAlias(c, &req)
 }
@@ -285,6 +359,9 @@ func (h *Handlers) handleDropAlias(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.DropAlias(c, &req)
 }
 
@@ -293,6 +370,9 @@ func (h *Handlers) handleAlterAlias(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.AlterAlias(c, &req)
 }
@@ -303,6 +383,9 @@ func (h *Handlers) handleCreateIndex(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.CreateIndex(c, &req)
 }
 
@@ -311,6 +394,9 @@ func (h *Handlers) handleDescribeIndex(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.DescribeIndex(c, &req)
 }
@@ -321,6 +407,9 @@ func (h *Handlers) handleGetIndexState(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetIndexState(c, &req)
 }
 
@@ -330,6 +419,9 @@ func (h *Handlers) handleGetIndexBuildProgress(c *gin.Context) (interface{}, err
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetIndexBuildProgress(c, &req)
 }
 
@@ -338,6 +430,9 @@ func (h *Handlers) handleDropIndex(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.DropIndex(c, &req)
 }
@@ -352,6 +447,9 @@ func (h *Handlers) handleInsert(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "convert body to pb failed")
 	}
+	if err := h.checkAuthorization(c, req); err != nil {
+		return nil, err
+	}
 	return h.proxy.Insert(c, req)
 }
 
@@ -360,6 +458,9 @@ func (h *Handlers) handleDelete(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.Delete(c, &req)
 }
@@ -395,6 +496,9 @@ func (h *Handlers) handleSearch(c *gin.Context) (interface{}, error) {
 			PlaceholderGroup: vector2Bytes(wrappedReq.Vectors),
 		}
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.Search(c, &req)
 }
 
@@ -404,6 +508,9 @@ func (h *Handlers) handleQuery(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.Query(c, &req)
 }
 
@@ -412,6 +519,9 @@ func (h *Handlers) handleFlush(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.Flush(c, &req)
 }
@@ -429,6 +539,9 @@ func (h *Handlers) handleCalcDistance(c *gin.Context) (interface{}, error) {
 		OpLeft:  wrappedReq.OpLeft.AsPbVectorArray(),
 		OpRight: wrappedReq.OpRight.AsPbVectorArray(),
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.CalcDistance(c, &req)
 }
 
@@ -437,6 +550,9 @@ func (h *Handlers) handleGetFlushState(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetFlushState(c, &req)
 }
@@ -447,6 +563,9 @@ func (h *Handlers) handleGetPersistentSegmentInfo(c *gin.Context) (interface{}, 
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetPersistentSegmentInfo(c, &req)
 }
 
@@ -455,6 +574,9 @@ func (h *Handlers) handleGetQuerySegmentInfo(c *gin.Context) (interface{}, error
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetQuerySegmentInfo(c, &req)
 }
@@ -465,6 +587,9 @@ func (h *Handlers) handleGetReplicas(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetReplicas(c, &req)
 }
 
@@ -473,6 +598,9 @@ func (h *Handlers) handleGetMetrics(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetMetrics(c, &req)
 }
@@ -483,6 +611,9 @@ func (h *Handlers) handleLoadBalance(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.LoadBalance(c, &req)
 }
 
@@ -491,6 +622,9 @@ func (h *Handlers) handleGetCompactionState(c *gin.Context) (interface{}, error)
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetCompactionState(c, &req)
 }
@@ -501,6 +635,9 @@ func (h *Handlers) handleGetCompactionStateWithPlans(c *gin.Context) (interface{
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.GetCompactionStateWithPlans(c, &req)
 }
 
@@ -509,6 +646,9 @@ func (h *Handlers) handleManualCompaction(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.ManualCompaction(c, &req)
 }
@@ -519,6 +659,9 @@ func (h *Handlers) handleImport(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.Import(c, &req)
 }
 
@@ -527,6 +670,9 @@ func (h *Handlers) handleGetImportState(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.GetImportState(c, &req)
 }
@@ -537,6 +683,9 @@ func (h *Handlers) handleListImportTasks(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.ListImportTasks(c, &req)
 }
 
@@ -545,6 +694,9 @@ func (h *Handlers) handleCreateCredential(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.CreateCredential(c, &req)
 }
@@ -555,6 +707,9 @@ func (h *Handlers) handleUpdateCredential(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.UpdateCredential(c, &req)
 }
 
@@ -564,6 +719,9 @@ func (h *Handlers) handleDeleteCredential(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
 	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
+	}
 	return h.proxy.DeleteCredential(c, &req)
 }
 
@@ -572,6 +730,9 @@ func (h *Handlers) handleListCredUsers(c *gin.Context) (interface{}, error) {
 	err := shouldBind(c, &req)
 	if err != nil {
 		return nil, badRequestf(err, "parse body failed")
+	}
+	if err := h.checkAuthorization(c, &req); err != nil {
+		return nil, err
 	}
 	return h.proxy.ListCredUsers(c, &req)
 }

--- a/internal/distributed/proxy/httpserver/handler_authz_test.go
+++ b/internal/distributed/proxy/httpserver/handler_authz_test.go
@@ -1,0 +1,134 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/proxy"
+	"github.com/milvus-io/milvus/internal/proxy/privilege"
+	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// authzProbeProxy counts how often a privileged operation is reached.
+type authzProbeProxy struct {
+	types.ProxyComponent
+
+	createCredentialCalls atomic.Int32
+}
+
+func (m *authzProbeProxy) CreateCredential(ctx context.Context, req *milvuspb.CreateCredentialRequest) (*commonpb.Status, error) {
+	m.createCredentialCalls.Add(1)
+	return testStatus, nil
+}
+
+// newLowLevelServerForAuthzTest builds the low-level REST server the way the
+// metrics port serves it, with an authentication middleware that only records
+// the parsed username, so the test exercises the authorization added on top.
+func newLowLevelServerForAuthzTest(t *testing.T, pxy types.ProxyComponent) *gin.Engine {
+	t.Helper()
+	h := NewHandlers(pxy)
+	ginHandler := gin.Default()
+	apiv1 := ginHandler.Group("/api/v1", func(c *gin.Context) {
+		username, _, ok := ParseUsernamePassword(c)
+		if !ok || username == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
+			return
+		}
+		c.Set(ContextUsername, username)
+	})
+	h.RegisterRoutesTo(apiv1)
+	return ginHandler
+}
+
+// TestLowLevelRESTAuthorization verifies that the low-level REST API enforces
+// the same RBAC rules as the gRPC path instead of letting any authenticated
+// user reach privileged proxy operations.
+func TestLowLevelRESTAuthorization(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+
+	cache := proxy.InitEmptyMetaCacheForTest()
+	require.NotNil(t, cache)
+
+	mp := &authzProbeProxy{}
+	testEngine := newLowLevelServerForAuthzTest(t, proxyComponentWithMetaCache{ProxyComponent: mp, metaCache: cache})
+
+	postCreateCredential := func(t *testing.T, user string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := `{"username":"backdoor","password":"QmFja2Rvb3IjMTIz"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/credential", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if user != "" {
+			req.SetBasicAuth(user, "pwd")
+		}
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("user without grants is denied", func(t *testing.T) {
+		w := postCreateCredential(t, "lowpriv")
+		assert.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+		assert.Equal(t, int32(0), mp.createCredentialCalls.Load())
+	})
+
+	t.Run("request without credentials is rejected", func(t *testing.T) {
+		w := postCreateCredential(t, "")
+		assert.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+		assert.Equal(t, int32(0), mp.createCredentialCalls.Load())
+	})
+
+	t.Run("granted user reaches the operation", func(t *testing.T) {
+		privCache := privilege.GetPrivilegeCache()
+		require.NotNil(t, privCache)
+		require.NoError(t, privCache.RefreshPolicyInfo(typeutil.CacheOp{
+			OpType: typeutil.CacheGrantPrivilege,
+			OpKey:  funcutil.PolicyForPrivilege(util.RolePublic, commonpb.ObjectType_Global.String(), util.AnyWord, commonpb.ObjectPrivilege_PrivilegeCreateUser.String(), util.AnyWord),
+		}))
+
+		w := postCreateCredential(t, "lowpriv")
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, int32(1), mp.createCredentialCalls.Load())
+	})
+
+	t.Run("authorization disabled keeps the legacy passthrough", func(t *testing.T) {
+		paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+		t.Cleanup(func() { paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key) })
+
+		w := postCreateCredential(t, "")
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, int32(2), mp.createCredentialCalls.Load())
+	})
+}

--- a/internal/distributed/proxy/httpserver/wrapper.go
+++ b/internal/distributed/proxy/httpserver/wrapper.go
@@ -28,7 +28,11 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-var errBadRequest = errors.New("bad request")
+var (
+	errBadRequest   = errors.New("bad request")
+	errUnauthorized = errors.New("unauthorized")
+	errForbidden    = errors.New("forbidden")
+)
 
 // badRequestf wraps err with the package-internal errBadRequest sentinel and
 // a contextual message, preserving the inner error chain. wrapHandler maps
@@ -62,6 +66,20 @@ func wrapHandler(handle handlerFunc) gin.HandlerFunc {
 					Reason:    err.Error(),
 				}
 				c.Negotiate(http.StatusBadRequest, bodyFormatNegotiate)
+				return
+			case errors.Is(err, errUnauthorized):
+				bodyFormatNegotiate.Data = ErrResponse{
+					ErrorCode: merr.Code(merr.ErrNeedAuthenticate),
+					Reason:    err.Error(),
+				}
+				c.Negotiate(http.StatusUnauthorized, bodyFormatNegotiate)
+				return
+			case errors.Is(err, errForbidden):
+				bodyFormatNegotiate.Data = ErrResponse{
+					ErrorCode: merr.Code(err),
+					Reason:    err.Error(),
+				}
+				c.Negotiate(http.StatusForbidden, bodyFormatNegotiate)
 				return
 			default:
 				bodyFormatNegotiate.Data = ErrResponse{


### PR DESCRIPTION
## What this PR does / why we need it

With `authorizationEnabled=true`, the low-level REST API on the metrics port (`:9091/api/v1/*`) authenticates the caller but never authorizes the operation: `registerHTTPServer` only installs the `authenticate` middleware, and the handlers in `handler.go` invoke the proxy implementation directly. The per-request privilege check (`PrivilegeInterceptor`) only exists on the gRPC server chain, so a user holding just the public role can perform any operation through this port: create or delete users, create or drop collections, insert, query, import.

Reproduced on standalone v2.6.4 with authorization enabled: a user that gets `PrivilegeCreateOwnership`/`PrivilegeCreateCollection` permission denied on the gRPC path created a user via `POST :9091/api/v1/credential` and a collection via `POST :9091/api/v1/collection`, both succeeding.

The authentication half of this port was fixed for CVE-2026-26190 (#47278); this adds the missing authorization half. The open management-plane auth PRs (#49847, #52580) gate the console routes and add admin authentication, but the legacy data-plane routes still run without per-object RBAC after them.

## Changes

- `internal/distributed/proxy/httpserver/handler.go`: add `checkAuthorization`, which mirrors the gRPC chain — a no-op while authorization is disabled (keeping the legacy behavior byte-for-byte), HTTP 401 when the authenticated username is missing, otherwise the same `proxy.PrivilegeInterceptorWithMetaCache` call the v1/v2 REST layers already use, with the request context carrying the resulting roles. Every handler with a proxy call now goes through it. `/health` and `/dummy` are excluded: their requests carry no privilege annotation in the proto, so the gRPC path authorizes nothing for them either.
- `internal/distributed/proxy/httpserver/wrapper.go`: new `errUnauthorized`/`errForbidden` sentinels, mapped to HTTP 401/403 in `wrapHandler`.
- `internal/distributed/proxy/httpserver/handler_authz_test.go`: `TestLowLevelRESTAuthorization` covers no-grant denial (403), missing credentials (401), a granted user reaching the operation (200), and the authorization-disabled passthrough.

## Tests

- `TestLowLevelRESTAuthorization` exercises the real privilege interceptor with an empty meta cache and privilege-cache grants — the same infrastructure `TestRESTV2AliasRBAC` uses.
- The authorization-disabled path is untouched by design: the guard early-returns, so deployments with authorization off behave exactly as before.

issue: #53415
