### PR TITLE
test: preserve segcore code in corrupted XGBoost assertion

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_function_chain.py
+++ b/tests/python_client/milvus_client/test_milvus_client_function_chain.py
@@ -1646,13 +1646,12 @@ class TestMilvusClientFunctionChainXGBoost(TestMilvusClientV2Base):
             )
             self._assert_scores_match(recovered, fixture["expected_scores"])
             assert error_is_explicit, error_text
-            # The original segcore code (2042 = ModelInvalid) now travels the
-            # wire directly instead of being collapsed to the generic 2000 with
-            # a "segcoreCode=" decoration in the message.
+            # The original segcore code (2042 = ModelInvalid) travels the wire
+            # directly and merr also preserves it in the error message.
             assert error_code == 2042, f"unexpected wire error code {error_code}: {error_text}"
             assert error_is_input is True, f"corrupted user model was not classified as input error: {error_text}"
             assert error_retriable is False, f"corrupted user model was unexpectedly retriable: {error_text}"
-            assert "segcoreCode=" not in error_text, f"legacy segcoreCode decoration reappeared: {error_text}"
+            assert "segcoreCode=2042" in error_text, f"original segcore code was not preserved: {error_text}"
         finally:
             self._cleanup_file_resource(
                 client,


### PR DESCRIPTION
## What

The corrupted XGBoost UBJ test expected the client error to omit `segcoreCode=`, although `merr` preserves the original segcore code in the error message. Update the assertion to require `segcoreCode=2042` while retaining the existing wire-code, input-classification, and non-retriable checks.

## Validation

- `python -m py_compile tests/python_client/milvus_client/test_milvus_client_function_chain.py`
- `git diff --check`
- Focused e2e collection was blocked because `xgboost` is unavailable; the live Milvus/MinIO environment was not available.

Closes #53398

## Reviewers

- zhuwenxing
- binbinlv
- ThreadDao